### PR TITLE
Fix wrong HKLM keys that were missing SOFTWARE at the root

### DIFF
--- a/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
+++ b/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
@@ -957,7 +957,7 @@ To turn off **Location for this device**:
 
    -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessLocation** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessLocation** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
     -or-
 
@@ -990,7 +990,7 @@ To turn off **Location**:
 
    -or-
 
--   Create a REG\_DWORD registry setting named **DisableLocation** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\LocationAndSensors** with a value of 1 (one).
+-   Create a REG\_DWORD registry setting named **DisableLocation** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\LocationAndSensors** with a value of 1 (one).
 
     -or-
 
@@ -1018,7 +1018,7 @@ To turn off **Let apps use my camera**:
 
    -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessCamera** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessCamera** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
     -or-
 
@@ -1067,7 +1067,7 @@ To turn off **Let apps use my microphone**:
     
     -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessMicrophone** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two)
+-   Create a REG\_DWORD registry setting named **LetAppsAccessMicrophone** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two)
 
 To turn off **Choose apps that can use your microphone**:
 
@@ -1115,7 +1115,7 @@ To turn off **Let apps access my notifications**:
 
        -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessNotifications** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two)
+-   Create a REG\_DWORD registry setting named **LetAppsAccessNotifications** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two)
 
 ### <a href="" id="bkmk-priv-speech"></a>17.6 Speech, inking, & typing
 
@@ -1134,7 +1134,7 @@ To turn off the functionality:
 
        -or-
 
--   Create a REG\_DWORD registry setting named **RestrictImplicitInkCollection** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\InputPersonalization** with a value of 1 (one).
+-   Create a REG\_DWORD registry setting named **RestrictImplicitInkCollection** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\InputPersonalization** with a value of 1 (one).
 
    -or-
 
@@ -1269,7 +1269,7 @@ To turn off **Let apps access my call history**:
 
         -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessCallHistory** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessCallHistory** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 ### <a href="" id="bkmk-priv-email"></a>17.11 Email
 
@@ -1295,7 +1295,7 @@ To turn off **Let apps access and send email**:
 
      -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessEmail** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessEmail** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 ### <a href="" id="bkmk-priv-messaging"></a>17.12 Messaging
 
@@ -1351,7 +1351,7 @@ To turn off **Let apps make phone calls**:
 
      -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessPhone** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessPhone** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 
 To turn off **Choose apps that can make phone calls**:
@@ -1382,7 +1382,7 @@ To turn off **Let apps control radios**:
 
      -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessRadios** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessRadios** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 
 To turn off **Choose apps that can control radios**:
@@ -1412,7 +1412,7 @@ To turn off **Let apps automatically share and sync info with wireless devices t
    
      -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsSyncWithDevices** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsSyncWithDevices** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 To turn off **Let your apps use your trusted devices (hardware you've already connected, or comes with your PC, tablet, or phone)**:
 
@@ -1453,7 +1453,7 @@ To change how frequently **Windows should ask for my feedback**:
 
    -or-
 
--   Create a REG\_DWORD registry setting named **DoNotShowFeedbackNotifications** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\DataCollection** with a value of 1 (one).
+-   Create a REG\_DWORD registry setting named **DoNotShowFeedbackNotifications** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection** with a value of 1 (one).
 
    -or-
 
@@ -1572,7 +1572,7 @@ To turn off **Let Windows and your apps use your motion data and collect motion 
     
     -or-
 
--   Create a REG\_DWORD registry setting named **LetAppsAccessMotion** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
+-   Create a REG\_DWORD registry setting named **LetAppsAccessMotion** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\AppPrivacy** with a value of 2 (two).
 
 ### <a href="" id="bkmk-priv-tasks"></a>17.19 Tasks
 
@@ -1631,7 +1631,7 @@ For Windows 10:
 
    -or-
 
-- Create a REG\_DWORD registry setting named **NoGenTicket** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows NT\\CurrentVersion\\Software Protection Platform** with a value of 1 (one).
+- Create a REG\_DWORD registry setting named **NoGenTicket** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\CurrentVersion\\Software Protection Platform** with a value of 1 (one).
 
 For Windows Server 2016 with Desktop Experience or Windows Server 2016 Server Core:
 
@@ -1639,7 +1639,7 @@ For Windows Server 2016 with Desktop Experience or Windows Server 2016 Server Co
 
    -or-
 
-- Create a REG\_DWORD registry setting named **NoGenTicket** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows NT\\CurrentVersion\\Software Protection Platform** with a value of 1 (one).
+- Create a REG\_DWORD registry setting named **NoGenTicket** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\CurrentVersion\\Software Protection Platform** with a value of 1 (one).
 
 The Windows activation status will be valid for a rolling period of 180 days with weekly activation status checks to the KMS.
 
@@ -1663,7 +1663,7 @@ You can control if your settings are synchronized:
 
     -or-
 
--   Create a REG\_DWORD registry setting named **DisableSettingSync** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\SettingSync** with a value of 2 (two) and another named **DisableSettingSyncUserOverride** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\SettingSync** with a value of 1 (one).
+-   Create a REG\_DWORD registry setting named **DisableSettingSync** in **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\SettingSync** with a value of 2 (two) and another named **DisableSettingSyncUserOverride** in **HKEY\_LOCAL\_MACHINE\\Policies\\Microsoft\\Windows\\SettingSync** with a value of 1 (one).
 
     -or-
 


### PR DESCRIPTION
A bunch of keys I was trying to use didn't exist. Googling the keys, it looks like they were missing `SOFTWARE\` at the root.