### PR TITLE
Fix a minor typo

### DIFF
--- a/windows/security/threat-protection/intelligence/worms-malware.md
+++ b/windows/security/threat-protection/intelligence/worms-malware.md
@@ -25,7 +25,7 @@ Jenxcus (also known as Dunihi), Gamarue (also known as Androm), and Bondat have 
 
 * **Gamarue** typically arrives through spam campaigns, exploits, downloaders, social networking sites, and removable drives. When Gamarue infects a device, it becomes a distribution channel for other malware. We’ve seen it distribute other malware such as infostealers, spammers, clickers, downloaders, and rogues.
 
-* **Bondat** typically arrives through fictitious Nullsoft Sciptable Install System (NSIS) Java installers and removable drives. When Bondat infects a system, it gathers information about the machine such as device name, Globally Unique Identifier (GUID), and OS build. It then sends that information to a remote server.
+* **Bondat** typically arrives through fictitious Nullsoft Scriptable Install System (NSIS), Java installers, and removable drives. When Bondat infects a system, it gathers information about the machine such as device name, Globally Unique Identifier (GUID), and OS build. It then sends that information to a remote server.
 
 Both Bondat and Gamarue have clever ways of obscuring themselves to evade detection. By hiding what they are doing, they try to avoid detection by security software.
 


### PR DESCRIPTION
Replaced "Nullsoft Scriptable Install System" with "Nullsoft Sciptable Install System" in the Bondat section, and also put commas in the list to make it consistent with the other lists