### PR TITLE
Add MVC 4.0 requirement to Administration and Monitoring Server

### DIFF
--- a/mdop/mbam-v25/mbam-25-server-prerequisites-for-stand-alone-and-configuration-manager-integration-topologies.md
+++ b/mdop/mbam-v25/mbam-25-server-prerequisites-for-stand-alone-and-configuration-manager-integration-topologies.md
@@ -286,6 +286,10 @@ The following table lists the installation prerequisites for the MBAM Administra
 </ul></td>
 </tr>
 <tr class="even">
+<td align="left"><p>ASP.NET MVC 4.0</p></td>
+<td align="left"><p>[ASP.NET MVC 4 download](https://go.microsoft.com/fwlink/?LinkId=392271)</p></td>
+</tr>
+<tr class="odd">
 <td align="left"><p>Service Principal Name (SPN)</p></td>
 <td align="left"><p>The web applications require an SPN for the virtual host name under the domain account that you use for the web application pools.</p>
 <p>If your administrative rights permit you to create SPNs in Active Directory Domain Services, MBAM creates the SPN for you. See [Setspn](http://technet.microsoft.com/library/cc731241.aspx) for information about the rights required to create SPNs.</p>


### PR DESCRIPTION
While the actual role itself likely does not rely on MVC 4.0, the prerequisite check fails when this component is not installed even if you're not installing the Self Service portal.