### PR TITLE
Fix incorrect information about PIN complexity policy

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-cert-trust-policy-settings.md
+++ b/windows/security/identity-protection/hello-for-business/hello-cert-trust-policy-settings.md
@@ -126,7 +126,7 @@ Windows 10 provides eight PIN Complexity Group Policy settings that give you gra
 * Require special characters
 * Require uppercase letters
 
-In the Windows 10, version 1703, the PIN complexity Group Policy settings have moved to remove misunderstanding that PIN complexity policy settings were exclusive to Windows Hello for Business. The new location of these Group Policy settings is under Administrative Templates\System\PIN Complexity under both the Computer and User Configuration nodes of the Group Policy editor.
+In the Windows 10, version 1703, the PIN complexity Group Policy settings have moved to remove misunderstanding that PIN complexity policy settings were exclusive to Windows Hello for Business. The new location of these Group Policy settings is under Computer Configuration\Administrative Templates\System\PIN Complexity in the Group Policy editor.
 
 ## Review
 


### PR DESCRIPTION
PIN complexity group policy is only supported in Computer Configuration, not User Configuration.