### PR TITLE
Update supl-ddf-file.md

### DIFF
--- a/windows/client-management/mdm/supl-ddf-file.md
+++ b/windows/client-management/mdm/supl-ddf-file.md
@@ -171,7 +171,7 @@ The XML below is the current version for this CSP.
                 </DFProperties>
               </Node>
               <Node>
-                <NodeName>MCCMNPairs</NodeName>
+                <NodeName>MCCMNCPairs</NodeName>
                 <DFProperties>
                   <AccessType>
                     <Get />
@@ -483,6 +483,201 @@ The XML below is the current version for this CSP.
           </Node>
         </Node>
         <Node>
+          <NodeName>RootCertificate4</NodeName>
+          <DFProperties>
+            <AccessType>
+              <Get />
+            </AccessType>
+            <Description>Required. Specifies the root certificate for the H-SLP server. Windows Phone does not support a non-secure mode. If this node is not included, the configuration service provider will fail but may not return a specific error.</Description>
+            <DFFormat>
+              <node />
+            </DFFormat>
+            <Occurrence>
+              <One />
+            </Occurrence>
+            <Scope>
+              <Permanent />
+            </Scope>
+            <DFType>
+              <DDFName></DDFName>
+            </DFType>
+          </DFProperties>
+          <Node>
+            <NodeName>Name</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>Specifies the name of the H-SLP root certificate as a string, in the format name.cer.</Description>
+              <DFFormat>
+                <chr />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <MIME>text/plain</MIME>
+              </DFType>
+            </DFProperties>
+          </Node>
+          <Node>
+            <NodeName>Data</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>The base 64 encoded blob of the H-SLP root certificate.</Description>
+              <DFFormat>
+                <b64 />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <DDFName></DDFName>
+              </DFType>
+            </DFProperties>
+          </Node>
+        </Node>
+        <Node>
+          <NodeName>RootCertificate5</NodeName>
+          <DFProperties>
+            <AccessType>
+              <Get />
+            </AccessType>
+            <Description>Required. Specifies the root certificate for the H-SLP server. Windows Phone does not support a non-secure mode. If this node is not included, the configuration service provider will fail but may not return a specific error.</Description>
+            <DFFormat>
+              <node />
+            </DFFormat>
+            <Occurrence>
+              <One />
+            </Occurrence>
+            <Scope>
+              <Permanent />
+            </Scope>
+            <DFType>
+              <DDFName></DDFName>
+            </DFType>
+          </DFProperties>
+          <Node>
+            <NodeName>Name</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>Specifies the name of the H-SLP root certificate as a string, in the format name.cer.</Description>
+              <DFFormat>
+                <chr />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <MIME>text/plain</MIME>
+              </DFType>
+            </DFProperties>
+          </Node>
+          <Node>
+            <NodeName>Data</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>The base 64 encoded blob of the H-SLP root certificate.</Description>
+              <DFFormat>
+                <b64 />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <DDFName></DDFName>
+              </DFType>
+            </DFProperties>
+          </Node>
+        </Node>
+        <Node>
+          <NodeName>RootCertificate6</NodeName>
+          <DFProperties>
+            <AccessType>
+              <Get />
+            </AccessType>
+            <Description>Required. Specifies the root certificate for the H-SLP server. Windows Phone does not support a non-secure mode. If this node is not included, the configuration service provider will fail but may not return a specific error.</Description>
+            <DFFormat>
+              <node />
+            </DFFormat>
+            <Occurrence>
+              <One />
+            </Occurrence>
+            <Scope>
+              <Permanent />
+            </Scope>
+            <DFType>
+              <DDFName></DDFName>
+            </DFType>
+          </DFProperties>
+          <Node>
+            <NodeName>Name</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>Specifies the name of the H-SLP root certificate as a string, in the format name.cer.</Description>
+              <DFFormat>
+                <chr />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <MIME>text/plain</MIME>
+              </DFType>
+            </DFProperties>
+          </Node>
+          <Node>
+            <NodeName>Data</NodeName>
+            <DFProperties>
+              <AccessType>
+                <Get />
+                <Replace />
+              </AccessType>
+              <Description>The base 64 encoded blob of the H-SLP root certificate.</Description>
+              <DFFormat>
+                <b64 />
+              </DFFormat>
+              <Occurrence>
+                <One />
+              </Occurrence>
+              <Scope>
+                <Permanent />
+              </Scope>
+              <DFType>
+                <DDFName></DDFName>
+              </DFType>
+            </DFProperties>
+          </Node>
+        </Node>
+        <Node>
           <NodeName>V2UPL1 </NodeName>
           <DFProperties>
             <AccessType>
@@ -662,6 +857,7 @@ The XML below is the current version for this CSP.
         </Node>
       </Node>
 </MgmtTree>
+
 ```
 
  


### PR DESCRIPTION
We have recently made a change in our Location Platform pertaining to SUPL to increase the max number of root certificates from 3 to 6 (as mandated). As a result, we will need to update the necessary public documentation here:  https://docs.microsoft.com/en-us/windows/client-management/mdm/supl-ddf-file