### PR TITLE
Security/Information Protection: insert missing word "identifies"

### DIFF
--- a/windows/security/information-protection/encrypted-hard-drive.md
+++ b/windows/security/information-protection/encrypted-hard-drive.md
@@ -62,7 +62,7 @@ For Encrypted Hard Drives used as **startup drives**:
  
 ## Technical overview
 
-Rapid encryption in BitLocker directly addresses the security needs of enterprises while offering significantly improved performance. In versions of Windows earlier than Windows Server 2012, BitLocker required a two-step process to complete read/write requests. In Windows Server 2012, Windows 8, or later, Encrypted Hard Drives offload the cryptographic operations to the drive controller for much greater efficiency. When the operating system an Encrypted Hard Drive, it activates the security mode. This activation lets the drive controller generate a media key for every volume that the host computer creates. This media key, which is never exposed outside the disk, is used to rapidly encrypt or decrypt every byte of data that is sent or received from the disk.
+Rapid encryption in BitLocker directly addresses the security needs of enterprises while offering significantly improved performance. In versions of Windows earlier than Windows Server 2012, BitLocker required a two-step process to complete read/write requests. In Windows Server 2012, Windows 8, or later, Encrypted Hard Drives offload the cryptographic operations to the drive controller for much greater efficiency. When the operating system identifies an Encrypted Hard Drive, it activates the security mode. This activation lets the drive controller generate a media key for every volume that the host computer creates. This media key, which is never exposed outside the disk, is used to rapidly encrypt or decrypt every byte of data that is sent or received from the disk.
 
 ## Configuring Encrypted Hard Drives as Startup drives
 


### PR DESCRIPTION
**Originating source file:**
https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/information-protection/encrypted-hard-drive.md

**Current issue:**
A word is missing in the sentence "When the operating system an Encrypted Hard Drive, it activates the security mode."

**Expected behaviour:**
There should be a verb in the sentence to tell the reader what is happening in this process.

**Suggested changes:**

- insert the missing word "identifies" in the sentence
  "When the operating system an Encrypted Hard Drive, it activates the security mode."

Closes #2710

**Based on current doc commit rev. hash:** https://github.com/MicrosoftDocs/windows-itpro-docs/commit/af837ebfe70f11762d0a3ac2cfee2f1adef92f76

**Todo/Notes:**
If the suggested word is incorrect, please suggest the correct word to insert, so this Pull Request can be completed for merging.