### PR TITLE
Grammar fix and factual accuracy

### DIFF
--- a/windows/threat-protection/windows-defender-security-center/windows-defender-security-center.md
+++ b/windows/threat-protection/windows-defender-security-center/windows-defender-security-center.md
@@ -1,6 +1,6 @@
 ---
 title: Windows Defender Security Center 
-description: The Windows Defender Security Center brings together common Windows security features into one place
+description: Windows Defender Security Center brings together common Windows security features into one place
 keywords: wdav, smartscreen, antivirus, wdsc, firewall, device health, performance, Edge, browser, family, parental options, security, windows
 search.product: eADQiWindows 10XVcnh
 ms.pagetype: security
@@ -18,7 +18,7 @@ ms.date: 08/25/2017
 
 
 
-# The Windows Defender Security Center
+# Windows Defender Security Center
 
 **Applies to**
 
@@ -32,7 +32,7 @@ In Windows 10, version 1703 we introduced the new Windows Defender Security Cent
 
 
 
-![Screen shot of the Windows Defender Security Center showing that the device is protected and five icons for each of the features](images/security-center-home.png)
+![Screen shot of Windows Defender Security Center, showing that the device is protected and five icons for each of the features](images/security-center-home.png)
 
 
 
@@ -41,62 +41,53 @@ Many settings that were previously part of the individual features and main Wind
 
 The app includes the settings and status for the following security features:
 
-- Virus & threat protection, including settings for Windows Defender Antivirus
-- Device performance & health, which includes information about drivers, storage space, and general Windows Update issues
-- Firewall & network protection, including Windows Firewall
-- App & browser control, covering Windows Defender SmartScreen settings
-- Family options, which include a number of parental controls along with tips and information for keeping kids safe online
+- __Virus & threat protection__: Monitors, operates and configures Windows Defender Antivirus, if enabled and not overridden by another antivirus product. Otherwise, it show the status of the other antivirus product.
+-__ Device performance & health__: Includes information about drivers, storage space, and general Windows Update issues.
+- __Firewall & network protection__: The name of this section is somewhat of a misnomer as it only monitors Windows Firewall. Unlike the Security and Maintenance applet (nee Action Center, nee Windows Security Center), it does not account for third-party personal firewall apps.
+- __App & browser control__: Configures SmartScreen 
+- __Family options__: Displays include a number of hyperlinks about parental controls along with tips and information for keeping kids safe online. It has otherwise no functionality.
 
 
 
-The Windows Defender Security Center uses the [Windows Security Center service](https://technet.microsoft.com/en-us/library/bb457154.aspx#EDAA) to provide the status and information on 3rd party antivirus and firewall products that are installed on the device. 
+Windows Defender Security Center __does not__ use the [Security Center service](https://technet.microsoft.com/en-us/library/bb457154.aspx#EDAA) (`wscsvc`). Instead, it relies on its own dedicated Windows Defender Security Center Service (`SecurityHealthService`). 
 
-> [!IMPORTANT] 
-> Disabling the Windows Security Center service will not disable Windows Defender AV or [Windows Firewall](https://docs.microsoft.com/en-us/windows/access-protection/windows-firewall/windows-firewall-with-advanced-security). These will be disabled automatically when a 3rd party antivirus or firewall product is installed and kept up to date.
-
-> [!WARNING] 
-> If you do disable the Windows Security Center service, or configure its associated Group Policy settings to prevent it from starting or running, the Windows Defender Security Center may display stale or inaccurate information about any antivirus or firewall products you have installed on the device. 
->It may also prevent Windows Defender AV from enabling itself if you have an old or outdated 3rd party antivirus, or if you uninstall any 3rd party antivirus products you may have previously installed. 
->This will significantly lower the protection of your device and could lead to malware infection.
-
-
-## Open the Windows Defender Security Center
+## Open Windows Defender Security Center
 - Right-click the icon in the notification area on the taskbar and click **Open**.
 
-    ![Screen shot of the Shield icon for the Windows Defender Security Center in the bottom Windows task bar](images/security-center-taskbar.png)
+    ![Screen shot of the shield icon for Windows Defender Security Center on the bottom Windows task bar](images/security-center-taskbar.png)
 - Search the Start menu for **Windows Defender Security Center**.
 
     ![Screen shot of the Start menu showing the results of a search for Windows Defender Security Center, the first option with a large shield symbol is selected](images/security-center-start-menu.png)
 
 
 > [!NOTE]
-> Settings configured with management tools, such as Group Policy, Microsoft Intune, or System Center Configuration Manager, will generally take precedence over the settings in the Windows Defender Security Center. Review the settings for each feature in its appropriate library. Links for both home user and enterprise or commercial audiences are listed below.
+> Settings configured with management tools, such as Group Policy, Microsoft Intune, or System Center Configuration Manager, will generally take precedence over the settings in Windows Defender Security Center. Review the settings for each feature in its appropriate library. Links for both home user and enterprise or commercial audiences are listed below.
 
-## How the Windows Defender Security Center works with Windows security features
-
-
+## How Windows Defender Security Center works with Windows security features
 
 
-The Windows Defender Security Center operates as a separate app or process from each of the individual features, and will display notifications through the Action Center. 
+
+
+Windows Defender Security Center operates as a separate app or process from each of the individual features, and will display notifications through the Action Center. 
 
 It acts as a collector or single place to see the status and perform some configuration for each of the features.
 
 Disabling any of the individual features (through Group Policy or other management tools, such as System Center Configuration Manager) will prevent that feature from reporting its status in the Windows Defender Security Center. The Windows Defender Security Center itself will still run and show status for the other security features.
 
 > [!IMPORTANT] 
-> Individually disabling any of the services will not disable the other services or the Windows Defender Security Center itself.
+> Individually disabling any of the services will not disable the other services or Windows Defender Security Center itself.
 
-For example, [using a 3rd party antivirus will disable Windows Defender Antivirus](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/deploy-manage-report-windows-defender-antivirus). However, the Windows Defender Security Center will still run, show its icon in the taskbar, and display information about the other features, such as Windows Defender SmartScreen and Windows Firewall.
+For example, [using a 3rd party antivirus will disable Windows Defender Antivirus](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/deploy-manage-report-windows-defender-antivirus). However, Windows Defender Security Center will still run, show its icon in the taskbar, and display information about the other features, such as Windows Defender SmartScreen and Windows Firewall.
 
-The presence of the 3rd party antivirus will be indicated under the **Virus & threat protection** section in the Windows Defender Security Center.
+The presence of the 3rd party antivirus will be indicated under the **Virus & threat protection** section in Windows Defender Security Center.
 
 
 
 ## More information
 
-See the following links for more information on the features in the Windows Defender Security Center:
+See the following links for more information on the features in Windows Defender Security Center:
 - Windows Defender Antivirus
-    - IT administrators and IT pros can get configuration guidance from the [Windows Defender Antivirus in the Windows Defender Security Center topic](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/windows-defender-security-center-antivirus) and the [Windows Defender Antivirus documentation library](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/windows-defender-antivirus-in-windows-10)
+    - IT administrators and IT pros can get configuration guidance from [Windows Defender Antivirus in the Windows Defender Security Center topic](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/windows-defender-security-center-antivirus) and the [Windows Defender Antivirus documentation library](https://docs.microsoft.com/en-us/windows/threat-protection/windows-defender-antivirus/windows-defender-antivirus-in-windows-10)
     - Home users can learn more at the [Virus & threat protection in Windows Defender Security Center topic at support.microsoft.com](https://support.microsoft.com/en-us/help/4012987/windows-10-virus-threat-protection-windows-defender-security-center)
 - Device performance & health
     - It administrators and IT pros can [configure the Load and unload device drivers security policy setting](https://docs.microsoft.com/en-us/windows/device-security/security-policy-settings/load-and-unload-device-drivers), and learn how to [deploy drivers during Windows 10 deployment using System Center Configuration Manager](https://docs.microsoft.com/en-us/windows/deployment/deploy-windows-sccm/add-drivers-to-a-windows-10-deployment-with-windows-pe-using-configuration-manager)
@@ -110,13 +101,13 @@ See the following links for more information on the features in the Windows Defe
 - Family options, which include a number of parental controls along with tips and information for keeping kids safe online
     - Home users can learn more at the [Help protection your family online in Windows Defender Security Center topic at support.microsoft.com](https://support.microsoft.com/en-us/help/4013209/windows-10-protect-your-family-online-in-windows-defender)
 
-## Customize notifications from the Windows Defender Security Center
+## Customize notifications from Windows Defender Security Center
 
 You can customize notifcations so they show information to users about how to get more help from your organization's help desk.
 
 ![](images/security-center-custom-notif.png)
 
-This information will also appear as a pop-out window on the Windows Defender Security Center app.
+This information will also appear as a pop-out window on Windows Defender Security Center.
 
 ![](images/security-center-custom-flyout.png)
 


### PR DESCRIPTION
1. **Grammar fix:** Names of computer programs do not require the definite article ("the") when they appear alone. (e.g. "I like Windows 10", not "I like the Windows 10". But the definite article appears when the name become part of a noun group, e.g. "I like the Windows 10 operating system".
2. **Corrected factual inaccuracies:** For example WDSC neither checks for third-party firewalls nor relies on the "Windows Security Center" service; it uses its own "Windows Defender Security Center Service".