### PR TITLE
Update for the <path> element

### DIFF
--- a/browsers/internet-explorer/ie11-deploy-guide/enterprise-mode-schema-version-1-guidance.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/enterprise-mode-schema-version-1-guidance.md
@@ -131,8 +131,8 @@ This table includes the elements used by the Enterprise Mode schema.
 <p><b>Example</b>
 <pre class="syntax">
 &lt;emie&gt;
-  &lt;domain exclude="false"&gt;fabrikam.com
-    &lt;path exclude="true"&gt;/products&lt;/path&gt;
+  &lt;domain exclude="true"&gt;fabrikam.com
+    &lt;path exclude="false"&gt;/products&lt;/path&gt;
   &lt;/domain&gt;
 &lt;/emie&gt;</pre><p>
 Where http://fabrikam.com doesn't use IE8 Enterprise Mode, but http://fabrikam.com/products does.</td>


### PR DESCRIPTION
Enterprise Mode sitelist manager outputs:

<emie>
  <domain exclude="true">fabrikam.com
    <path exclude="false">/products</path>
  </domain>
</emie>

The above mentioned version is the only version that works.

Current version of the documentation (that does not work as expected) is the following:

<emie>
  <domain exclude="false">fabrikam.com
    <path exclude="true">/products</path>
  </domain>
</emie>