### PR TITLE
Location and registry clarification

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level.md
+++ b/windows/security/threat-protection/security-policy-settings/network-security-lan-manager-authentication-level.md
@@ -55,9 +55,13 @@ authentication level that servers accept. The following table identifies the pol
 
 -   Best practices are dependent on your specific security and authentication requirements.
 
-### Location
+### Policy Location
 
 Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options
+
+### Registry Location
+
+HKLM\System\CurrentControlSet\Control\Lsa\LmCompatibilityLevel
 
 ### Default values
 


### PR DESCRIPTION
Clarified that existing listed location is the policy location.
Added registry location as recommended by user TonyLongsonFJ
Personal note: While adding the registry location to the article is not a bad idea, it will be a lot of work to add that to all the settings in all the articles. It could also be a lot of maintenance when changes occur. 
It may be better to refer in the articles to the fact that the associated registry locations for all settings can be found in the Group Policy Settings Reference downloadable spreadsheet.