### PR TITLE
Update enroll-a-windows-10-device-automatically-using-group-policy.md

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -27,7 +27,7 @@ Here is a partial screenshot of the result:
 
 ![device status result](images/autoenrollment-device-status.png)
 
-The auto-enrollment relies of the presence of an MDM service and the Azure Active Directory registration for the PC. Starting in Windows 10, version 1611, once the enterprise has registered its AD with Azure AD, a Windows PC that is domain joined is automatically AAD registered.
+The auto-enrollment relies of the presence of an MDM service and the Azure Active Directory registration for the PC. Starting in Windows 10, version 1511, once the enterprise has registered its AD with Azure AD, a Windows PC that is domain joined is automatically AAD registered.
 
 > [!Note]  
 > In Windows 10, version 1709, the enrollment protocol was updated to check whether the device is domain-joined. For details, see [\[MS-MDE2\]: Mobile Device Enrollment Protocol Version 2](https://msdn.microsoft.com/en-us/library/mt221945.aspx). For examples, see section 4.3.1 RequestSecurityToken of the the MS-MDE2 protocol documentation. 

--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -27,7 +27,7 @@ Here is a partial screenshot of the result:
 
 ![device status result](images/autoenrollment-device-status.png)
 
-The auto-enrollment relies of the presence of an MDM service and the Azure Active Directory registration for the PC. Starting in Windows 10, version 1511, once the enterprise has registered its AD with Azure AD, a Windows PC that is domain joined is automatically AAD registered.
+The auto-enrollment relies of the presence of an MDM service and the Azure Active Directory registration for the PC. Starting in Windows 10, version 1607, once the enterprise has registered its AD with Azure AD, a Windows PC that is domain joined is automatically AAD registered.
 
 > [!Note]  
 > In Windows 10, version 1709, the enrollment protocol was updated to check whether the device is domain-joined. For details, see [\[MS-MDE2\]: Mobile Device Enrollment Protocol Version 2](https://msdn.microsoft.com/en-us/library/mt221945.aspx). For examples, see section 4.3.1 RequestSecurityToken of the the MS-MDE2 protocol documentation. 


### PR DESCRIPTION
There was a reference to Windows 10, version 1611 in the doc - there is no such thing.  I assume it should have been 1511, made that change.  If it needs to be something else (e.g. 1607) then feel free to correct.