### PR TITLE
Adding reference to Enterprise Edition

### DIFF
--- a/windows/threat-protection/windows-defender-application-guard/reqs-wd-app-guard.md
+++ b/windows/threat-protection/windows-defender-application-guard/reqs-wd-app-guard.md
@@ -13,7 +13,7 @@ ms.date: 08/11/2017
 # System requirements for Windows Defender Application Guard
 
 **Applies to:**
-- Windows 10, version 1709
+- Windows 10 Enterprise, version 1709
 
 The threat landscape is continually evolving. While hackers are busy developing new techniques to breach enterprise networks by compromising workstations, phishing schemes remain one of the top ways to lure employees into social engineering attacks. Windows Defender Application Guard is designed to help prevent old, and newly emerging attacks, to help keep employees productive.
 
@@ -33,6 +33,6 @@ Your environment needs the following hardware to run Windows Defender Applicatio
 
 |Software|Description|
 |--------|-----------|
-|Operating system|Windows 10, Windows Insider Program (Enterprise edition, Build 16188 or later)|
+|Operating system|Windows 10 Enterprise, Windows Insider Program (Enterprise edition, Build 16188 or later)|
 |Browser|Microsoft Edge and Internet Explorer|
 |Management system|[Microsoft Intune](https://docs.microsoft.com/en-us/intune/)<br><br>**-OR-**<br><br>[System Center Configuration Manager](https://docs.microsoft.com/en-us/sccm/)<br><br>**-OR-**<br><br>[Group Policy](https://technet.microsoft.com/en-us/library/cc753298(v=ws.11).aspx)<br><br>**-OR-**<br><br>Your current company-wide 3rd party mobile device management (MDM) solution. For info about 3rd party MDM solutions, see the documentation that came with your product.|


### PR DESCRIPTION
It is not immediately clear that you need Enterprise SKU.  This is a great feature, that when talked about at large publicly DOESN'T APPLY to the vast majority of users because they do not have Enterprise SKU.  Lots of time saved asking why doesn't this work on my version when they see that ENTERPRISE is the required version not just Windows 10 1709.