### PR TITLE
WDEG: Correct SCCM + WMI Error

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/attack-surface-reduction-exploit-guard.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/attack-surface-reduction-exploit-guard.md
@@ -191,7 +191,7 @@ Local Security Authority Subsystem Service (LSASS) authenticates users who log i
 This rule blocks processes through PsExec and WMI commands from running, to prevent remote code execution that can spread malware attacks.
 
 >[!WARNING]
->[Only use this rule if you are managing your devices with Intune or other MDM solution. If you use this rule with SCCM, it will prevent SCCM compliance rules from working, because this rule blocks the PSExec commands in SCCM.]
+>[Only use this rule if you are managing your devices with [Intune](https://docs.microsoft.com/intune) or another MDM solution. This rule is incompatible with management through [System Center Configuration Manager](https://docs.microsoft.com/sccm) because this rule blocks WMI commands that the Configuration Manager client uses to function correctly.]
  
 ### Rule: Block untrusted and unsigned processes that run from USB
  


### PR DESCRIPTION
Corrected a technical error around SCCM compatibility with Exploit Guard and cleaned up surrounding text.