### PR TITLE
Update policy-csp-deliveryoptimization.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-deliveryoptimization.md
+++ b/windows/client-management/mdm/policy-csp-deliveryoptimization.md
@@ -509,7 +509,7 @@ If you set this policy, the GroupID policy will be ignored.
 
 The options set in this policy only apply to Group (2) download mode. If Group (2) isn't set as Download mode, this policy will be ignored.  
 
-For option 4 - DHCP Option ID, the client will query DHCP Option ID 234 and use the returned GUID value as the Group ID.
+For option 3 - DHCP Option ID, the client will query DHCP Option ID 234 and use the returned GUID value as the Group ID.
 
 <!--/Description-->
 <!--ADMXMapped-->


### PR DESCRIPTION
Incorrect option number when refering to DHCP option ID.

"For option 4 - DHCP Option ID, the client will query DHCP Option ID 234 and use the returned GUID value as the Group ID."

- It should state "For option *3* (...)".