### PR TITLE
Update run-detection-test-windows-defender-advanced-threat-protection.md

### DIFF
--- a/windows/security/threat-protection/windows-defender-atp/run-detection-test-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/run-detection-test-windows-defender-advanced-threat-protection.md
@@ -39,7 +39,7 @@ Run the following PowerShell script on a newly onboarded machine to verify that 
 3. At the prompt, copy and run the following command:
 
     ```
-    powershell.exe -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden (New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\test-WDATP-test\invoice.exe');Start-Process 'C:\test-WDATP-test\invoice.exe'
+    powershell.exe -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden $ErrorActionPreference= 'silentlycontinue';(New-Object System.Net.WebClient).DownloadFile('http://127.0.0.1/1.exe', 'C:\\test-WDATP-test\\invoice.exe');Start-Process 'C:\\test-WDATP-test\\invoice.exe'
     ```
 
 The Command Prompt window will close automatically. If successful, the detection test will be marked as completed and a new alert will appear in the portal for the onboarded machine in approximately 10 minutes.


### PR DESCRIPTION
Update detection test command to match the command provided in the Windows Defender ATP console. The command in this documentation does not work, while that command from the ATP console does.

Command copied from the WD ATP console here: [https://securitycenter.windows.com/preferences2/onboarding](https://securitycenter.windows.com/preferences2/onboarding)