### PR TITLE
Fix table format under Prerequisites section

### DIFF
--- a/mdop/agpm/whats-new-in-agpm-40-sp3.md
+++ b/mdop/agpm/whats-new-in-agpm-40-sp3.md
@@ -172,7 +172,6 @@ AGPM 4.0 SP3 supports the configurations in the following table. Although AGPM 
 
 ## Prerequisites for installing AGPM 4.0 SP3
 
-
 The following table describes the behavior of AGPM 4.0 SP3 Client and Server installers when the .NET Framework 4.5.1, PowerShell 3.0, or the GPMC in the Remote Server Administration Tools is missing.
 
 **AGPM Client**


### PR DESCRIPTION
The information under the section Prerequisites for installing AGPM 4.0 SP3 should have been a table and is incorrectly formatted.