### PR TITLE
Update policy-csp-controlpolicyconflict.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-controlpolicyconflict.md
+++ b/windows/client-management/mdm/policy-csp-controlpolicyconflict.md
@@ -67,7 +67,8 @@ Added in Windows 10, version 1803. This policy allows the IT admin to control wh
 > [!Note]  
 > MDMWinsOverGP only applies to policies in Policy CSP. It does not apply to other MDM settings with equivalent GP settings that are defined on other configuration service providers.
 
-This policy is used to ensure that MDM policy wins over GP when same setting is set by both GP and MDM channel. This policy doesn’t support Delete command. This policy doesn’t support setting the value to be 0 again after it was previously set 1. The default value is 0. The MDM policies in Policy CSP will behave as described if this policy value is set 1.
+This policy is used to ensure that MDM policy wins over GP when same setting is set by both GP and MDM channel. The default value is 0. The MDM policies in Policy CSP will behave as described if this policy value is set 1.
+Note: This policy doesn’t support Delete command. This policy doesn’t support setting the value to be 0 again after it was previously set 1. In Windows 10, version 1809, Delete command and setting the value to be 0 again if it was previously set to 1 will be supported.
 
 The following list shows the supported values:
 

--- a/windows/client-management/mdm/policy-csp-controlpolicyconflict.md
+++ b/windows/client-management/mdm/policy-csp-controlpolicyconflict.md
@@ -68,7 +68,7 @@ Added in Windows 10, version 1803. This policy allows the IT admin to control wh
 > MDMWinsOverGP only applies to policies in Policy CSP. It does not apply to other MDM settings with equivalent GP settings that are defined on other configuration service providers.
 
 This policy is used to ensure that MDM policy wins over GP when same setting is set by both GP and MDM channel. The default value is 0. The MDM policies in Policy CSP will behave as described if this policy value is set 1.
-Note: This policy doesn’t support Delete command. This policy doesn’t support setting the value to be 0 again after it was previously set 1. In Windows 10, version 1809, Delete command and setting the value to be 0 again if it was previously set to 1 will be supported.
+Note: This policy doesn’t support Delete command. This policy doesn’t support setting the value to be 0 again after it was previously set 1. In Windows 10, next major version, Delete command and setting the value to be 0 again if it was previously set to 1 will be supported.
 
 The following list shows the supported values:
 


### PR DESCRIPTION
Change description field for RS5. In RS5, delete command and set the value to 0 after setting it to be 1 will be supported. Please review the text with Peter Kaufman.