### PR TITLE
Update supl-csp.md

### DIFF
--- a/windows/client-management/mdm/supl-csp.md
+++ b/windows/client-management/mdm/supl-csp.md
@@ -232,6 +232,24 @@ Specifies the name of the H-SLP root certificate as a string, in the format *nam
 <a href="" id="rootcertificate3-data"></a>**RootCertificate3/Data**  
 The base 64 encoded blob of the H-SLP root certificate.
 
+<a href="" id="rootcertificate-name"></a>**RootCertificate4/Name**  
+Specifies the name of the H-SLP root certificate as a string, in the format *name*.cer.
+
+<a href="" id="rootcertificate-data"></a>**RootCertificate4/Data**  
+The base 64 encoded blob of the H-SLP root certificate.
+
+<a href="" id="rootcertificate2-name"></a>**RootCertificate5/Name**  
+Specifies the name of the H-SLP root certificate as a string, in the format *name*.cer.
+
+<a href="" id="rootcertificate2-data"></a>**RootCertificate5/Data**  
+The base 64 encoded blob of the H-SLP root certificate.
+
+<a href="" id="rootcertificate3-name"></a>**RootCertificate6/Name**  
+Specifies the name of the H-SLP root certificate as a string, in the format *name*.cer.
+
+<a href="" id="rootcertificate3-data"></a>**RootCertificate6/Data**  
+The base 64 encoded blob of the H-SLP root certificate.
+
 <a href="" id="v2upl1"></a>**V2UPL1**  
 Required for V2 UPL for CDMA. Specifies the account settings for user plane location and IS-801 for CDMA. Only one account is supported at a given time.
 


### PR DESCRIPTION
We have recently made a change in our Location Platform pertaining to SUPL to increase the max number of root certificates from 3 to 6 (as mandated). As a result, we will need to update the necessary public documentation here: https://docs.microsoft.com/en-us/windows/client-management/mdm/supl-csp