### PR TITLE
Update hello-biometrics-in-enterprise.md

### DIFF
--- a/windows/access-protection/hello-for-business/hello-biometrics-in-enterprise.md
+++ b/windows/access-protection/hello-for-business/hello-biometrics-in-enterprise.md
@@ -50,21 +50,17 @@ We’ve been working with the device manufacturers to help ensure a high-level o
 -   **False Reject Rate (FRR).** Represents the instances a biometric identification solution fails to verify an authorized person correctly. Usually represented as a percentage, the sum of the True Accept Rate and False Reject Rate is 1. Can be with or without anti-spoofing or liveness detection.
 
 ### Fingerprint sensor requirements
-To allow fingerprint matching, you must have devices with fingerprint sensors and software. Fingerprint sensors, or sensors that use an employee’s unique fingerprint as an alternative log on option, can be touch sensors (large area or small area) or swipe sensors. Each type of sensor has its own set of detailed requirements that must be implemented by the manufacturer, but all of the sensors must include anti-spoofing measures (required) and a way to configure them (optional).
+To allow fingerprint matching, you must have devices with fingerprint sensors and software. Fingerprint sensors, or sensors that use an employee’s unique fingerprint as an alternative log on option, can be touch sensors (large area or small area) or swipe sensors. Each type of sensor has its own set of detailed requirements that must be implemented by the manufacturer, but all of the sensors must include anti-spoofing measures (required).
 
 **Acceptable performance range for small to large size touch sensors**
 
 -   False Accept Rate (FAR): &lt;0.001 – 0.002%
-
--   False Reject Rate (FRR) without Anti-spoofing or liveness detection: &lt;5%
 
 -   Effective, real world FRR with Anti-spoofing or liveness detection: &lt;10%
 
 **Acceptable performance range for swipe sensors**
 
 -   False Accept Rate (FAR): &lt;0.002%
-
--   False Reject Rate (FRR) without Anti-spoofing or liveness detection: &lt;5%
 
 -   Effective, real world FRR with Anti-spoofing or liveness detection: &lt;10%
 


### PR DESCRIPTION
Anti-spoofing for fingerprint is currently not configurable and is a requirement for all sensors. This document is being updated to reflect that and to remove references to FRR without anti-spoofing for fingerprint.