### PR TITLE
unlinked manager dock firmware update page

### DIFF
--- a/devices/surface/surface-dock-updater.md
+++ b/devices/surface/surface-dock-updater.md
@@ -112,7 +112,7 @@ Microsoft Surface Dock Updater logs its progress into the Event Log, as shown in
 
 ## Changes and updates
 
-Microsoft periodically updates Surface Dock Updater. To learn more about the application of firmware by Surface Dock Updater, see [Manage Surface Dock firmware updates](https://technet.microsoft.com/itpro/surface/manage-surface-dock-firmware-updates).
+Microsoft periodically updates Surface Dock Updater. <!-- To learn more about the application of firmware by Surface Dock Updater, see [Manage Surface Dock firmware updates](https://technet.microsoft.com/itpro/surface/manage-surface-dock-firmware-updates). -->
 
 >[!Note]
 >Each update to Surface Dock firmware is included in a new version of Surface Dock Updater. To update a Surface Dock to the latest firmware, you must use the latest version of Surface Dock Updater.


### PR DESCRIPTION
Commented the link that points to "manager dock firmware update" page temporarily until we have the new page