### PR TITLE
Correct date format to configure

### DIFF
--- a/windows/client-management/mdm/reboot-csp.md
+++ b/windows/client-management/mdm/reboot-csp.md
@@ -36,12 +36,14 @@ The following diagram shows the Reboot configuration service provider management
 <p style="margin-left: 20px">The supported operation is Get.</p>
 
 <a href="" id="schedule-single"></a>**Schedule/Single**  
-<p style="margin-left: 20px">This node will execute a reboot at a scheduled date and time. Setting a null (empty) date will delete the existing schedule. The date and time value is ISO8601, and both the date and time are required. For example: 2015-12-15T07:36:25Z</p>
+<p style="margin-left: 20px">This node will execute a reboot at a scheduled date and time. Setting a null (empty) date will delete the existing schedule. The date and time value is ISO8601, and both the date and time are required.  </br>
+Example to configure: 2018-10-25T18:00:00</p>
 
 <p style="margin-left: 20px">The supported operations are Get, Add, Replace, and Delete.</p>
 
 <a href="" id="schedule-dailyrecurrent"></a>**Schedule/DailyRecurrent**  
-<p style="margin-left: 20px">This node will execute a reboot each day at a scheduled time starting at the configured starting time and date. Setting a null (empty) date will delete the existing schedule. The date and time value is ISO8601, and both the date and time are required. The CSP will return the date time in the following format: 2018-06-29T10:00:00+01:00. </p>
+<p style="margin-left: 20px">This node will execute a reboot each day at a scheduled time starting at the configured starting time and date. Setting a null (empty) date will delete the existing schedule. The date and time value is ISO8601, and both the date and time are required. The CSP will return the date time in the following format: 2018-06-29T10:00:00+01:00.  </br>
+Example to configure: 2018-10-25T18:00:00</p>
 
 <p style="margin-left: 20px">The supported operations are Get, Add, Replace, and Delete.</p>
 


### PR DESCRIPTION
Due to lot of confusion of the given example I corrected it and added to both settings a verified working example with the valid datetime format. Verified in several tenants (kudos Maurice Delay how initially discovered it, Yinghua Zeng for testing and I tested as well).