### PR TITLE
Fixed obvious technical errors

### DIFF
--- a/windows/deployment/update/fod-and-lang-packs.md
+++ b/windows/deployment/update/fod-and-lang-packs.md
@@ -16,7 +16,7 @@ ms.date: 10/18/2018
 
 As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host [Features on Demand](https://docs.microsoft.com/windows-hardware/manufacture/desktop/features-on-demand-v2--capabilities) (FOD) and language packs for Windows 10 clients locally. Instead, you can enforce a Group Policy setting that tells the clients to pull them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, language packs can only be installed from Windows Update.
  
-For Windows domain environments running WSUS or SCCM, change the "**Specify settings for optional component installation and component repair**" policy to enable downloading language and FOD packs from Windows Update. This setting is located in `Computer Configuration\Administrative Templates\System` in the Group Policy Editor.
+For Windows domain environments running WSUS or SCCM, change the **Specify settings for optional component installation and component repair** policy to enable downloading language and FOD packs from Windows Update. This setting is located in `Computer Configuration\Administrative Templates\System` in the Group Policy Editor.
 
 Changing this policy does not affect how other updates are distributed. They continue to come from WSUS or SCCM as you have scheduled them.
 

--- a/windows/deployment/update/fod-and-lang-packs.md
+++ b/windows/deployment/update/fod-and-lang-packs.md
@@ -1,6 +1,6 @@
 ---
-title: Windows 10 - How to make FoDs and language packs available when you're using WSUS/SCCM
-description: Learn how to make FoDs and language packs available for updates when you're using WSUS/SCCM.
+title: Windows 10 - How to make FoD and language packs available when you're using WSUS/SCCM
+description: Learn how to make FoD and language packs available when you're using WSUS/SCCM
 ms.prod: w10
 ms.mktglfcycl: manage
 ms.sitesec: library
@@ -14,10 +14,10 @@ ms.date: 10/18/2018
 
 > Applies to: Windows 10
 
-As of Windows 10, version 1709, you can't use Windows Server Update Services (WSUS) to host [Features on Demand](https://docs.microsoft.com/windows-hardware/manufacture/desktop/features-on-demand-v2--capabilities) and language packs for Windows 10 clients. Instead, you can pull them directly from Windows Update - you just need to change a Group Policy setting that lets clients download these directly from Windows Update. You can also host Features on Demand and language packs on a network share, but starting with Windows 10, version 1809, language packs can only be installed from Windows Update.
+As of Windows 10 version 1709, you cannot use Windows Server Update Services (WSUS) to host [Features on Demand](https://docs.microsoft.com/windows-hardware/manufacture/desktop/features-on-demand-v2--capabilities) (FOD) and language packs for Windows 10 clients locally. Instead, you can enforce a Group Policy setting that tells the clients to pull them directly from Windows Update. You can also host FOD and language packs on a network share, but starting with Windows 10 version 1809, language packs can only be installed from Windows Update.
  
-For Active Directory and Group Policy environments running in a WSUS\SCCM environment change the **Specify settings for optional component installation and component repair** policy to enable downloading Features on Demand directly from Windows Update or a local share. This setting is located in Computer Configuration\Administrative Templates\System in the Group Policy Editor.
- 
-Changing this policy only enables Features on Demand and language pack downloads from Windows Update - it doesn't affect how clients get feature and quality updates. Feature and quality updates will continue to come directly from WSUS\SCCM. It also doesn't affect the schedule for your clients to receive updates.
+For Windows domain environments running WSUS or SCCM, change the "**Specify settings for optional component installation and component repair**" policy to enable downloading language and FOD packs from Windows Update. This setting is located in `Computer Configuration\Administrative Templates\System` in the Group Policy Editor.
 
-Learn about other client management options, including using Group Policy and ADMX, in [Manage clients in Windows 10](https://docs.microsoft.com/windows/client-management/).
+Changing this policy does not affect how other updates are distributed. They continue to come from WSUS or SCCM as you have scheduled them.
+
+Learn about other client management options, including using Group Policy and administrative templates, in [Manage clients in Windows 10](https://docs.microsoft.com/windows/client-management/).


### PR DESCRIPTION
The article had some errors, including incorrect use of "\" (backslash) instead of "/" (slash), incorrect use of the word "environment", but most importantly, its incorrect use of the "feature and quality updates" phrase defeated the purpose of an entire paragraph. You see, the paragraph was trying to reassure the reader that WSUS and SCCM continue to work as intended, but these two distribute much more than just quality and feature updates. They distribute device drivers, definition updates, security updates, feature packs (e.g. .NET Framework) and service packs. The "feature and quality updates" phrase unnecessarily restricted the scope of reassurance. Wordiness is bad.