### PR TITLE
fix the tag and redesign the table for "Log file"

### DIFF
--- a/windows/deployment/upgrade/resolve-windows-10-upgrade-errors.md
+++ b/windows/deployment/upgrade/resolve-windows-10-upgrade-errors.md
@@ -199,7 +199,7 @@ Several log files are created during each phase of the upgrade process. These lo
 <TR>
 <td BGCOLOR="#a0e4fa"><B>Log file<td BGCOLOR="#a0e4fa"><B>Phase: Location<td BGCOLOR="#a0e4fa"><B>Description<td BGCOLOR="#a0e4fa"><B>When to use
 
-<TR><TD rowspan=5>setupact.log<TD>Down-Level:<BR>$Windows.~BT\Sources\Panther<TD>Contains information about setup actions during the downlevel phase. 
+<TR><TD rowspan=5>setupact.log<TD rowspan=5>setupact.log<TD>Down-Level:<BR>$Windows.~BT\Sources\Panther<TD>Contains information about setup actions during the downlevel phase. 
 <TD>All down-level failures and starting point for rollback investigations.<BR> This is the most important log for diagnosing setup issues.
 <TR><TD>OOBE:<BR>$Windows.~BT\Sources\Panther\UnattendGC
 <TD>Contains information about actions during the OOBE phase.<TD>Investigating rollbacks that failed during OOBE phase and operations – 0x4001C, 0x4001D, 0x4001E, 0x4001F.


### PR DESCRIPTION
<TD rowspan=5>setupact.log
"<TD>" tag is one of HTML tag and may be used for desigining the table. It is curious for "<TD>" tag is printed directly in the document.
And, table has four rows.
- Log file
- Phase: Location
- Description
- When to use.
In "When to use" rows, you can see some columns are none. I think the table is broken because of "<TD>" tag is sticked out