### PR TITLE
Update bitlocker-how-to-enable-network-unlock.md

### DIFF
--- a/windows/security/information-protection/bitlocker/bitlocker-how-to-enable-network-unlock.md
+++ b/windows/security/information-protection/bitlocker/bitlocker-how-to-enable-network-unlock.md
@@ -7,7 +7,7 @@ ms.mktglfcycl: deploy
 ms.sitesec: library
 ms.pagetype: security
 author: brianlic-msft
-ms.date: 06/18/2018
+ms.date: 02/20/2019
 ---
 
 # BitLocker: How to enable Network Unlock
@@ -39,6 +39,7 @@ Network Unlock must meet mandatory hardware and software requirements before the
 
 -   You must be running at least Windows 8 or Windows Server 2012.
 -   Any supported operating system with UEFI DHCP drivers can be Network Unlock clients.
+-   Network Unlock clients must have a TPM chip and at least one TPM protector.
 -   A server running the Windows Deployment Services (WDS) role on any supported server operating system.
 -   BitLocker Network Unlock optional feature installed on any supported server operating system.
 -   A DHCP server, separate from the WDS server.
@@ -83,7 +84,7 @@ The server side configuration to enable Network Unlock also requires provisionin
 
 The following steps allow an administrator to configure Network Unlock in a domain where the Domain Functional Level is at least Windows Server 2012.
 
-### Install the WDS Server role
+### <a href="" id="bkmk-installwdsrole"/>Install the WDS Server role
 
 The BitLocker Network Unlock feature will install the WDS role if it is not already installed. If you want to install it separately before you install BitLocker Network Unlock you can use Server Manager or Windows PowerShell. To install the role using Server Manager, select the **Windows Deployment Services** role in Server Manager.
 
@@ -95,7 +96,7 @@ Install-WindowsFeature WDS-Deployment
 
 You must configure the WDS server so that it can communicate with DHCP (and optionally Active Directory Doman Services) and the client computer. You can do using the WDS management tool, wdsmgmt.msc, which starts the Windows Deployment Services Configuration Wizard.
 
-### Confirm the WDS Service is running
+### <a href="" id="bkmk-confirmwdsrunning"/>Confirm the WDS Service is running
 
 To confirm the WDS service is running, use the Services Management Console or Windows PowerShell. To confirm the service is running in Services Management Console, open the console using **services.msc** and check the status of the Windows Deployment Services service.
 
@@ -104,7 +105,7 @@ To confirm the service is running using Windows PowerShell, use the following co
 ``` syntax
 Get-Service WDSServer
 ```
-### Install the Network Unlock feature
+### <a href="" id="bkmk-installnufeature"/>Install the Network Unlock feature
 
 To install the Network Unlock feature, use Server Manager or Windows PowerShell. To install the feature using Server Manager, select the **BitLocker Network Unlock** feature in the Server Manager console.
 
@@ -113,7 +114,7 @@ To install the feature using Windows PowerShell, use the following command:
 ``` syntax
 Install-WindowsFeature BitLocker-NetworkUnlock
 ```
-### Create the certificate template for Network Unlock
+### <a href="" id="bkmk-createcerttmpl"/>Create the certificate template for Network Unlock
 
 A properly configured Active Directory Services Certification Authority can use this certificate template to create and issue Network Unlock certificates.
 
@@ -143,7 +144,7 @@ To add the Network Unlock template to the Certification Authority, open the Cert
 
 After adding the Network Unlock template to the Certification Authority, this certificate can be used to configure BitLocker Network Unlock.
 
-### Create the Network Unlock certificate
+### <a href="" id="bkmk-createcert"/>Create the Network Unlock certificate
 
 Network Unlock can use imported certificates from an existing PKI infrastructure, or you can use a self-signed certificate.
 
@@ -214,7 +215,7 @@ Certreq example:
 5.  Launch Certificates - Local Machine by running **certlm.msc**.
 6.  Create a .pfx file by opening the **Certificates – Local Computer\\Personal\\Certificates** path in the navigation pane, right-clicking the previously imported certificate, selecting **All Tasks**, then **Export**. Follow through the wizard to create the .pfx file.
 
-### Deploy the private key and certificate to the WDS server
+### <a href="" id="bkmk-deploycert"/>Deploy the private key and certificate to the WDS server
 
 With the certificate and key created, deploy them to the infrastructure to properly unlock systems. To deploy the certificates, do the following:
 
@@ -230,7 +231,7 @@ With certificate and key deployed to the WDS server for Network Unlock, the fina
 The following steps describe how to enable the Group Policy setting that is a requirement for configuring Network Unlock.
 
 1.  Open Group Policy Management Console (gpmc.msc).
-2.  Enable the policy **Require additional authentication at startup** and select the **Require startup PIN with TPM** option.
+2.  Enable the policy **Require additional authentication at startup** and select the **Require startup PIN with TPM** or **Allow startup PIN with TPM** option.
 3.  Turn on BitLocker with TPM+PIN protectors on all domain-joined computers.
 
 The following steps describe how to deploy the required Group Policy setting:
@@ -247,15 +248,10 @@ The following steps describe how to deploy the required Group Policy setting:
     3.  Follow the wizard steps and import the .cer file that was copied earlier.
 
 >**Note:**  Only one network unlock certificate can be available at a time. If a new certificate is required, delete the current certificate before deploying a new one. The Network Unlock certificate is located in the **HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\SystemCertificates\\FVE\_NKP** key on the client computer.
+
+5. Reboot the clients after deploying the group policy.
+>**Note:** The **Network (Certificate Based)** protector will be added only after a reboot with the policy enabled and a valid certificate present in the FVE_NKP store.
  
-### Require TPM+PIN protectors at startup
-
-An additional step is for enterprises to use TPM+PIN protectors for an extra level of security. To require TPM+PIN protectors in an environment, do the following:
-
-1.  Open Group Policy Management Console (gpmc.msc).
-2.  Enable the policy **Require additional authentication at startup** and select the **Require startup PIN with TPM** option.
-3.  Turn on BitLocker with TPM+PIN protectors on all domain-joined computers.
-
 ### Subnet policy configuration files on WDS Server (Optional)
 
 By default, all clients with the correct Network Unlock Certificate and valid Network Unlock protectors that have wired access to a Network Unlock-enabled WDS server via DHCP are unlocked by the server. A subnet policy configuration file on the WDS server can be created to limit which subnet(s) Network Unlock clients can use to unlock.
@@ -285,13 +281,13 @@ The subnet policy configuration file must use a “\[SUBNETS\]” section to ide
 
 To disallow the use of a certificate altogether, its subnet list may contain the line “DISABLED".
 
-## Turning off Network Unlock
+## <a href="" id="bkmk-turnoffnetworkunlock"/>Turning off Network Unlock
 
 To turn off the unlock server, the PXE provider can be unregistered from the WDS server or uninstalled altogether. However, to stop clients from creating Network Unlock protectors the **Allow Network Unlock at startup** Group Policy setting should be disabled. When this policy setting is updated to disabled on client computers any Network Unlock key protectors on the computer will be deleted. Alternatively, the BitLocker Network Unlock certificate policy can be deleted on the domain controller to accomplish the same task for an entire domain.
 
->**Note:**  Removing the FVENKP certificate store that contains the Network Unlock certificate and key on the WDS server will also effectively disable the server’s ability to respond to unlock requests for that certificate. However, this is seen as an error condition and is not a supported or recommended method for turning off the Network Unlock server.
+>**Note:**  Removing the FVE_NKP certificate store that contains the Network Unlock certificate and key on the WDS server will also effectively disable the server’s ability to respond to unlock requests for that certificate. However, this is seen as an error condition and is not a supported or recommended method for turning off the Network Unlock server.
  
-## Update Network Unlock certificates
+## <a href="" id="bkmk-updatecerts"/>Update Network Unlock certificates
 
 To update the certificates used by Network Unlock, administrators need to import or generate the new certificate for the server and then update the Network Unlock certificate Group Policy setting on the domain controller.
 
@@ -302,12 +298,13 @@ Troubleshooting Network Unlock issues begins by verifying the environment. Many 
 -   Verify client hardware is UEFI-based and is on firmware version is 2.3.1 and that the UEFI firmware is in native mode without a Compatibility Support Module (CSM) for BIOS mode enabled. Do this by checking that the firmware does not have an option enabled such as "Legacy mode" or "Compatibility mode" or that the firmware does not appear to be in a BIOS-like mode.
 -   All required roles and services are installed and started
 -   Public and private certificates have been published and are in the proper certificate containers. The presence of the Network Unlock certificate can be verified in the Microsoft Management Console (MMC.exe) on the WDS server with the certificate snap-ins for the local computer enabled. The client certificate can be verified by checking the registry key **HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\SystemCertificates\\FVE\_NKP** on the client computer.
--   Group policy for Network Unlock is enabled and linked to the appropriate domains
+-   Group policy for Network Unlock is enabled and linked to the appropriate domains.
 -   Verify group policy is reaching the clients properly. This can be done using the GPRESULT.exe or RSOP.msc utilities.
+-   Verify the clients were rebooted after applying the policy.
 -   Verify the **Network (Certificate Based)** protector is listed on the client. This can be done using either manage-bde or Windows PowerShell cmdlets. For example the following command will list the key protectors currently configured on the C: drive of the lcoal computer:
 
     ``` syntax
-    Manage-bde –protectors –get C:
+    manage-bde –protectors –get C:
     ```
 >**Note:**  Use the output of manage-bde along with the WDS debug log to determine if the proper certificate thumbprint is being used for Network Unlock
  
@@ -343,14 +340,14 @@ Network Unlock and the accompanying Group Policy settings were introduced in Win
 
 The following steps can be used to configure Network Unlock on these older systems.
 
-1.  [Step One: Install the WDS Server role](#bkmk-stepone)
-2.  [Step Two: Confirm the WDS Service is running](#bkmk-steptwo)
-3.  [Step Three: Install the Network Unlock feature](#bkmk-stepthree)
-4.  [Step Four: Create the Network Unlock certificate](#bkmk-stepfour)
-5.  [Step Five: Deploy the private key and certificate to the WDS server](#bkmk-stepfive)
-6.  [Step Six: Configure registry settings for Network Unlock](#bkmk-stepsix)
+1.  [Install the WDS Server role](#bkmk-installwdsrole)
+2.  [Confirm the WDS Service is running](#bkmk-confirmwdsrunning)
+3.  [Install the Network Unlock feature](#bkmk-installnufeature)
+4.  [Create the Network Unlock certificate](bkmk-createcert)
+5.  [Deploy the private key and certificate to the WDS server](#bkmk-deploycert)
+6.  Configure registry settings for Network Unlock:
 
-    Apply the registry settings by running the following certutil script on each computer running any of the client operating systems designated in the **Applies To** list at the beginning of this topic.
+    Apply the registry settings by running the following certutil script (assuming your network unlock certificate file is called **BitLocker-NetworkUnlock.cer**) on each computer running any of the client operating systems designated in the **Applies To** list at the beginning of this topic.
 
         certutil -f -grouppolicy -addstore FVE_NKP BitLocker-NetworkUnlock.cer
         reg add "HKLM\SOFTWARE\Policies\Microsoft\FVE" /v OSManageNKP /t REG_DWORD /d 1 /f
@@ -361,10 +358,8 @@ The following steps can be used to configure Network Unlock on these older syste
         reg add "HKLM\SOFTWARE\Policies\Microsoft\FVE" /v UseTPMKey /t REG_DWORD /d 2 /f
         reg add "HKLM\SOFTWARE\Policies\Microsoft\FVE" /v UseTPMKeyPIN /t REG_DWORD /d 2 /f
 
-7.  [Create the Network Unlock certificate](#bkmk-stepfour)
-8.  [Deploy the private key and certificate to the WDS server](#bkmk-stepfive)
-9.  [Create the certificate template for Network Unlock](#bkmk-createcerttmpl)
-10. [Require TPM+PIN protectors at startup](#bkmk-stepseven)
+7.  Set up a TPM protector on the clients
+8.  Reboot the clients to add the Network (Certificate Based) protector
 
 ## See also
 


### PR DESCRIPTION
- Corrected certificate store name from FVENKP to FVE_NKP
- Added the requirement to reboot the clients after applying the policy
- Added the requirement for the clients to have a TPM protector
- Removed duplicate steps of adding a TPM protector (require TPM+PIN vs allow TPM+PIN)
- Fixed linking within the document