### PR TITLE
Fix table format

### DIFF
--- a/mdop/agpm/whats-new-in-agpm-40-sp3.md
+++ b/mdop/agpm/whats-new-in-agpm-40-sp3.md
@@ -174,57 +174,12 @@ AGPM 4.0 SP3 supports the configurations in the following table. Although AGPM 
 
 The following table describes the behavior of AGPM 4.0 SP3 Client and Server installers when the .NET Framework 4.5.1, PowerShell 3.0, or the GPMC in the Remote Server Administration Tools is missing.
 
-**AGPM Client**
-
-**AGPM Server**
-
-**Operating system**
-
-**.NET Framework**
-
-**PowerShell**
-
-**Remote Server Administration Tools**
-
-**.NET Framework**
-
-**Remote Server Administration Tools**
-
-**Windows 10 or Windows Server 2016**
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If Powershell 3.0 is not installed, the installer blocks the installation.
-
-If the GPMC is not enabled or installed, the installer blocks the installation.
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If the GPMC is not enabled or installed, the installer blocks the installation.
-
-**Windows 8.1**
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If Powershell 3.0 is not installed, the installer blocks the installation.
-
-If the GPMC is not enabled or installed, the installer blocks the installation.
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If the GPMC is not enabled or installed, the installer blocks the installation.
-
-**Windows Server 2012 R2**
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If Powershell 3.0 is not installed, the installer blocks the installation.
-
-If the GPMC is not enabled, the installer enables it during the installation.
-
-If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation.
-
-If the GPMC is not enabled, the installer enables it during the installation.
+| AGPM Client            |                                                                                                 |                                                                            | AGPM Server                                                                     |                                                                                                 |                                                                                 |
+|------------------------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| Operating system       | .NET Framework                                                                                  | PowerShell                                                                 | Remote Server Administration Tools                                              | .NET Framework                                                                                  | Remote Server Administration Tools                                              |
+| Windows 10             | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If Powershell 3.0 is not installed, the installer blocks the installation. | If the GPMC is not enabled or installed, the installer blocks the installation. | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If the GPMC is not enabled or installed, the installer blocks the installation. |
+| Windows 8.1            | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If Powershell 3.0 is not installed, the installer blocks the installation. | If the GPMC is not enabled or installed, the installer blocks the installation. | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If the GPMC is not enabled or installed, the installer blocks the installation. |
+| Windows Server 2012 R2 | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If Powershell 3.0 is not installed, the installer blocks the installation. | If the GPMC is not enabled, the installer enables it during the installation.   | If the .NET Framework 4.5.1 is not enabled or installed, the installer blocks the installation. | If the GPMC is not enabled, the installer enables it during the installation.   |
 
  
 


### PR DESCRIPTION
The information under the section Prerequisites for installing AGPM 4.0 SP3 should have been a table and is incorrectly formatted.