### PR TITLE
Use Full Path for Security Options

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
+++ b/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
@@ -34,7 +34,7 @@ The **Interactive logon: Prompt user to change password before expiration** poli
 
 ### Location
 
-Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options
+Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options
 
 ### Default values
 


### PR DESCRIPTION
Previously, the path to "Security Options" was defined as `Computer Configuration\Windows Settings\Security Settings\Local Policies\Security Options`.

However, there is no such path.

There is a path `Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options`, at which interactive logon settings may be found.

Accordingly, add `Policies` to the path to complete the path.