### PR TITLE
Update high-level-architecture-of-mbam-25-with-stand-alone-topology.md

### DIFF
--- a/mdop/mbam-v25/high-level-architecture-of-mbam-25-with-stand-alone-topology.md
+++ b/mdop/mbam-v25/high-level-architecture-of-mbam-25-with-stand-alone-topology.md
@@ -109,7 +109,7 @@ This feature is configured on a computer running Windows Server.
 The **monitoring web services** are used by the MBAM Client and the websites to communicate to the database.
 
 **Important**  
-The Monitoring Web Service is no longer available in Microsoft BitLocker Administration and Monitoring (MBAM) 2.5 SP1 since the MBAM Client and the websites communicate directly with the Recovery Database.
+The Monitoring Web Service is no longer available in Microsoft BitLocker Administration and Monitoring (MBAM) 2.5 SP1 since the MBAM websites communicate directly with the Recovery Database.
 
  
 


### PR DESCRIPTION
Removed erroneous inclusion of clients communicating directly with recovery database. This was confirmed with our Microsoft PFE, Sean Kearney:
"I’m trying to reach back with the owner of the documentation as I’ve spoke to another PFE who just implemented MBAM 2.5 SP1 and the Architecture is the same as 2.5 (Workstations communicate with Web Server).   I’m trying to get clarification on why the documentation says this when it doesn’t seem to behave that way.    
 
I can confirm from his installation that the workstations do NOT communicate directly with the SQL server as he had to define explicit firewall rules for each part of the installation.    Workstations talking directly to a Clustered SQL instance would have been rejected.

Sean P Kearney |  
-- | --
Premier Field Engineer   Enterprise Services Delivery \| Secure Infrastructure   Microsoft \| Ottawa, ON Canada | Office: +1 (613) 212-2382   Mobile:+1 (613) 852-8721   sean.kearney@microsoft.com
Scripting Guy   Microsoft Script Center |  
"
