### PR TITLE
 PS AppvClientConfiguration: spelling, example 

### DIFF
--- a/mdop/appv-v5/how-to-modify-client-configuration-by-using-powershell.md
+++ b/mdop/appv-v5/how-to-modify-client-configuration-by-using-powershell.md
@@ -24,9 +24,9 @@ Use the following procedure to configure the App-V 5.0 client configuration.
 
     `$config = Get-AppvClientConfiguration`
 
-    `Set-AppcClientConfiguration $config`
+    `Set-AppvClientConfiguration $config`
 
-    `Set-AppcClientConfiguration –Name1 MyConfig –Name2 “xyz”`
+    `Set-AppvClientConfiguration –AutoLoad 2`
 
     **Got a suggestion for App-V**? Add or vote on suggestions [here](http://appv.uservoice.com/forums/280448-microsoft-application-virtualization). **Got an App-V issu**e? Use the [App-V TechNet Forum](https://social.technet.microsoft.com/Forums/home?forum=mdopappv).
 

--- a/mdop/appv-v5/how-to-modify-client-configuration-by-using-powershell51.md
+++ b/mdop/appv-v5/how-to-modify-client-configuration-by-using-powershell51.md
@@ -24,9 +24,9 @@ Use the following procedure to configure the App-V 5.1 client configuration.
 
     `$config = Get-AppvClientConfiguration`
 
-    `Set-AppcClientConfiguration $config`
+    `Set-AppvClientConfiguration $config`
 
-    `Set-AppcClientConfiguration –Name1 MyConfig –Name2 “xyz”`
+    `Set-AppvClientConfiguration –AutoLoad 2`
 
     **Got a suggestion for App-V**? Add or vote on suggestions [here](http://appv.uservoice.com/forums/280448-microsoft-application-virtualization). **Got an App-V issue?** Use the [App-V TechNet Forum](https://social.technet.microsoft.com/Forums/home?forum=mdopappv).
 


### PR DESCRIPTION
This fixes the spelling of AppvClientConfiguration and provides a clearer example.
For both 5.0 and 5.1.