### PR TITLE
Update customize-exploit-protection.md

### DIFF
--- a/windows/threat-protection/windows-defender-exploit-guard/customize-exploit-protection.md
+++ b/windows/threat-protection/windows-defender-exploit-guard/customize-exploit-protection.md
@@ -82,11 +82,11 @@ Disable Win32k system calls | Prevents an app from using the Win32k system call 
 Do not allow child processes | Prevents an app from creating child processes. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
 Export address filtering (EAF) | Detects dangerous operations being resolved by malicious code. Can optionally validate access by modules commonly used by exploits. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
 Import address filtering (IAF) | Detects dangerous operations being resolved by malicious code. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
-Simulate execution (SimExec) | Ensures that calls to sensitive APIs return to legitimate callers. Only configurable for 32-bit (x86) applications. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
-Validate API invocation (CallerCheck) | Ensures that sensitive APIs are invoked by legitimate callers. Only configurable for 32-bit (x86) applications. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
+Simulate execution (SimExec) | Ensures that calls to sensitive APIs return to legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
+Validate API invocation (CallerCheck) | Ensures that sensitive APIs are invoked by legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
 Validate handle usage | Causes an exception to be raised on any invalid handle references. | App-level only | [!include[Check mark no](images/svg/check-no.svg)]
 Validate image dependency integrity | Enforces code signing for Windows image dependency loading. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
-Validate stack integrity (StackPivot) | Ensures that the stack has not been redirected for sensitive APIs. | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
+Validate stack integrity (StackPivot) | Ensures that the stack has not been redirected for sensitive APIs. Not compatible with ACG | App-level only | [!include[Check mark yes](images/svg/check-yes.svg)]
 
 >[!IMPORTANT]
 >If you add an app to the **Program settings** section and configure individual mitigation settings there, they will be honored above the configuration for the same mitigations specified in the **System settings** section. The following matrix and examples help to illustrate how defaults work:


### PR DESCRIPTION
Add notes for anti-ROP mitigations indicating they are not compatible with ACG. Users that enable ACG for a process should not enable the anti-ROP mitigations at the same time.