### PR TITLE
Update start-layout-xml-desktop

### DIFF
--- a/windows/configuration/start-layout-xml-desktop.md
+++ b/windows/configuration/start-layout-xml-desktop.md
@@ -56,9 +56,6 @@ The following table lists the supported elements and attributes for the LayoutMo
 | [start:Tile](#specify-start-tiles)</br></br>Parent:</br>AppendGroup | AppUserModelID</br>Size</br>Row</br>Column | Use to specify any of the following:</br>- A Universal Windows app</br>- A Windows 8 or Windows 8.1 app</br></br>Note that AppUserModelID is case-sensitive. |
 | start:DesktopApplicationTile</br></br>Parent:</br>AppendGroup | DesktopApplicationID</br>DesktopApplicationLinkPath</br>Size</br>Row</br>Column | Use to specify any of the following:</br>- A Windows desktop application with a known AppUserModelID</br>- An application in a known folder with a link in a legacy Start Menu folder</br>- A Windows desktop application link in a legacy Start Menu folder</br>- A Web link tile with an associated .url file that is in a legacy Start Menu folder |
 | start:SecondaryTile</br></br>Parent:</br>AppendGroup | AppUserModelID</br>TileID</br>Arguments</br>DisplayName</br>Square150x150LogoUri</br>ShowNameOnSquare150x150Logo</br>ShowNameOnWide310x150Logo</br>Wide310x150LogoUri</br>BackgroundColor</br>ForegroundText</br>IsSuggestedApp</br>Size</br>Row</br>Column | Use to pin a Web link through a Microsoft Edge secondary tile. Note that AppUserModelID is case-sensitive. |
-| TopMFUApps</br></br>Parent:</br>LayoutModificationTemplate | n/a | Use to add up to 3 default apps to the frequently used apps section in the system area |
-| Tile</br></br>Parent:</br>TopMFUApps | AppUserModelID | Use with the TopMFUApps tags to specify an app with a known AppUserModelID |
-| DesktopApplicationTile</br></br>Parent:</br>TopMFUApps | LinkFilePath | Use with the TopMFUApps tags to specify an app without a known AppUserModelID |
 | AppendOfficeSuite</br></br>Parent:</br>LayoutModificationTemplate | n/a | Use to add the in-box installed Office suite to Start</br></br>Do not use this tag with AppendDownloadOfficeTile |
 | AppendDownloadOfficeTile</br></br>Parent:</br>LayoutModificationTemplate | n/a | Use to add a specific **Download Office** tile to a specific location in Start</br></br>Do not use this tag with AppendOfficeSuite |
 
@@ -259,28 +256,7 @@ Secondary Microsoft Edge tiles have the same size and location behavior as a Uni
 
 #### TopMFUApps
 
-You can use the **TopMFUApps** tag to add up to 3 default apps to the frequently used apps section in the system area, which delivers system-driven lists to the user including important or frequently accessed system locations and recently installed apps. 
-
-You can use this tag to add:
-
-- Apps with an **AppUserModelID** attribute - This includes Windows desktop applications that have a known application user model ID. Use a **Tile** tag with the **AppUserModelID** attribute set to the app's application user model ID.
-- Apps without a **AppUserModelID** attribute - For these apps, you must create a .lnk file that points to the installed app and place the .lnk file in the `%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs` directory. Use a **DesktopApplicationTile** tag with the **LinkFilePath** attribute set to the .lnk file name and path.
-
-The following example shows how to modify your LayoutModification.xml file to add both kinds of apps to the system area in Start:
-
- ```XML
- <LayoutModificationTemplate
-    xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification"
-    xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout"
-    xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout"
-    Version="1">
-    <TopMFUApps>
-        <Tile AppUserModelID="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App" />
-        <Tile AppUserModelID="Microsoft.Getstarted_8wekyb3d8bbwe!App" />
-        <DesktopApplicationTile LinkFilePath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Win32App.lnk" />
-  </TopMFUApps>
-</LayoutModificationTemplate>
-```
+In Windows 10 version 1709, you can no longer pin apps to the Most Frequently Used apps list in Start.
 
 #### AppendOfficeSuite
 
@@ -392,9 +368,6 @@ The following sample LayoutModification.xml shows how you can configure the Star
       </AppendGroup>	  
     </RequiredStartGroups>
   </RequiredStartGroupsCollection> 
-  <TopMFUApps>
-    <Tile AppUserModelID="Microsoft.WindowsCalculator_8wekyb3d8bbwe!App" />
-  </TopMFUApps>  
 </LayoutModificationTemplate>
 ```
 


### PR DESCRIPTION
The ability for OEMs to pin apps to the MFU section of Start was deprecated in 1709. OEMs can still include the TopMFUApps tags in the layoutmodification.xml, but it will have no impact to the Start layout.