### PR TITLE
Reference Enterprise SKU at the top

### DIFF
--- a/windows/threat-protection/windows-defender-application-guard/install-wd-app-guard.md
+++ b/windows/threat-protection/windows-defender-application-guard/install-wd-app-guard.md
@@ -13,7 +13,7 @@ ms.date: 08/11/2017
 # Prepare and install Windows Defender Application Guard
 
 **Applies to:**
-- Windows 10, version 1709
+- Windows 10 Enterprise, version 1709
 
 ## Prepare to install Windows Defender Application Guard 
 Before you can install and use Windows Defender Application Guard, you must determine which way you intend to use it in your enterprise. You can use Application Guard in either **Standalone** or **Enterprise-managed** mode.


### PR DESCRIPTION
Saves a lot of time with following instructions if you specify this Enterprise SKU reference.  People find out eventually that they can't run it but not before they've gotten all the way down to the steps.  Especially when you Bing search for this, and you skip the FIRST doc that specifies systems requirements.