### PR TITLE
Added pre-requisite regarding management by Intune Agents

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -17,6 +17,7 @@ Requirements:
 - AD-joined PC running Windows 10, version 1709
 - Enterprise has MDM service already configured 
 - Enterprise AD must be registered with Azure AD
+- Device should not already be enrolled in Intune using the classic agents (devices manged using agents will fail enrollment with error 0x80180026)
 
 > [!Tip]  
 > [How to configure automatic registration of Windows domain-joined devices with Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/active-directory-conditional-access-automatic-device-registration-setup)


### PR DESCRIPTION
The scheduled task fails with 0x80180026 if the device is already managed by the old style Intune agents.