### PR TITLE
Typo fixes

### DIFF
--- a/mdop/appv-v4/application-virtualization-client-hardware-and-software-requirements.md
+++ b/mdop/appv-v4/application-virtualization-client-hardware-and-software-requirements.md
@@ -50,7 +50,7 @@ The hardware requirements are applicable to all versions.
 <th align="left">Operating System</th>
 <th align="left">Edition</th>
 <th align="left">Service Pack</th>
-<th align="left">System Architecture</th>
+<th align="left">Achitectural SKU</th>
 </tr>
 </thead>
 <tbody>
@@ -74,30 +74,20 @@ The hardware requirements are applicable to all versions.
 </tr>
 <tr class="even">
 <td align="left"><p>Windows 8</p></td>
-<td align="left"><p>Professional or Enterprise Edition</p></td>
+<td align="left"><p>Pro or Enterprise Edition</p></td>
 <td align="left"><p></p></td>
 <td align="left"><p>x86 and x64</p></td>
 </tr>
 </tbody>
 </table>
 
- 
-
-**Note**  
 The following software prerequisites are installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, the following products must be installed first.
-
 -   **Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2005 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=119961) (https://go.microsoft.com/fwlink/?LinkId=119961). For version 4.5 SP2 of the App-V client, download Vcredist\_x86.exe from [Microsoft Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update](https://go.microsoft.com/fwlink/?LinkId=169360) (https://go.microsoft.com/fwlink/?LinkId=169360).
+ -   **Microsoft Core XML Services (MSXML) 6.0 SP1 (x86)**—For more information about installing Microsoft Core XML Services (MSXML) 6.0 SP1 (x86), see [Microsoft Core XML Services (MSXML) 6.0 SP1 (x86)](https://go.microsoft.com/fwlink/?LinkId=63266) (https://go.microsoft.com/fwlink/?LinkId=63266).
 
--   **Microsoft Core XML Services (MSXML) 6.0 SP1 (x86)**—For more information about installing Microsoft Core XML Services (MSXML) 6.0 SP1 (x86), see [Microsoft Core XML Services (MSXML) 6.0 SP1 (x86)](https://go.microsoft.com/fwlink/?LinkId=63266) (https://go.microsoft.com/fwlink/?LinkId=63266).
-
- 
-
-**Note**  
 For the Application Virtualization (App-V) 4.6 Desktop Client, the following additional software prerequisite is installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, you must also install with the other prerequisites listed.
 
 -   **Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2008 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=150700) (https://go.microsoft.com/fwlink/?LinkId=150700).
-
- 
 
 ### Software Requirements for Versions that Precede App-V 4.6 SP2
 
@@ -113,7 +103,7 @@ For the Application Virtualization (App-V) 4.6 Desktop Client, the following add
 <th align="left">Operating System</th>
 <th align="left">Edition</th>
 <th align="left">Service Pack</th>
-<th align="left">System Architecture</th>
+<th align="left">Achitectural SKU</th>
 </tr>
 </thead>
 <tbody>
@@ -121,33 +111,26 @@ For the Application Virtualization (App-V) 4.6 Desktop Client, the following add
 <td align="left"><p>Windows XP</p></td>
 <td align="left"><p>Professional Edition</p></td>
 <td align="left"><p>SP2 or SP3</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Windows Vista</p></td>
 <td align="left"><p>Business, Enterprise, or Ultimate Edition</p></td>
 <td align="left"><p>No service pack, SP1, or SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Windows 7¹</p></td>
 <td align="left"><p>Professional, Enterprise, or Ultimate Edition</p></td>
 <td align="left"><p>No service pack or SP1</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 </tbody>
 </table>
-
- 
-
 ¹Supported for App-V 4.5 SP1 and SP2, App-V 4.6 and 4.6 SP1 only
 
-**Note**  
-The Application Virtualization (App-V) 4.6 Desktop Client supports 32-bit and 64-bit versions of these operating systems.
+The Application Virtualization (App-V) 4.6 Desktop Client supports x86 and x64 SKUs of these operating systems.
 
- 
-
-**Note**  
 The following software prerequisites are installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, the following products must be installed first.
 
 -   **Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2005 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=119961) (https://go.microsoft.com/fwlink/?LinkId=119961). For version 4.5 SP2 of the App-V client, download Vcredist\_x86.exe from [Microsoft Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update](https://go.microsoft.com/fwlink/?LinkId=169360) (https://go.microsoft.com/fwlink/?LinkId=169360).
@@ -156,24 +139,15 @@ The following software prerequisites are installed automatically if you are usin
 
 -   **Microsoft Application Error Reporting**—The installation program for this software is included in the **Support\\Watson** folder in the self-extracting archive file.
 
- 
-
-**Note**  
 For the Application Virtualization (App-V) 4.6 Desktop Client, the following additional software prerequisite is installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, you must also install with the other prerequisites listed.
 
 -   **Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2008 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=150700) (https://go.microsoft.com/fwlink/?LinkId=150700).
 
- 
-
 ## Application Virtualization Client for Remote Desktop Services
-
 
 Following are the recommended hardware and software requirements for the Application Virtualization Client for Remote Desktop Services. The requirements are listed first for appv461\_3, followed by the requirements for versions that preceded App-V 4.6 SP2.
 
-**Note**  
 The Application Virtualization (App-V) Client for Remote Desktop Services requires no additional processor or RAM resources beyond the requirements of the host operating system.
-
- 
 
 ### Hardware Requirements
 
@@ -199,7 +173,7 @@ The hardware requirements are applicable to all versions.
 <th align="left">Operating System</th>
 <th align="left">Edition</th>
 <th align="left">Service Pack</th>
-<th align="left">System Architecture</th>
+<th align="left">Achitectural SKU</th>
 </tr>
 </thead>
 <tbody>
@@ -207,13 +181,13 @@ The hardware requirements are applicable to all versions.
 <td align="left"><p>Windows Server 2003 R2</p></td>
 <td align="left"><p>Standard Edition, Enterprise Edition, or Datacenter Edition</p></td>
 <td align="left"><p>SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Windows Server 2008</p></td>
 <td align="left"><p>Standard, Enterprise, or Datacenter Edition</p></td>
 <td align="left"><p>SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Windows Server 2008 R2</p></td>
@@ -225,14 +199,11 @@ The hardware requirements are applicable to all versions.
 <td align="left"><p>Windows Server 2012</p></td>
 <td align="left"><p>Standard, Enterprise, or Datacenter Edition</p></td>
 <td align="left"><p></p></td>
-<td align="left"><p>x86 or x64</p></td>
+<td align="left"><p>x64</p></td>
 </tr>
 </tbody>
 </table>
 
- 
-
-**Note**  
 The following software prerequisites are installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, the following products must be installed first.
 
 -   **Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2005 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2005 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=119961) (https://go.microsoft.com/fwlink/?LinkId=119961). For version 4.5 SP2 of the App-V client, download Vcredist\_x86.exe from [Microsoft Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update](https://go.microsoft.com/fwlink/?LinkId=169360) (https://go.microsoft.com/fwlink/?LinkId=169360).
@@ -241,14 +212,9 @@ The following software prerequisites are installed automatically if you are usin
 
 -   **Microsoft Application Error Reporting**—The installation program for this software is included in the **Support\\Watson** folder in the self-extracting archive file.
 
- 
-
-**Note**  
 For the Application Virtualization (App-V) 4.6 Desktop Client, the following additional software prerequisite is installed automatically if you are using the Setup.exe method. If you are using the Setup.msi installation program, you must also install with the other prerequisites listed.
 
 -   **Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)**—For more information about installing Microsoft Visual C++ 2008 SP1 Redistributable Package (x86), see [Microsoft Visual C++ 2008 SP1 Redistributable Package (x86)](https://go.microsoft.com/fwlink/?LinkId=150700) (https://go.microsoft.com/fwlink/?LinkId=150700).
-
- 
 
 ### Software Requirements for Versions that Precede App-V 4.6 SP2
 
@@ -264,7 +230,7 @@ For the Application Virtualization (App-V) 4.6 Desktop Client, the following add
 <th align="left">Operating System</th>
 <th align="left">Edition</th>
 <th align="left">Service Pack</th>
-<th align="left">System Architecture</th>
+<th align="left">Achitectural SKU</th>
 </tr>
 </thead>
 <tbody>
@@ -272,19 +238,19 @@ For the Application Virtualization (App-V) 4.6 Desktop Client, the following add
 <td align="left"><p>Windows Server 2003</p></td>
 <td align="left"><p>Standard Edition, Enterprise Edition, or Datacenter Edition</p></td>
 <td align="left"><p>SP1 or SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Windows Server 2003 R2</p></td>
 <td align="left"><p>Standard Edition, Enterprise Edition, or Datacenter Edition</p></td>
 <td align="left"><p>No service pack or SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="odd">
 <td align="left"><p>Windows Server 2008</p></td>
 <td align="left"><p>Standard, Enterprise, or Datacenter Edition</p></td>
 <td align="left"><p>SP1 or SP2</p></td>
-<td align="left"><p>x86</p></td>
+<td align="left"><p>x86 and x64</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Windows Server 2008 R2</p></td>
@@ -295,31 +261,11 @@ For the Application Virtualization (App-V) 4.6 Desktop Client, the following add
 </tbody>
 </table>
 
- 
-
-**Note**  
-The Application Virtualization (App-V) 4.6 Client for Remote Desktop Services supports 32-bit and 64-bit versions of these operating systems.
-
- 
+The Application Virtualization (App-V) 4.6 Client for Remote Desktop Services supports x86 and x64 SKUs of these operating systems.
 
 ## Related topics
-
-
-[Application Virtualization Sequencer Hardware and Software Requirements](application-virtualization-sequencer-hardware-and-software-requirements.md)
-
-[Application Virtualization System Requirements](application-virtualization-system-requirements.md)
-
-[How to Install the Client by Using the Command Line](how-to-install-the-client-by-using-the-command-line-new.md)
-
-[How to Manually Install the Application Virtualization Client](how-to-manually-install-the-application-virtualization-client.md)
-
-[How to Upgrade the Application Virtualization Client](how-to-upgrade-the-application-virtualization-client.md)
-
- 
-
- 
-
-
-
-
-
+- [Application Virtualization Sequencer Hardware and Software Requirements](application-virtualization-sequencer-hardware-and-software-requirements.md)
+- [Application Virtualization System Requirements](application-virtualization-system-requirements.md)
+- [How to Install the Client by Using the Command Line](how-to-install-the-client-by-using-the-command-line-new.md)
+- [How to Manually Install the Application Virtualization Client](how-to-manually-install-the-application-virtualization-client.md)
+- [How to Upgrade the Application Virtualization Client](how-to-upgrade-the-application-virtualization-client.md)

--- a/mdop/appv-v4/application-virtualization-sequencer-hardware-and-software-requirements.md
+++ b/mdop/appv-v4/application-virtualization-sequencer-hardware-and-software-requirements.md
@@ -86,7 +86,7 @@ The following list outlines the supported operating systems for running the App-
 </tr>
 <tr class="even">
 <td align="left"><p>Windows 8</p></td>
-<td align="left"><p>Professional or Enterprise Edition</p></td>
+<td align="left"><p>Pro or Enterprise Edition</p></td>
 <td align="left"><p></p></td>
 <td align="left"><p>x86 and x64</p></td>
 </tr>

--- a/windows/deployment/upgrade/windows-10-upgrade-paths.md
+++ b/windows/deployment/upgrade/windows-10-upgrade-paths.md
@@ -142,7 +142,7 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td></td>
     </tr>
     <tr>
-        <td>Professional</td>
+        <td>Pro</td>
         <td>D</td>
         <td>✔</td>
         <td>✔</td>
@@ -153,7 +153,7 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td></td>
     </tr>
     <tr>
-        <td>Professional Student</td>
+        <td>Pro Student</td>
         <td>D</td>
         <td>✔</td>
         <td>✔</td>
@@ -164,7 +164,7 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td></td>
     </tr>
     <tr>
-        <td>Professional WMC</td>
+        <td>Pro WMC</td>
         <td>D</td>
         <td>✔</td>
         <td>✔</td>
@@ -233,7 +233,7 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td></td>
     </tr>
     <tr>
-        <td>Professional</td>
+        <td>Pro</td>
         <td>D</td>
         <td>✔</td>
         <td>✔</td>

--- a/windows/deployment/windows-autopilot/windows-autopilot-requirements-licensing.md
+++ b/windows/deployment/windows-autopilot/windows-autopilot-requirements-licensing.md
@@ -18,22 +18,19 @@ ms.date: 06/01/2018
 
 Windows Autopilot depends on specific capabilities available in Windows 10 and Azure Active Directory; it also requires an MDM service such as Microsoft Intune. These capabilities can be obtained through various editions and subscription programs:
 
--   Windows 10 version 1703 or higher must be used. The Professional, Professional for Education, Business, Enterprise, and Education editions are supported.
-
+-   Windows 10 version 1703 or higher must be used. Supported editions are the following:
+    -   Pro
+    -   Pro Education
+    -   Pro for Workstations
+    -   Enterprise
+    -   Education
 -   One of the following, to provide needed Azure Active Directory (automatic MDM enrollment and company branding features) and MDM functionality:
-
     -   Microsoft 365 Business subscriptions
-    
     -   Microsoft 365 F1 subscriptions
-
     -   Microsoft 365 Enterprise E3 or E5 subscriptions, which include all Windows 10, Office 365, and EM+S features (Azure AD and Intune)
-
     -   Enterprise Mobility + Security E3 or E5 subscriptions, which include all needed Azure AD and Intune features
-
     -   Azure Active Directory Premium P1 or P2 and Intune subscriptions (or an alternative MDM service)
 
 Additionally, the following are also recommended but not required:
-
 -   Office 365 ProPlus, which can be deployed easily via Intune (or other MDM services)
-
 -   [Windows Subscription Activation](https://docs.microsoft.com/en-us/windows/deployment/windows-10-enterprise-subscription-activation), to automatically step up devices from Windows 10 Pro to Windows 10 Enterprise


### PR DESCRIPTION
All these changes are typo fixes. In most cases, Windows 10 Pro was incorrectly written as "Windows 10 Professional". Someone familiar with the topic, however, might want to review [mdop/appv-v4/application-virtualization-client-hardware-and-software-requirements.md](mdop/appv-v4/application-virtualization-client-hardware-and-software-requirements.md). It has contradictory sections that deserve attention beyond that of just uncontroversial typo fix.