### PR TITLE
Recommending new URL for Commercial Suite features

### DIFF
--- a/devices/hololens/hololens-upgrade-enterprise.md
+++ b/devices/hololens/hololens-upgrade-enterprise.md
@@ -12,7 +12,7 @@ ms.date: 02/02/2018
 
 # Unlock Windows Holographic for Business features
 
-Microsoft HoloLens is available in the *Development Edition*, which runs Windows Holographic (an edition of Windows 10 designed for HoloLens), and in the [Commercial Suite](https://developer.microsoft.com/windows/mixed-reality/release_notes_-_august_2016#introducing_microsoft_hololens_commercial_suite), which provides extra features designed for business. 
+Microsoft HoloLens is available in the *Development Edition*, which runs Windows Holographic (an edition of Windows 10 designed for HoloLens), and in the [Commercial Suite](https://docs.microsoft.com/en-us/windows/mixed-reality/commercial-features), which provides extra features designed for business. 
 
 When you purchase the Commercial Suite, you receive a license that upgrades Windows Holographic to Windows Holographic for Business. This license can be applied to the device either through the organization's [mobile device management (MDM) provider](#edition-upgrade-using-mdm) or a [provisioning package](#edition-upgrade-using-a-provisioning-package).
 


### PR DESCRIPTION
I'd recommend using the article we have specifically on commercial features rather than the release notes for the build where they were introduced. It's also updated with the docs.msft.com URL since we migrated all our dev documentation off Dev Center.