### PR TITLE
Update manage-settings-with-mdm-for-surface-hub.md

### DIFF
--- a/devices/surface-hub/manage-settings-with-mdm-for-surface-hub.md
+++ b/devices/surface-hub/manage-settings-with-mdm-for-surface-hub.md
@@ -46,7 +46,6 @@ Surface Hub now supports the ability to automatically enroll in Intune by joinin
 
 For more information, see [Enable Windows 10 automatic enrollment](https://docs.microsoft.com/intune/windows-enroll#enable-windows-10-automatic-enrollment).
 
-
 ## Manage Surface Hub settings with MDM
 
 You can use MDM to manage some [Surface Hub CSP settings](#supported-surface-hub-csp-settings), and some [Windows 10 settings](#supported-windows-10-settings). Depending on the MDM provider that you use, you may set these settings using a built-in user interface, or by deploying custom SyncML. Microsoft Intune and System Center Configuration Manager provide built-in experiences to help create policy templates for Surface Hub. Refer to documentation from your MDM provider to learn how to create and deploy SyncML.
@@ -85,7 +84,7 @@ For more information, see [SurfaceHub configuration service provider](https://ms
 
 ### Supported Windows 10 settings
 
-In addition to Surface Hub-specific settings, there are numerous settings common to all Windows 10 devices. These settings are defined in the [Configuration service provider reference](https://msdn.microsoft.com/library/windows/hardware/dn920025.aspx). 
+In addition to Surface Hub-specific settings, there are numerous settings common to all Windows 10 devices. These settings are defined in the [Configuration service provider reference](https://docs.microsoft.com/en-us/windows/client-management/mdm/configuration-service-provider-reference). 
 
 The following tables include info on Windows 10 settings that have been validated with Surface Hub. There is a table with settings for these areas: security, browser, Windows Updates, Windows Defender, remote reboot, certificates, and logs. Each table identifies if the setting is supported with Microsoft Intune, System Center Configuration Manager, or SyncML.
 

--- a/devices/surface-hub/manage-settings-with-mdm-for-surface-hub.md
+++ b/devices/surface-hub/manage-settings-with-mdm-for-surface-hub.md
@@ -84,7 +84,7 @@ For more information, see [SurfaceHub configuration service provider](https://ms
 
 ### Supported Windows 10 settings
 
-In addition to Surface Hub-specific settings, there are numerous settings common to all Windows 10 devices. These settings are defined in the [Configuration service provider reference](https://docs.microsoft.com/en-us/windows/client-management/mdm/configuration-service-provider-reference). 
+In addition to Surface Hub-specific settings, there are numerous settings common to all Windows 10 devices. These settings are defined in the [Configuration service provider reference](https://docs.microsoft.com/windows/client-management/mdm/configuration-service-provider-reference). 
 
 The following tables include info on Windows 10 settings that have been validated with Surface Hub. There is a table with settings for these areas: security, browser, Windows Updates, Windows Defender, remote reboot, certificates, and logs. Each table identifies if the setting is supported with Microsoft Intune, System Center Configuration Manager, or SyncML.
 


### PR DESCRIPTION
In the Supported Windows setting section, the link in the first paragraph for Configuration service provider reference is outdated, but does get redirected to the correct webpage.  Corrected link so that it points directly to the article