### PR TITLE
New links + small edits

### DIFF
--- a/windows/security/threat-protection/windows-platform-common-criteria.md
+++ b/windows/security/threat-protection/windows-platform-common-criteria.md
@@ -1,14 +1,14 @@
 ---
-title: Windows Platform Common Criteria Certification
+title: Common Criteria Certifications
 description: This topic details how Microsoft supports the Common Criteria certification program.
 ms.prod: w10
 ms.localizationpriority: medium
 ms.author: daniha
 author: danihalfin
-ms.date: 04/03/2018
+ms.date: 10/8/2018
 ---
 
-# Windows Platform Common Criteria Certification
+# Common Criteria Certifications
 
 Microsoft is committed to optimizing the security of its products and services. As part of that commitment, Microsoft supports the Common Criteria certification program, continues to ensure that products incorporate the features and functions required by relevant Common Criteria protection profiles, and completes Common Criteria certifications of Microsoft Windows products.
 
@@ -18,7 +18,8 @@ Microsoft is committed to optimizing the security of its products and services. 
 
 The Security Target describes security functionality and assurance measures used to evaluate Windows.
 
-  - [Microsoft Window 10 (Creators Update)](http://download.microsoft.com/download/e/8/b/e8b8c42a-a0b6-4ba1-9bdc-e704e8289697/windows%2010%20version%201703%20gp%20os%20security%20target%20-%20public%20\(january%2016,%202018\)\(final\)\(clean\).pdf)
+  - [Microsoft Windows 10 (Fall Creators Update)](http://download.microsoft.com/download/B/6/A/B6A5EC2C-6351-4FB9-8FF1-643D4BD5BE6E/Windows%2010%201709%20GP%20OS%20Security%20Target.pdf)
+  - [Microsoft Windows 10 (Creators Update)](http://download.microsoft.com/download/e/8/b/e8b8c42a-a0b6-4ba1-9bdc-e704e8289697/windows%2010%20version%201703%20gp%20os%20security%20target%20-%20public%20\(january%2016,%202018\)\(final\)\(clean\).pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](http://download.microsoft.com/download/1/c/3/1c3b5ab0-e064-4350-a31f-48312180d9b5/st_vid10823-st.pdf)
   - [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](http://download.microsoft.com/download/1/5/e/15eee6d3-f2a8-4441-8cb1-ce8c2ab91c24/windows%2010%20anniversary%20update%20mdf%20security%20target%20-%20public%20\(april%203%202017\).docx)
   - [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](http://download.microsoft.com/download/f/8/c/f8c1c2a4-719c-48ae-942f-9fd3ce5b238f/windows%2010%20au%20and%20server%202016%20gp%20os%20security%20target%20-%20public%20\(december%202%202016\)%20\(clean\).docx)
@@ -52,7 +53,9 @@ These documents describe how to configure Windows to replicate the configuration
 
 **Windows 10, Windows 10 Mobile, Windows Server 2016, Windows Server 2012 R2**
 
-  - [Microsoft Window 10 (Creators Update)](http://download.microsoft.com/download/e/9/7/e97f0c7f-e741-4657-8f79-2c0a7ca928e3/windows%2010%20cu%20gp%20os%20operational%20guidance%20\(jan%208%202017%20-%20public\).pdf)
+  
+  - [Microsoft Windows 10 (Fall Creators Update)](http://download.microsoft.com/download/5/D/2/5D26F473-0FCE-4AC4-9065-6AEC0FE5B693/Windows%2010%201709%20GP%20OS%20Administrative%20Guide.pdf)
+  - [Microsoft Windows 10 (Creators Update)](http://download.microsoft.com/download/e/9/7/e97f0c7f-e741-4657-8f79-2c0a7ca928e3/windows%2010%20cu%20gp%20os%20operational%20guidance%20\(jan%208%202017%20-%20public\).pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](http://download.microsoft.com/download/d/c/4/dc40b5c8-49c2-4587-8a04-ab3b81eb6fc4/st_vid10823-agd.pdf)
   - [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](http://download.microsoft.com/download/4/c/1/4c1f4ea4-2d66-4232-a0f5-925b2bc763bc/windows%2010%20au%20operational%20guidance%20\(16%20mar%202017\)\(clean\).docx)
   - [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](http://download.microsoft.com/download/b/5/2/b52e9081-05c6-4895-91a3-732bfa0eb4da/windows%2010%20au%20and%20server%202016%20gp%20os%20operational%20guidance%20\(final\).docx)
@@ -127,7 +130,8 @@ These documents describe how to configure Windows to replicate the configuration
 
 An Evaluation Technical Report (ETR) is a report submitted to the Common Criteria certification authority for how Windows complies with the claims made in the Security Target. A Certification / Validation Report provides the results of the evaluation by the validation team.
 
-  - [Microsoft Window 10 (Creators Update)](http://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
+  - [Microsoft Windows 10 (Fall Creators Update)](http://download.microsoft.com/download/2/C/2/2C20D013-0610-4047-B2FA-516819DFAE0A/Windows%2010%201709%20GP%20OS%20Certification%20Report.pdf) 
+  - [Microsoft Windows 10 (Creators Update)](http://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](http://download.microsoft.com/download/a/3/3/a336f881-4ac9-4c79-8202-95289f86bb7a/st_vid10823-vr.pdf)
   - [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](http://download.microsoft.com/download/f/2/f/f2f7176e-34f4-4ab0-993c-6606d207bb3c/st_vid10752-vr.pdf)
   - [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](http://download.microsoft.com/download/5/4/8/548cc06e-c671-4502-bebf-20d38e49b731/2016-36-inf-1779.pdf)


### PR DESCRIPTION
This is the first PR from the feature team in Windows Security, after this topic was migrated to docs.microsoft.com from TechNet.  The scope of changes in this commit are small:

-Added links to the Common Criteria downloads for the Win10 1709 / Fall Creators Update certification.
-Fixed typos in the topic, correcting 'Window' > 'Windows' in several spots.
-Adjusted the title to simplify, per discussion within the feature team. 
