### PR TITLE
Reflected setting name in 1709 ADMX

### DIFF
--- a/windows/configuration/ue-v/uev-configuring-uev-with-group-policy-objects.md
+++ b/windows/configuration/ue-v/uev-configuring-uev-with-group-policy-objects.md
@@ -51,7 +51,7 @@ The following policy settings can be configured for UE-V.
 <td align="left"><p>The default is enabled.</p></td>
 </tr>
 <tr class="odd">
-<td align="left"><p>Roam Windows settings</p></td>
+<td align="left"><p>Synchronize Windows settings</p></td>
 <td align="left"><p>Computers and Users</p></td>
 <td align="left"><p>This Group Policy setting configures the synchronization of Windows settings.</p></td>
 <td align="left"><p>Select which Windows settings synchronize between computers.</p>


### PR DESCRIPTION
In my environment using a 1709 ADMX template, this setting is now called 'Synchronize Windows settings'. I can't tell you when this changed from 'roam', but 'Synchronize' is the case now.