### PR TITLE
Adding Preserving user Always On preference

### DIFF
--- a/windows/client-management/mdm/vpnv2-csp.md
+++ b/windows/client-management/mdm/vpnv2-csp.md
@@ -255,7 +255,14 @@ An optional flag to enable Always On mode. This will automatically connect the V
 
 > **Note**  Always On only works for the active profile. The first profile provisioned that can be auto triggered will automatically be set as active.
 
- 
+Preserving user Always On preference
+
+Windows has a feature to preserve a user’s AlwaysOn preference.  In the event that a user manually unchecks the “Connect    automatically” checkbox, Windows will remember this user preference for this profile name by adding the profile name to the value AutoTriggerDisabledProfilesList.  
+Should a management tool remove/add the same profile name back and set AlwaysOn to true, Windows will not check the box if the profile name exists in the below registry value in order to preserve user preference.
+Key: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RasMan\Config
+Value: AutoTriggerDisabledProfilesList
+Type: REG_MULTI_SZ
+
 
 Valid values:
 


### PR DESCRIPTION
Adding a note under the AlwaysOn node to explain to users how the AlwaysOn preference is stored in the registry and take precedence over the AlwaysOn setting if enabled.