### PR TITLE
Update manage-users-and-groups-microsoft-store-for-business.md

### DIFF
--- a/store-for-business/manage-users-and-groups-microsoft-store-for-business.md
+++ b/store-for-business/manage-users-and-groups-microsoft-store-for-business.md
@@ -35,7 +35,7 @@ For more information on Azure AD, see [About Office 365 and Azure Active Directo
 ## Add user accounts to your Azure AD directory
 If you created a new Azure AD directory when you signed up for Store for Business, you'll have a directory set up with one user account - the global administrator. That global administrator can add user accounts to your Azure AD directory. However, adding user accounts to your Azure AD directory will not give those employees access to Store for Business. You'll need to assign Store for Business roles to your employees. For more information, see [Roles and permissions in the Store for Business.](roles-and-permissions-microsoft-store-for-business.md)
 
-You can use the [Office 365 admin dashboard](https://go.microsoft.com/fwlink/p/?LinkId=708616) or [Azure management portal](https://go.microsoft.com/fwlink/p/?LinkId=691086) to add user accounts to your Azure AD directory. If you'll be using Azure management portal, you'll need an active subscription to [Azure management portal](https://go.microsoft.com/fwlink/p/?LinkId=708617).
+You can use the [Office 365 admin dashboard](https://portal.office.com/adminportal) or [Azure management portal](https://go.microsoft.com/fwlink/p/?LinkId=691086) to add user accounts to your Azure AD directory. If you'll be using Azure management portal, you'll need an active subscription to [Azure management portal](https://go.microsoft.com/fwlink/p/?LinkId=708617).
 
 For more information, see:
 - [Add user accounts using Office 365 admin dashboard](https://go.microsoft.com/fwlink/p/?LinkId=708618)


### PR DESCRIPTION
Currently the link to the O365 admin dashboard redirects customer to a help page (https://support.office.com/en-us/article/where-to-sign-in-to-office-365-for-business-e9eb7d51-5430-4929-91ab-6157c5a050b4?ui=en-US&rs=en-US&ad=US) which then prompts admins to sign in to the Office admin portal using the wrong link (www.office.com/signin). 

Admins cannot manage users from the signin page so it may cause confusion and create SR volume. The correct link to the Office admin portal is https://portal.office.com/adminportal.