### PR TITLE
Incorrect information about deferral on Win10 1703

### DIFF
--- a/windows/deployment/update/waas-configure-wufb.md
+++ b/windows/deployment/update/waas-configure-wufb.md
@@ -63,10 +63,6 @@ Starting with Windows 10, version 1703, users can configure the branch readiness
 
 After you configure the servicing branch (Windows Insider Preview or Semi-Annual Channel), you can then define if, and for how long, you would like to defer receiving Feature Updates following their availability from Microsoft on Windows Update. You can defer receiving these Feature Updates for a period of up to 365 days from their release by setting the `DeferFeatureUpdatesPeriodinDays` value.  
 
->[!IMPORTANT]
->
->You can only defer up to 180 days on devices running Windows 10, version 1703.
-
 For example, a device on the Semi-Annual Channel with `DeferFeatureUpdatesPeriodinDays=30` will not install a feature update that is first publicly available on Windows Update in September until 30 days later, in October.
 
 


### PR DESCRIPTION
Hi, this was tested internally by multiple engineers and for 1703 the max deferral is 365 days, the MDM CSP documentation is correct:
 Important
The default maximum number of days to defer an update has been increased from 180 (Windows 10, version 1607) to 365 in Windows 10, version 1703.
https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-csp-update#update-deferfeatureupdatesperiodindays

Thank you,
Andrei