### PR TITLE
The location for download is changed

### DIFF
--- a/devices/surface/use-system-center-configuration-manager-to-manage-devices-with-semm.md
+++ b/devices/surface/use-system-center-configuration-manager-to-manage-devices-with-semm.md
@@ -42,7 +42,7 @@ Management of SEMM with Configuration Manager requires the installation of Micro
 
 #### Download SEMM scripts for Configuration Manager
 
-After Microsoft Surface UEFI Manager is installed on the client Surface device, SEMM is deployed and managed with PowerShell scripts. You can download samples of the [SEMM management scripts](https://gallery.technet.microsoft.com/Sample-PowerShell-for-5eb5f03c) from the TechNet Gallery Script Center.
+After Microsoft Surface UEFI Manager is installed on the client Surface device, SEMM is deployed and managed with PowerShell scripts. You can download samples of the [SEMM management scripts](https://www.microsoft.com/en-us/download/details.aspx?id=46703) from the Download Center.
 
 ## Deploy Microsoft Surface UEFI Manager
 
@@ -269,7 +269,7 @@ The following code fragment, found on lines 352-363, is used to write this regis
 
 ### Settings names and IDs
 
-To configure Surface UEFI settings or permissions for Surface UEFI settings, you must refer to each setting by either its setting name or setting ID. With each new update for Surface UEFI, new settings may be added. The best way to get a complete list of the settings available on a Surface device, along with the settings name and settings IDs, is to use the ShowSettingsOptions.ps1 script from [SEMM management scripts for Configuration Manager](https://gallery.technet.microsoft.com/Sample-PowerShell-for-5eb5f03c) in the TechNet Gallery Script Center.
+To configure Surface UEFI settings or permissions for Surface UEFI settings, you must refer to each setting by either its setting name or setting ID. With each new update for Surface UEFI, new settings may be added. The best way to get a complete list of the settings available on a Surface device, along with the settings name and settings IDs, is to use the ShowSettingsOptions.ps1 script from SEMM_Powershell.zip in [Surface Tools for IT Downloads](https://www.microsoft.com/en-us/download/details.aspx?id=46703) 
 
 The computer where ShowSettingsOptions.ps1 is run must have Microsoft Surface UEFI Manager installed, but the script does not require a Surface device.
 


### PR DESCRIPTION
There are 2 references to SEMM Management scripts download on this page. We have changed the location of where these are downloaded from
Old location: https://gallery.technet.microsoft.com/Sample-PowerShell-for-5eb5f03c
New Location: https://www.microsoft.com/en-us/download/details.aspx?id=46703. Name of the file is SEMM_PowerShell.zip

Changes: 
You can download samples of the SEMM management scripts from the TechNet Gallery Script Center.
To this
You can download samples of the SEMM management scripts, SEMM_Powershell.zip from the Surface Tools for IT Downloads.
Need to change this sentence
is to use the ShowSettingsOptions.ps1 script from SEMM management scripts for Configuration Manager in the TechNet Gallery Script Center.
To this
is to use the ShowSettingsOptions.ps1 script from SEMM_Powershell.zip from the Surface Tools for IT Downloads