### PR TITLE
Fixed Broken Link - Mixed Reality Documentation

### DIFF
--- a/devices/hololens/index.md
+++ b/devices/hololens/index.md
@@ -33,7 +33,7 @@ ms.localizationpriority: medium
 
 - [Help for using HoloLens](https://support.microsoft.com/products/hololens)
 
-- [Documentation for Holographic app development](https://developer.microsoft.com/windows/mixed-reality/documentation)
+- [Documentation for Holographic app development](https://developer.microsoft.com/windows/mixed-reality/development)
 
 - [HoloLens Commercial Suite](https://www.microsoft.com/microsoft-hololens/hololens-commercial)
 


### PR DESCRIPTION
Corrected broken Mixed Reality link in docs

Old link: https://de​veloper.mi​crosoft.co​m/windows/​mixed-real​ity/docume​ntation
New link (proposed): https://developer.microsoft.com/windows/mixed-reality/development