### PR TITLE
Finding the right Registrar Pool

### DIFF
--- a/devices/surface-hub/appendix-a-powershell-scripts-for-surface-hub.md
+++ b/devices/surface-hub/appendix-a-powershell-scripts-for-surface-hub.md
@@ -1568,7 +1568,7 @@ if ($online)
 {
     try {
         $strRegPool = $null;
-        $strRegPool = (Get-CsTenant).TenantPoolExtension
+        $strRegPool = (Get-CsTenant).RegistrarPool
     } catch {}
     if ($Error)
     {


### PR DESCRIPTION
If running the existing command, you'll get: 
PS C:\WINDOWS\system32> (Get-CsTenant).TenantPoolExtension
MCOProfessional:sippoolDB42E08.infra.lync.com

If running the right command, you'll get:
PS C:\WINDOWS\system32> (Get-CsTenant).RegistrarPool
sippoolDB42E08.infra.lync.com

Otherwise, the script will forever fail.