### PR TITLE
Fixing default registry value set for DisableTelemetryOptInChangeNotification

### DIFF
--- a/windows/privacy/windows-personal-data-services-configuration.md
+++ b/windows/privacy/windows-personal-data-services-configuration.md
@@ -109,7 +109,7 @@ This setting determines whether a device shows notifications about Windows diagn
 >| **Registry key** | HKLM\Software\Policies\Microsoft\Windows\DataCollection |
 >| **Value** | DisableTelemetryOptInChangeNotification |
 >| **Type** | REG_DWORD |
->| **Setting** | "00000001" |
+>| **Setting** | "00000000" |
 
 #### MDM
 


### PR DESCRIPTION
This change, fixes the "Registry" section for "Diagnostic opt-in change notifications". The "GP/MDM" sections contradict the "Registry" section of the document. The default value (i.e. Enable mentioned in GP/MDM section) is 0 and not 1, setting the registry key to 1 will actually disable the notification, while the default behavior is to have it not set OR enabled (i.e. 0).