### PR TITLE
Added words to "Help to make your Windows experience better"

### DIFF
--- a/windows/privacy/diagnostic-data-viewer-overview.md
+++ b/windows/privacy/diagnostic-data-viewer-overview.md
@@ -69,7 +69,7 @@ The Diagnostic Data Viewer provides you with the following features to view and 
 
     Selecting a check box lets you filter between the diagnostic event categories.
 
-- **Help to make your Windows experience better.** Microsoft only needs diagnostic data from a small amount of devices to make big improvements to the Windows operating system and ultimately, your experience. If you’re a part of this small device group and you experience issues, Microsoft will collect the associated event diagnostic data, allowing your info to potentially help fix the issue for others.
+- **Help to make your Windows experience better through sampling.** Microsoft only needs diagnostic data from a small amount of devices to make big improvements to the Windows operating system and ultimately, your experience. If you’re a part of this small device group and you experience issues, Microsoft will collect the associated event diagnostic data, allowing your info to potentially help fix the issue for others.
 
     To signify your contribution, you’ll see this icon (![Icon to review the device-level sampling](images/ddv-device-sample.png)) if your device is part of the group. In addition, if any of your diagnostic data events are sent from your device to Microsoft to help make improvements, you’ll see this icon (![Icon to review the event-level sampling](images/ddv-event-sample.png)). 
 


### PR DESCRIPTION
Added "through sampling" under "Help to make your Windows experience better".

Reason: Our current wording on the application's "about" page states that we use a policy called "sampling", but the word does not exist anywhere on this page, so users are confused when they go to the docs and cannot find any info on "sampling". 