### PR TITLE
Fixing the registry path for setting telemetry level via GP

### DIFF
--- a/windows/privacy/configure-windows-diagnostic-data-in-your-organization.md
+++ b/windows/privacy/configure-windows-diagnostic-data-in-your-organization.md
@@ -379,7 +379,7 @@ Use the [Policy Configuration Service Provider (CSP)](http://msdn.microsoft.com/
 
 Use Registry Editor to manually set the registry level on each device in your organization or you can write a script to edit the registry. If a management policy already exists, such as Group Policy or MDM, it will override this registry setting.
 
-1.  Open Registry Editor, and go to **HKEY\_LOCAL\_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\DataCollection**.
+1.  Open Registry Editor, and go to **HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\Windows\\DataCollection**.
 
 2.  Right-click **DataCollection**, click New, and then click **DWORD (32-bit) Value**.
 


### PR DESCRIPTION
This PR fixes the registry path for settings telemetry level via GP.
Fixes issues #715 & #1303 