### PR TITLE
Add note on joining to Azure AD when device already setup

### DIFF
--- a/windows/deployment/deploy-enterprise-licenses.md
+++ b/windows/deployment/deploy-enterprise-licenses.md
@@ -91,6 +91,9 @@ Now the device is Azure AD joined to the company’s subscription.
 
 **To join a device to Azure AD when the device already has Windows 10 Pro, version 1703 installed and set up**
 
+>[!IMPORTANT]
+>Make sure that the user you're signing in with is **not** a BUILTIN/Administrator. That user cannot use the `+ Connect` button to join a work or school account.
+
 1.  Go to **Settings &gt; Accounts &gt; Access work or school**, as illustrated in **Figure 5**.
 
     <img src="images/enterprise-e3-connect-to-work-or-school.png" alt="Connect to work or school configuration" width="624" height="482" />


### PR DESCRIPTION
Adding an important note to the section with instructions on joining a device to Azure AD when it has already been setup. Without that disclaimer, a user going through a rather common scenario will experience a silent error where clicking the button does NOTHING leaving the user at a loss as to why things aren't working.