### PR TITLE
Missing a backslash in UNC path

### DIFF
--- a/windows/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
+++ b/windows/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
@@ -157,7 +157,7 @@ You can use Group Policy to deploy the configuration you've created to multiple 
 
 7. In the **Options::** section, enter the location and filename of the Exploit Protection configuration file that you want to use, such as in the following examples:
     - C:\MitigationSettings\Config.XML
-    -  \\Server\Share\Config.xml
+    -  \\\Server\Share\Config.xml
     -  https://localhost:8080/Config.xml
 
 8. Click **OK** and [Deploy the updated GPO as you normally do](https://msdn.microsoft.com/en-us/library/ee663280(v=vs.85).aspx). 


### PR DESCRIPTION
Missing a backslash in UNC path, it looks OK in the source but only one backslash is displayed in the browser where it should be two backslashes.