### PR TITLE
Client Management/MDM: repair broken links in oma-dm-protocol-support.md

### DIFF
--- a/windows/client-management/mdm/oma-dm-protocol-support.md
+++ b/windows/client-management/mdm/oma-dm-protocol-support.md
@@ -13,7 +13,7 @@ ms.date: 06/26/2017
 
 # OMA DM protocol support
 
-The OMA DM client communicates with the server over HTTPS and uses DM Sync (OMA DM v1.2) as the message payload. This topic describes the OMA DM functionality that the DM client supports in general. The full description of the OMA DM protocol v1.2 can be found at the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2-20070209-A/OMA-TS-DM_Protocol-V1_2-20070209-A.pdf).
+The OMA DM client communicates with the server over HTTPS and uses DM Sync (OMA DM v1.2) as the message payload. This topic describes the OMA DM functionality that the DM client supports in general. The full description of the OMA DM protocol v1.2 can be found at the [OMA website](https://www.openmobilealliance.org/release/DM/V1_2-20070209-A/OMA-TS-DM_Protocol-V1_2-20070209-A.pdf).
 
 
 ## In this topic
@@ -62,7 +62,7 @@ The following table shows the OMA DM standards that Windows uses.
 </tr>
 <tr class="odd">
 <td style="vertical-align:top"><p>DM protocol commands</p></td>
-<td style="vertical-align:top"><p>The following list shows the commands that are used by the device. For further information about the OMA DM command elements, see &quot;SyncML Representation Protocol Device Management Usage (OMA-SyncML-DMRepPro-V1_1_2-20030613-A)&quot; available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).</p>
+<td style="vertical-align:top"><p>The following list shows the commands that are used by the device. For further information about the OMA DM command elements, see &quot;SyncML Representation Protocol Device Management Usage (OMA-SyncML-DMRepPro-V1_1_2-20030613-A)&quot; available from the [OMA website](https://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).</p>
 <ul>
 <li><p>Add (Implicit Add supported)</p></li>
 <li><p>Alert (DM alert): Generic alert (1226) is used by enterprise management client when the user triggers an MDM unenrollment action from the device or when a CSP finishes some asynchronous actions. Device alert (1224) is used to notify the server some device triggered event.</p></li>
@@ -146,7 +146,7 @@ The following table shows the OMA DM standards that Windows uses.
 <a href="" id="protocol-common-elements"></a>
 ## OMA DM protocol common elements
 
-Common elements are used by other OMA DM element types. The following table lists the OMA DM common elements used to configure the devices. For more information about OMA DM common elements, see "SyncML Representation Protocol Device Management Usage" (OMA-SyncML-DMRepPro-V1_1_2-20030613-A) available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).
+Common elements are used by other OMA DM element types. The following table lists the OMA DM common elements used to configure the devices. For more information about OMA DM common elements, see "SyncML Representation Protocol Device Management Usage" (OMA-SyncML-DMRepPro-V1_1_2-20030613-A) available from the [OMA website](https://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).
 
 <table>
 <colgroup>
@@ -303,13 +303,13 @@ The following table shows the sequence of events during a typical DM session.
 
 
 
-The step numbers in the table do not represent message identification numbers (MsgID). All messages from the server must have a MsgID that is unique within the session, starting at 1 for the first message, and increasing by an increment of 1 for each additional message. For more information about MsgID and OMA SyncML protocol, see "OMA Device Management Representation Protocol" (DM_RepPro-V1_2-20070209-A) available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2-20070209-A/).
+The step numbers in the table do not represent message identification numbers (MsgID). All messages from the server must have a MsgID that is unique within the session, starting at 1 for the first message, and increasing by an increment of 1 for each additional message. For more information about MsgID and OMA SyncML protocol, see "OMA Device Management Representation Protocol" (DM_RepPro-V1_2-20070209-A) available from the [OMA website](https://www.openmobilealliance.org/release/DM/V1_2-20070209-A/).
 
 During OMA DM application level mutual authentication, if the device response code to Cred element in the server request is 212, no further authentication is needed for the remainder of the DM session. In the case of the MD5 authentication, the Chal element can be returned. Then the next nonce in Chal must be used for the MD5 digest when the next DM session is started.
 
 If a request includes credentials and the response code to the request is 200, the same credential must be sent within the next request. If the Chal element is included and the MD5 authentication is required, a new digest is created by using the next nonce via the Chal element for next request.
 
-For more information about Basic or MD5 client authentication, MD5 server authentication, MD5 hash, and MD5 nonce, see the OMA Device Management Security specification (OMA-TS-DM_Security-V1_2_1-20080617-A), authentication response code handling and step-by-step samples in OMA Device Management Protocol specification (OMA-TS-DM_Protocol-V1_2_1-20080617-A), available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2_1-20080617-A/).
+For more information about Basic or MD5 client authentication, MD5 server authentication, MD5 hash, and MD5 nonce, see the OMA Device Management Security specification (OMA-TS-DM_Security-V1_2_1-20080617-A), authentication response code handling and step-by-step samples in OMA Device Management Protocol specification (OMA-TS-DM_Protocol-V1_2_1-20080617-A), available from the [OMA website](https://www.openmobilealliance.org/release/DM/V1_2_1-20080617-A/).
 
 
 ## User targeted vs. Device targeted configuration

--- a/windows/client-management/mdm/oma-dm-protocol-support.md
+++ b/windows/client-management/mdm/oma-dm-protocol-support.md
@@ -13,7 +13,7 @@ ms.date: 06/26/2017
 
 # OMA DM protocol support
 
-The OMA DM client communicates with the server over HTTPS and uses DM Sync (OMA DM v1.2) as the message payload. This topic describes the OMA DM functionality that the DM client supports in general. The full description of the OMA DM protocol v1.2 can be found at the [OMA website](https://go.microsoft.com/fwlink/p/?LinkId=267526).
+The OMA DM client communicates with the server over HTTPS and uses DM Sync (OMA DM v1.2) as the message payload. This topic describes the OMA DM functionality that the DM client supports in general. The full description of the OMA DM protocol v1.2 can be found at the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2-20070209-A/OMA-TS-DM_Protocol-V1_2-20070209-A.pdf).
 
 
 ## In this topic
@@ -62,7 +62,7 @@ The following table shows the OMA DM standards that Windows uses.
 </tr>
 <tr class="odd">
 <td style="vertical-align:top"><p>DM protocol commands</p></td>
-<td style="vertical-align:top"><p>The following list shows the commands that are used by the device. For further information about the OMA DM command elements, see &quot;SyncML Representation Protocol Device Management Usage (OMA-SyncML-DMRepPro-V1_1_2-20030613-A)&quot; available from the [OMA website](https://go.microsoft.com/fwlink/p/?LinkId=267526).</p>
+<td style="vertical-align:top"><p>The following list shows the commands that are used by the device. For further information about the OMA DM command elements, see &quot;SyncML Representation Protocol Device Management Usage (OMA-SyncML-DMRepPro-V1_1_2-20030613-A)&quot; available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).</p>
 <ul>
 <li><p>Add (Implicit Add supported)</p></li>
 <li><p>Alert (DM alert): Generic alert (1226) is used by enterprise management client when the user triggers an MDM unenrollment action from the device or when a CSP finishes some asynchronous actions. Device alert (1224) is used to notify the server some device triggered event.</p></li>
@@ -146,7 +146,7 @@ The following table shows the OMA DM standards that Windows uses.
 <a href="" id="protocol-common-elements"></a>
 ## OMA DM protocol common elements
 
-Common elements are used by other OMA DM element types. The following table lists the OMA DM common elements used to configure the devices. For more information about OMA DM common elements, see "SyncML Representation Protocol Device Management Usage" (OMA-SyncML-DMRepPro-V1\_1\_2-20030613-A) available from the [OMA website](https://go.microsoft.com/fwlink/p/?LinkId=526900).
+Common elements are used by other OMA DM element types. The following table lists the OMA DM common elements used to configure the devices. For more information about OMA DM common elements, see "SyncML Representation Protocol Device Management Usage" (OMA-SyncML-DMRepPro-V1_1_2-20030613-A) available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/).
 
 <table>
 <colgroup>
@@ -301,15 +301,15 @@ The following table shows the sequence of events during a typical DM session.
 </tbody>
 </table>
 
- 
 
-The step numbers in the table do not represent message identification numbers (MsgID). All messages from the server must have a MsgID that is unique within the session, starting at 1 for the first message, and increasing by an increment of 1 for each additional message. For more information about MsgID and OMA SyncML protocol, see "OMA Device Management Representation Protocol" (OMA-TS-DM\_RepPro-V1\_2-20070209-A) available from the [OMA website](https://go.microsoft.com/fwlink/p/?LinkId=526900).
+
+The step numbers in the table do not represent message identification numbers (MsgID). All messages from the server must have a MsgID that is unique within the session, starting at 1 for the first message, and increasing by an increment of 1 for each additional message. For more information about MsgID and OMA SyncML protocol, see "OMA Device Management Representation Protocol" (DM_RepPro-V1_2-20070209-A) available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2-20070209-A/).
 
 During OMA DM application level mutual authentication, if the device response code to Cred element in the server request is 212, no further authentication is needed for the remainder of the DM session. In the case of the MD5 authentication, the Chal element can be returned. Then the next nonce in Chal must be used for the MD5 digest when the next DM session is started.
 
 If a request includes credentials and the response code to the request is 200, the same credential must be sent within the next request. If the Chal element is included and the MD5 authentication is required, a new digest is created by using the next nonce via the Chal element for next request.
 
-For more information about Basic or MD5 client authentication, MD5 server authentication, MD5 hash, and MD5 nonce, see the OMA Device Management Security specification (OMA-TS-DM\_Security-V1\_2\_1-20080617-A), authentication response code handling and step-by-step samples in OMA Device Management Protocol specification (OMA-TS-DM\_Protocol-V1\_2\_1-20080617-A), available from the [OMA website](https://go.microsoft.com/fwlink/p/?LinkId=526900).
+For more information about Basic or MD5 client authentication, MD5 server authentication, MD5 hash, and MD5 nonce, see the OMA Device Management Security specification (OMA-TS-DM_Security-V1_2_1-20080617-A), authentication response code handling and step-by-step samples in OMA Device Management Protocol specification (OMA-TS-DM_Protocol-V1_2_1-20080617-A), available from the [OMA website](http://www.openmobilealliance.org/release/DM/V1_2_1-20080617-A/).
 
 
 ## User targeted vs. Device targeted configuration


### PR DESCRIPTION
(I have labeled this PR with the Work In Progress prefix to signal that I would like feedback regarding the content and its formats.)

Links to the OMA website containing OMA Device Management documents have been broken for some time now, due to OMA website rearrangements.
This is an attempt to restore the links to the OMA website as much as possible, given the existing references, to the documents or their directory containers.

Thanks to @vlad-MSFT for providing the initial link to the website folder structure.
- http://www.openmobilealliance.org/wp/overviews/dm_overview.html

Merging this Pull Request closes the following open issues:
- **Link to the OMA website is broken** #2759
- **Dead link found** #2362

**Please note:** The first link points directly to the PDF document, since there is no document name reference in the preceding text. If direct document linking is deprecated or discouraged, please let me know and I will alter the text accordingly.

**Caveat:** There are several folders containing newer versions of some of the documents. I do not have the proficiency nor experience to suggest which references and document versions to update, unless someone fluent in this type of documentation can point me to which document versions should be replaced with their newer counterparts. (Then again, that could be a topic for a new review after this update.)