### PR TITLE
Update windows-10-start-layout-options-and-policies.md

### DIFF
--- a/windows/configuration/windows-10-start-layout-options-and-policies.md
+++ b/windows/configuration/windows-10-start-layout-options-and-policies.md
@@ -30,6 +30,8 @@ Organizations might want to deploy a customized Start and taskbar configuration 
 >Start and taskbar configuration can be applied to devices running Windows 10 Pro, version 1703.
 >
 >Using the layout modification XML to configure Start is not supported with roaming user profiles. For more information, see [Deploy Roaming User Profiles](https://technet.microsoft.com/library/jj649079.aspx).
+>
+>Using CopyProfile for Start menu customization in Windows 10 isn't supported. For more information [Customize the Default User Profile by Using CopyProfile](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/customize-the-default-user-profile-by-using-copyprofile)
 
 
 


### PR DESCRIPTION
I think adding the reference to CopyProfile not being supported will help insure IT Pros do not consider using it as a alternative to the options detailed here