### PR TITLE
Correct Exploit Guard and Edition Requirements

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/windows-defender-exploit-guard.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/windows-defender-exploit-guard.md
@@ -74,8 +74,8 @@ This section covers requirements for each feature in Windows Defender EG.
 
 | Feature | Windows 10 Home | Windows 10 Professional | Windows 10 E3 | Windows 10 E5 |
 | ----------------- | :------------------------------------: | :---------------------------: | :-------------------------: | :--------------------------------------: |
-| Exploit protection | ![supported](./images/ball_50.png) | ![supported](./images/ball_50.png) | ![supported, enhanced](./images/ball_75.png) | ![supported, full reporting](./images/ball_full.png) |
-| Attack surface reduction | ![not supported](./images/ball_empty.png) | ![not supported](./images/ball_empty.png) | ![not supported](./images/ball_50.png) | ![supported, full reporting](./images/ball_full.png) |
+| Exploit protection | ![supported](./images/ball_50.png) | ![supported](./images/ball_50.png) | ![supported](./images/ball_50.png) | ![supported, full reporting](./images/ball_full.png) |
+| Attack surface reduction | ![not supported](./images/ball_empty.png) | ![not supported](./images/ball_empty.png) | ![not supported](./images/ball_empty.png) | ![supported, full reporting](./images/ball_full.png) |
 | Network protection | ![not supported](./images/ball_empty.png) | ![not supported](./images/ball_empty.png) | ![supported, limited reporting](./images/ball_50.png) | ![supported, full reporting](./images/ball_full.png) |
 | Controlled folder access | ![supported, limited reporting](./images/ball_50.png) | ![supported, limited reporting](./images/ball_50.png) | ![supported, limited reporting](./images/ball_50.png) | ![supported, full reporting](./images/ball_full.png) |
 


### PR DESCRIPTION
Correcting the chart as of 1803 (HVCI in Pro) and also moving ASR to E5 only.