### PR TITLE
Update Note for Express update delivery scope

### DIFF
--- a/windows/deployment/update/waas-optimize-windows-10-updates.md
+++ b/windows/deployment/update/waas-optimize-windows-10-updates.md
@@ -51,7 +51,7 @@ Two methods of peer-to-peer content distribution are available in Windows 10.
 Windows 10 quality update downloads can be large because every package contains all previously released fixes to ensure consistency and simplicity. Windows has been able to reduce the size of Windows Update downloads with a feature called Express.
 
 >[!NOTE]
->Currently, Express update delivery only applies to quality update downloads.
+>Express update delivery applies to quality update downloads. Starting with Windows 10, version 1709, Express update delivery also applies to feature update downloads for clients connected to Windows Update and Windows Update for Business.
 
 ### How Microsoft supports Express
 - **Express on System Center Configuration Manager** starting with version 1702 of Configuration Manager and Windows 10, version 1703 or 1607 with the April 2017 cumulative update.


### PR DESCRIPTION
Starting with Fall Creators Update, Express update delivery no longer limited to quality update downloads.