### PR TITLE
Fix typos in application-management

### DIFF
--- a/windows/application-management/app-v/appv-application-publishing-and-client-interaction.md
+++ b/windows/application-management/app-v/appv-application-publishing-and-client-interaction.md
@@ -309,7 +309,7 @@ The following table shows local and roaming locations when folder redirection ha
 The current App-V Client VFS driver can't write to network locations, so the App-V Client detects the presence of folder redirection and copies the data on the local drive during publishing and when the virtual environment starts. After the user closes the App-V application and the App-V Client closes the virtual environment, the local storage of the VFS AppData is copied back to the network, enabling roaming to additional machines, where the process will be repeated. Here's what happens during the process:
 
 1. During publishing or virtual environment startup, the App-V Client detects the location of the AppData directory.
-2. If the roaming AppData path is local or ino AppData\\Roaming location is mapped, nothing happens.
+2. If the roaming AppData path is local or no AppData\\Roaming location is mapped, nothing happens.
 3. If the roaming AppData path is not local, the VFS AppData directory is mapped to the local AppData directory.
 
 This process solves the problem of a non-local %AppData% that is not supported by the App-V Client VFS driver. However, the data stored in this new location is not roamed with folder redirection. All changes during the running of the application happen to the local AppData location and must be copied to the redirected location. The process does the following things:
@@ -399,7 +399,7 @@ The process then configures the client for package or connection group additions
 
     7. Create the **Registry.dat** file from the package store to **%ProgramData%\\Microsoft\\AppV\\Client\\VReg\\{VersionGUID}.dat**.
 
-    8. Register the package with the App-V Kernal Mode Driver at **HKLM\\Microsoft\\Software\\AppV\\MAV**.
+    8. Register the package with the App-V Kernel Mode Driver at **HKLM\\Microsoft\\Software\\AppV\\MAV**.
 
     9. Invoke scripting from the **AppxManifest.xml** or **DeploymentConfig.xml** file for Package Add timing.
 

--- a/windows/application-management/app-v/appv-auto-batch-updating.md
+++ b/windows/application-management/app-v/appv-auto-batch-updating.md
@@ -80,7 +80,7 @@ Updating multiple apps at the same time requires that you create a **ConfigFile*
 
 ## Update multiple apps with the App-V Sequencer interface
 
-Updating multipe apps at the same time requires that you create a **ConfigFile** to collect all of the info related to each round of updating. This file is then used by the App-V Sequencer interface after creating a "clean" checkpoint on your VM.
+Updating multiple apps at the same time requires that you create a **ConfigFile** to collect all of the info related to each round of updating. This file is then used by the App-V Sequencer interface after creating a "clean" checkpoint on your VM.
 
 ### Create your ConfigFile for use by the App-V Sequencer interface
 
@@ -93,7 +93,7 @@ Updating multipe apps at the same time requires that you create a **ConfigFile**
     - ```<Installer>```. The file name for the app executable. This will typically be an .exe or .msi file.
     - ```<Package>```. The file path to the location of your App-V packages. These packages were created when you sequenced your apps.
     - ```<TimeoutInMinutes>```. The maximum amount of time, in minutes, the cmdlet should wait for updating to complete. You can enter a different value for each app, based on the size and complexity of the app itself.
-    - ```<Cmdlet>```. Determines whether the sequencer uses the cmdlet or the App-V Sequencer interface. **True** tells the sequencer to usea cmdlet-based updating, while **False** tells the sequencer to use the App-V Sequencer interface. You can use both the cmdlet and the interface together in the same ConfigFile, for different apps.
+    - ```<Cmdlet>```. Determines whether the sequencer uses the cmdlet or the App-V Sequencer interface. **True** tells the sequencer to use cmdlet-based updating, while **False** tells the sequencer to use the App-V Sequencer interface. You can use both the cmdlet and the interface together in the same ConfigFile, for different apps.
     - ```<Enabled>```. Indicates whether the app should be sequenced. **True** includes the app, while **False** ignores it. You can include as many apps as you want in the batch file, but optionally enable only a few of them.
 
         **Example:**

--- a/windows/application-management/app-v/appv-capacity-planning.md
+++ b/windows/application-management/app-v/appv-capacity-planning.md
@@ -182,7 +182,7 @@ Discounting scaling and fault-tolerance requirements, the minimum number of serv
 
 Ignoring scaling requirements, the minimum number of servers that a fault-tolerant implementation needs to function is four. The management server and Microsoft SQL Server roles support placement in fault-tolerant configurations. The management server service can be combined with any of the roles, but remains a single point of failure.
 
-Although there are many fault-tolerance strategies and technologies you can use, not all are applicable to a given service. Additionally, if App-V roles are combined, the resulting incompatabilities could cause certain fault-tolerance options to stop working.
+Although there are many fault-tolerance strategies and technologies you can use, not all are applicable to a given service. Additionally, if App-V roles are combined, the resulting incompatibilities could cause certain fault-tolerance options to stop working.
 
 ## Have a suggestion for App-V?
 

--- a/windows/application-management/app-v/appv-client-configuration-settings.md
+++ b/windows/application-management/app-v/appv-client-configuration-settings.md
@@ -14,7 +14,7 @@ ms.date: 04/18/2018
 
 The Microsoft Application Virtualization (App-V) client stores its configuration in the registry. Understanding how the register's format for data works can help you better understand the client, as you can configure many client actions by changing registry entries. This topic lists the App-V client configuration settings and explains their uses. You can use Windows PowerShell to modify the client configuration settings. For more information about using Windows PowerShell and App-V see [Administering App-V by using Windows PowerShell](appv-administering-appv-with-powershell.md).
 
-You can use Group Policy to configure App-V client settings by navigating to the **Group Policy managment console** at **Computer Configuration** > **Administrative Templates** > **System** > **App-V**.
+You can use Group Policy to configure App-V client settings by navigating to the **Group Policy management console** at **Computer Configuration** > **Administrative Templates** > **System** > **App-V**.
 
 ## App-V Client Configuration Settings: Windows PowerShell
 

--- a/windows/application-management/app-v/appv-connection-group-file.md
+++ b/windows/application-management/app-v/appv-connection-group-file.md
@@ -95,7 +95,7 @@ You can use the connection group file to configure each connection group by usin
 
 The priority field is required when a running virtual application initiates from a native application request, such as Microsoft Windows Explorer. The App-V client uses the priority to determine which connection group virtual environment the application should run in. This situation occurs if a virtual application is part of multiple connection groups.
 
-If a virtual application is opened using another virtual application, the client will use the orignal virtual application's virtual environment. The priority field is not used in this case.
+If a virtual application is opened using another virtual application, the client will use the original virtual application's virtual environment. The priority field is not used in this case.
 
 The following is an example of priority configuration:
 

--- a/windows/application-management/app-v/appv-create-a-connection-group-with-user-published-and-globally-published-packages.md
+++ b/windows/application-management/app-v/appv-create-a-connection-group-with-user-published-and-globally-published-packages.md
@@ -24,7 +24,7 @@ Here are some important things to know before you get started:
 - If you add user-published packages in globally entitled connection groups, the connection group will fail.
 - Track the connection groups where you've used a non-optional package before removing it with the **Unpublish-AppvClientPackage <</span>package> -global** cmdlet.
       
-    In situations where you have a gobally published package that's listed as non-optional in a user-published connection group that also appears in other packages, running **Unpublish-AppvClientPackage <</span>package> -global** cmdlet can unpublish the package from every connection group containing that package. Tracking connection groups can help you avoid unintentionally unpublishing non-optional packages.
+    In situations where you have a globally published package that's listed as non-optional in a user-published connection group that also appears in other packages, running **Unpublish-AppvClientPackage <</span>package> -global** cmdlet can unpublish the package from every connection group containing that package. Tracking connection groups can help you avoid unintentionally unpublishing non-optional packages.
 
 ## How to use Windows PowerShell cmdlets to create user-entitled connection groups
 

--- a/windows/application-management/app-v/appv-deploy-the-appv-server-with-a-script.md
+++ b/windows/application-management/app-v/appv-deploy-the-appv-server-with-a-script.md
@@ -413,12 +413,11 @@ To use a custom instance of Microsoft SQL Server, use these parameters:
 ### Example for using a custom instance of Microsoft SQL Server for installing the Reporting database on a different computer than the Reporting server
 
 ```SQL
-Using a custom instance of Microsoft SQL Server example:<br>
-/appv_server_setup.exe /QUIET<br>
-/DB_PREDEPLOY_REPORTING<br>
-/REPORTING_DB_CUSTOM_SQLINSTANCE="SqlInstanceName"<br>
-/REPORTING_DB_NAME="AppVReporting"<br>
-/REPORTING_REMOTE_SERVER_MACHINE_ACCOUNT="Domain\MachineAccount"<br>
+/appv_server_setup.exe /QUIET
+/DB_PREDEPLOY_REPORTING
+/REPORTING_DB_CUSTOM_SQLINSTANCE="SqlInstanceName"
+/REPORTING_DB_NAME="AppVReporting"
+/REPORTING_REMOTE_SERVER_MACHINE_ACCOUNT="Domain\MachineAccount"
 /REPORTING_SERVER_INSTALL_ADMIN_ACCOUNT="Domain\InstallAdminAccount"
 ```
 

--- a/windows/application-management/app-v/appv-deploying-microsoft-office-2013-with-appv.md
+++ b/windows/application-management/app-v/appv-deploying-microsoft-office-2013-with-appv.md
@@ -255,7 +255,7 @@ Deploy the App-V package for Office 2013 by using the same methods you use for a
 
 ### How to publish an Office package
 
-Run the following command to publish an Office package globally, wtih the bracketed value replaced by the path to the App-V package:
+Run the following command to publish an Office package globally, with the bracketed value replaced by the path to the App-V package:
 
 ```PowerShell
 Add-AppvClientPackage <Path_to_AppV_Package> | Publish-AppvClientPackage –global

--- a/windows/application-management/app-v/appv-deployment-checklist.md
+++ b/windows/application-management/app-v/appv-deployment-checklist.md
@@ -12,7 +12,7 @@ ms.date: 04/18/2018
 
 >Applies to: Windows 10, version 1607
 
-This checklist outlines the recommended steps and items to consider when deploying App-V features. Use it to organize your priorites while you deploy App-V. You can copy this checklist into a spreadsheet program and customize it for your use.
+This checklist outlines the recommended steps and items to consider when deploying App-V features. Use it to organize your priorities while you deploy App-V. You can copy this checklist into a spreadsheet program and customize it for your use.
 
 |Status|Task|References|Notes|
 |---|---|---|---|

--- a/windows/application-management/app-v/appv-dynamic-configuration.md
+++ b/windows/application-management/app-v/appv-dynamic-configuration.md
@@ -186,7 +186,7 @@ All shortcuts in the manifest will be ignored and no shortcuts will be integrate
     </Shortcuts>
 ```
 
-**File Type Associations**: Associates file types with programs to open by default as well as setup the context menu. (MIME types can also be set up with this susbsystem). The following is an example of a FileType association:
+**File Type Associations**: Associates file types with programs to open by default as well as setup the context menu. (MIME types can also be set up with this subsystem). The following is an example of a FileType association:
 
 ```xml
     <FileTypeAssociations Enabled="true">
@@ -252,7 +252,7 @@ All shortcuts in the manifest will be ignored and no shortcuts will be integrate
       </FileTypeAssociations>
 ```
 
-**URL Protocols**: This controls the URL Protocols integrated into the local registry of the client machine. The following example illustrates the “mailto:” ptrotocol.
+**URL Protocols**: This controls the URL Protocols integrated into the local registry of the client machine. The following example illustrates the “mailto:” protocol.
 
 ```xml
     <URLProtocols Enabled="true">

--- a/windows/application-management/app-v/appv-performance-guidance.md
+++ b/windows/application-management/app-v/appv-performance-guidance.md
@@ -587,7 +587,7 @@ If, during sequencer monitoring, an SxS Assembly (such as a VC++ Runtime) is ins
 
 **Client Side**:
 
-When publishing a virtual application package, the App-V Client will detect if a required SxS dependency is already installed. If the dependency is unavailable on the computer and it is included in the package, a traditional Windows Insataller (.**msi**) installation of the SxS assembly will be initiated. As previously documented, simply install the dependency on the computer running the client to ensure that the Windows Installer (.msi) installation will not occur.
+When publishing a virtual application package, the App-V Client will detect if a required SxS dependency is already installed. If the dependency is unavailable on the computer and it is included in the package, a traditional Windows Installer (.**msi**) installation of the SxS assembly will be initiated. As previously documented, simply install the dependency on the computer running the client to ensure that the Windows Installer (.msi) installation will not occur.
 
 <table>
 <colgroup>
@@ -618,7 +618,7 @@ When publishing a virtual application package, the App-V Client will detect if a
 
  
 
-### Disabling a Dynamic Configuration by using Windows Powershell
+### Disabling a Dynamic Configuration by using Windows PowerShell
 
 -   For already published packages, you can use `Set-AppVClientPackage –Name Myapp –Path c:\Packages\Apps\MyApp.appv` without
 
@@ -725,7 +725,7 @@ The following terms are used when describing concepts and actions related to App
 
     -   From the point that users initiate a log-in to when they are able to manipulate the desktop.
 
-    -   From the point where the desktop can be interacted with to the point a publishing refresh begins (in Windows PowerShell terms, sync) when using the App-V full server infrastructure. In standalone instances, it is when the **Add-AppVClientPackage** and **Publish-AppVClientPackage** Windows Powershell commands are initiated.
+    -   From the point where the desktop can be interacted with to the point a publishing refresh begins (in Windows PowerShell terms, sync) when using the App-V full server infrastructure. In standalone instances, it is when the **Add-AppVClientPackage** and **Publish-AppVClientPackage** Windows PowerShell commands are initiated.
 
     -   From start to completion of the publishing refresh. In standalone instances, this is the first to last virtual application published.
 

--- a/windows/application-management/app-v/appv-planning-folder-redirection-with-appv.md
+++ b/windows/application-management/app-v/appv-planning-folder-redirection-with-appv.md
@@ -37,7 +37,7 @@ For more information, see [Application publishing and client interaction](appv-a
 
 ## Unsupported scenarios for App-V folder redirection
 
-The following scenatios aren't supported by App-V:
+The following scenarios aren't supported by App-V:
 
 * Configuring %LocalAppData% as a network drive.
 * Redirecting the Start menu to a single folder for multiple users.

--- a/windows/application-management/app-v/appv-planning-for-high-availability-with-appv.md
+++ b/windows/application-management/app-v/appv-planning-for-high-availability-with-appv.md
@@ -77,7 +77,7 @@ The connection string on the management server can be modified to include ```fai
 Use the following steps to modify the connection string to include ```failover partner = <server2>```:
 
 >[!IMPORTANT]
->This process involves changing the Windows registry with Registry Editor. If you change the Windows registry incorrectly, you can cause serious problems that might require you to reinstall Windows. Always make a backup copy of the registry files (**System.dat** and **User.dat**) before chagning the registry. Microsoft can't guarantee that problems caused by changing the registry can be resolved, so change the registry at your own risk.
+>This process involves changing the Windows registry with Registry Editor. If you change the Windows registry incorrectly, you can cause serious problems that might require you to reinstall Windows. Always make a backup copy of the registry files (**System.dat** and **User.dat**) before changing the registry. Microsoft can't guarantee that problems caused by changing the registry can be resolved, so change the registry at your own risk.
 
 1. Log in to the management server and open **regedit**.
 2. Navigate to **HKEY\_LOCAL\_MACHINE** \\ **Software** \\ **Microsoft** \\ **AppV** \\ **Server** \\ **ManagementService**.

--- a/windows/application-management/app-v/appv-planning-for-sequencer-and-client-deployment.md
+++ b/windows/application-management/app-v/appv-planning-for-sequencer-and-client-deployment.md
@@ -30,7 +30,7 @@ Ideally, you should install the sequencer on a computer running as a virtual mac
 3. Take a “snapshot” of the environment.
 
 >[!IMPORTANT]
->Your corporate security team should review and approve the sequencing process plan before implementing it. For security reasons, it's a good idea to keep sequencer operations in a lab separate from the production environment. The sequencing computers must be capapble of connecting to the corporate network to copy finished packages to the production servers. However, because the sequencing computers are typically operated without antivirus protection, they shouldn't remail on the corporate network unprotected. You can protect your sequencing computers by operating them on an isolated network, behind a firewall, or by using virtual machines on an isolated virtual network. Make sure your solution follows your company's corporate security policies.
+>Your corporate security team should review and approve the sequencing process plan before implementing it. For security reasons, it's a good idea to keep sequencer operations in a lab separate from the production environment. The sequencing computers must be capable of connecting to the corporate network to copy finished packages to the production servers. However, because the sequencing computers are typically operated without antivirus protection, they shouldn't remain on the corporate network unprotected. You can protect your sequencing computers by operating them on an isolated network, behind a firewall, or by using virtual machines on an isolated virtual network. Make sure your solution follows your company's corporate security policies.
 
 ## Planning for App-V client deployment
 

--- a/windows/application-management/app-v/appv-planning-for-using-appv-with-office.md
+++ b/windows/application-management/app-v/appv-planning-for-using-appv-with-office.md
@@ -26,7 +26,7 @@ You can use the App-V Sequencer to create plug-in packages for language packs, l
 For a list of supported Office products, see [Microsoft Office Product IDs that App-V supports](https://support.microsoft.com/help/2842297/product-ids-that-are-supported-by-the-office-deployment-tool-for-click).
 
 >[!NOTE]
->You must use the Office Deployment Tool instead of the App-V Sequencer to create App-V packages for Office 365 ProPlus. App-V does not support package creation for volume-licensed versions of Office Professional Plus or Office Standard. Support for the [Office 2013 version of Office 365 ended in Februrary 2017](https://support.microsoft.com/kb/3199744).
+>You must use the Office Deployment Tool instead of the App-V Sequencer to create App-V packages for Office 365 ProPlus. App-V does not support package creation for volume-licensed versions of Office Professional Plus or Office Standard. Support for the [Office 2013 version of Office 365 ended in February 2017](https://support.microsoft.com/kb/3199744).
 
 ## Using App-V with coexisting versions of Office
 
@@ -90,7 +90,7 @@ To bypass the auto-registration operation for native Word 2010, follow these ste
 
     * In Windows 8.1 or Windows 10, enter **regedit**, select **Enter** on the Start page, then select the Enter key.
 
-    If you're prompted for an administrator password, enter the password. If you're propmted for a confirmation, select **Continue**.
+    If you're prompted for an administrator password, enter the password. If you're prompted for a confirmation, select **Continue**.
 3. Locate and then select the following registry subkey:
 
     ``` syntax

--- a/windows/application-management/app-v/appv-security-considerations.md
+++ b/windows/application-management/app-v/appv-security-considerations.md
@@ -60,7 +60,7 @@ Consider the following additional information:
 
 The following will help you plan how to ensure that virtualized packages are secure.
 
-* If an application installer applies an access control list (ACL) to a file or directory, then that ACL is not persisted in the package. If thje file or directory is modified by a user when the package is deployed, the modified file or directory will either inherit the ACL in the **%userprofile%** or inherit the ACL of the target computer’s directory. The former occurs if the file or directory does not exist in a virtual file system location; the latter occurs if the file or directory exists in a virtual file system location, such as **%windir%**.
+* If an application installer applies an access control list (ACL) to a file or directory, then that ACL is not persisted in the package. If the file or directory is modified by a user when the package is deployed, the modified file or directory will either inherit the ACL in the **%userprofile%** or inherit the ACL of the target computer’s directory. The former occurs if the file or directory does not exist in a virtual file system location; the latter occurs if the file or directory exists in a virtual file system location, such as **%windir%**.
 
 ## App-V log files
 

--- a/windows/application-management/app-v/appv-viewing-appv-server-publishing-metadata.md
+++ b/windows/application-management/app-v/appv-viewing-appv-server-publishing-metadata.md
@@ -84,7 +84,7 @@ In your publishing metadata query, enter the string values that correspond to th
 <tr class="header">
 <th align="left">Operating system</th>
 <th align="left">Architecture</th>
-<th align="left">Operating string string value</th>
+<th align="left">String value</th>
 </tr>
 </thead>
 <tbody>

--- a/windows/application-management/deploy-app-upgrades-windows-10-mobile.md
+++ b/windows/application-management/deploy-app-upgrades-windows-10-mobile.md
@@ -20,7 +20,7 @@ There are two steps to deploy an app upgrade:
 1. [Define the supersedence](#define-app-supersedence) - this lets Configuration Manager know that the old version should be replaced by the new version.
 2. [Deploy the upgrade](#deploy-the-app-upgrade) to your users.
 
-The following steps walk you through the upgrade deployment process - we have an upgraded version of the Walking Scorer app (moving from version 12.23.2.0 to 12.23.3.0). Becasuse we previously used Configuration Manager to deploy the existing version, we'll use it now to upgrade the app. 
+The following steps walk you through the upgrade deployment process - we have an upgraded version of the Walking Scorer app (moving from version 12.23.2.0 to 12.23.3.0). Because we previously used Configuration Manager to deploy the existing version, we'll use it now to upgrade the app. 
 
 Before you can deploy the upgrade, make sure you import the new version of the app and distribute it to your manage.microsoft.com distribution point.
 
@@ -42,7 +42,7 @@ Before you can deploy the upgrade, make sure you import the new version of the a
    > Do **NOT** select **Uninstall**. This tells Configuration Manager to uninstall the old version, but it does **NOT** then install the new version.
 
 6. Click **OK**.
-7. If you have other versions of the same app, repeate steps 4-6 for each version. Click **OK** when you're done.
+7. If you have other versions of the same app, repeat steps 4-6 for each version. Click **OK** when you're done.
 
 > [!NOTE]
 > Need to remove a supersedence? (Maybe the new version turned out to be flaky and you don't want users to get it yet.) On the **Supersedence** tab for the *new* version of the app, double-click the older version in the list of supersedence rules, and then change the **New Deployment Type** to **Do not replace**.

--- a/windows/application-management/msix-app-packaging-tool.md
+++ b/windows/application-management/msix-app-packaging-tool.md
@@ -15,7 +15,7 @@ ms.date: 12/03/2018
 
 MSIX is a packaging format built to be safe, secure and reliable, based on a combination of .msi, .appx, App-V and ClickOnce installation technologies. You can [use the MSIX packaging tool](https://docs.microsoft.com/windows/msix/packaging-tool/create-app-package-msi-vm) to repackage your existing Win32 applications to the MSIX format. 
 
-You can either run your installer interactivly (through the UI) or create a package from the command line. Either way, you can convert an application without having the source code. Then, you can make your app available through the Microsoft Store.
+You can either run your installer interactively (through the UI) or create a package from the command line. Either way, you can convert an application without having the source code. Then, you can make your app available through the Microsoft Store.
 
 - [Package your favorite application installer](https://docs.microsoft.com/windows/msix/packaging-tool/create-app-package-msi-vm) interactively (msi, exe, App-V 5.x and ClickOnce) in MSIX format. 
 - Create a [modification package](https://docs.microsoft.com/windows/msix/packaging-tool/package-editor) to update an existing MSIX package.

--- a/windows/application-management/svchost-service-refactoring.md
+++ b/windows/application-management/svchost-service-refactoring.md
@@ -68,7 +68,7 @@ For example, this is the registry key configuration for BFE:
 
 ## Memory footprint
 
-Be aware that separating services increases the total number of SvcHost instances, which increases memory utlization. (Service grouping provided a modest reduction to the overall resource footprint of the services involved.) 
+Be aware that separating services increases the total number of SvcHost instances, which increases memory utilization. (Service grouping provided a modest reduction to the overall resource footprint of the services involved.) 
 
 Consider the following:
 


### PR DESCRIPTION
Fixes all typos I could find in `/windows/application-management` and `/windows/application-management/app-v`.

---

The use of `SQL`-flavoured code blocks in [appv-deploy-the-appv-server-with-a-script.md](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/application-management/app-v/appv-deploy-the-appv-server-with-a-script.md) struck me as odd, but I left them as-is and merely removed the `<br>` tags and first sentence from the [last one](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/application-management/app-v/appv-deploy-the-appv-server-with-a-script.md#example-for-using-a-custom-instance-of-microsoft-sql-server-for-installing-the-reporting-database-on-a-different-computer-than-the-reporting-server), which I am certain should not be there (and is not consistent with the rest of the document).