### PR TITLE
Update policy-csp-localpoliciessecurityoptions.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-localpoliciessecurityoptions.md
+++ b/windows/client-management/mdm/policy-csp-localpoliciessecurityoptions.md
@@ -829,6 +829,8 @@ Logon information transmitted over the secure channel is always encrypted regard
 
 <!--/Description-->
 <!--RegistryMapped-->
+Starting in Windows 10, next major version, this policy is deprecated.
+
 GP Info:  
 -   GP English name: *Domain member: Digitally encrypt or sign secure channel data (always)*
 -   GP path: *Windows Settings/Security Settings/Local Policies/Security Options*


### PR DESCRIPTION
I went to LocalPoliciesSecurityOptions/DomainMember_DigitallyEncryptOrSignSecureChannelDataAlways and add this statement before the GP Info section:

Starting in Windows 10, next major version, this policy is deprecated.
