### PR TITLE
Fix-Manage-Connections-Registry-Key

### DIFF
--- a/windows/configuration/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
+++ b/windows/configuration/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
@@ -309,6 +309,10 @@ To prevent Windows from retrieving device metadata from the Internet, apply the 
 
 You can also create a new REG\_DWORD registry setting **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Device Metadata!PreventDeviceMetadataFromNetwork** to 1 (one).
 
+If you're running Windows 10, version 1703, or later:
+
+- Create a new REG\_DWORD registry setting **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Device Metadata!PreventDeviceMetadataFromNetwork** to 1 (one).
+
 ### <a href="" id="find-my-device"></a>5. Find My Device
 
 To turn off Find My Device:

--- a/windows/configuration/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
+++ b/windows/configuration/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
@@ -311,7 +311,7 @@ You can also create a new REG\_DWORD registry setting **HKEY\_LOCAL\_MACHINE\\SO
 
 If you're running Windows 10, version 1703, or later:
 
-- Create a new REG\_DWORD registry setting **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Device Metadata!PreventDeviceMetadataFromNetwork** to 1 (one).
+You can also create a new REG\_DWORD registry setting **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Device Metadata!PreventDeviceMetadataFromNetwork** to 1 (one).
 
 ### <a href="" id="find-my-device"></a>5. Find My Device
 


### PR DESCRIPTION
Validated that the PreventDeviceMetadataFromNetwork value in the documentation is incorrect on a fresh install of 1703. Updated documentation to reflect the correct location. 