### PR TITLE
Update policy-csp-browser.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-browser.md
+++ b/windows/client-management/mdm/policy-csp-browser.md
@@ -2785,7 +2785,7 @@ ADMX Info:
 Supported values:
 
 - Blank (default) - Load the pages specified in App settings as the default Start pages.
-- String - Enter the URLs of the pages you want to load as the Start pages, separating each page using angle brackets:<p><p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<support.contoso.com\>&nbsp;\<support.microsoft.com\>
+- String - Enter the URLs of the pages you want to load as the Start pages, separating each page using angle brackets and comma:<p><p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<support.contoso.com\>&comma;\<support.microsoft.com\>
 
 <!--/SupportedValues-->
 <!--/Policy-->


### PR DESCRIPTION
If you specify multiple URLs in Browser/HomePages policy, each URL should be separated by comma, not space. I've verified this behavior with Windows 10 RS5 + PPKG.