### PR TITLE
Update stop-employees-from-using-the-windows-store.md

### DIFF
--- a/windows/configuration/stop-employees-from-using-the-windows-store.md
+++ b/windows/configuration/stop-employees-from-using-the-windows-store.md
@@ -59,10 +59,10 @@ For more information on AppLocker, see [What is AppLocker?](/windows/device-secu
 ## <a href="" id="block-store-group-policy"></a>Block Microsoft Store using Group Policy
 
 
-Applies to: Windows 10 Enterprise, version 1511, Windows 10 Education 
+Applies to: Windows 10 Enterprise, Windows 10 Education 
 
 > [!Note]
-> Not supported on Windows 10 Pro.
+> Not supported on Windows 10 Pro, starting with version 1511. For more info, see [Knowledge Base article #3135657](https://support.microsoft.com/kb/3135657).
 
 You can also use Group Policy to manage access to Microsoft Store.
 


### PR DESCRIPTION
Windows 10 1511 is no longer needed to be specified.  As of 1511 Pro is no longer supported but Enterprise and Education continue to be supported

This will better articulate to enterprise customers sayings its there and can be used (on all versions of windows 10) while specifically mentioning the Pro edition does not support this starting with the specific build.

Updated the blurb to specify this as well and link to the KB for additional information (as mentioned: https://docs.microsoft.com/en-us/windows/client-management/group-policies-for-enterprise-and-education-editions)