### PR TITLE
Deployment/Update: typos and whitespace corrections in waas-restart.md

### DIFF
--- a/windows/deployment/update/waas-restart.md
+++ b/windows/deployment/update/waas-restart.md
@@ -17,15 +17,15 @@ ms.topic: article
 **Applies to**
 
 - Windows 10
-- Windows 10 Mobile 
+- Windows 10 Mobile
 
-> **Looking for consumer information?** See [Windows Update: FAQ](https://support.microsoft.com/help/12373/windows-update-faq) 
+> **Looking for consumer information?** See [Windows Update: FAQ](https://support.microsoft.com/help/12373/windows-update-faq)
 
 You can use Group Policy settings, mobile device management (MDM) or Registry (not recommended) to configure when devices will restart after a Windows 10 update is installed. You can schedule update installation and set policies for restart, configure active hours for when restarts will not occur, or you can do both.
 
 ## Schedule update installation
 
-In Group Policy, within **Configure Automatic Updates**, you can configure a forced restart after a specified installation time. 
+In Group Policy, within **Configure Automatic Updates**, you can configure a forced restart after a specified installation time.
 
 To set the time, you need to go to **Configure Automatic Updates**, select option **4 - Auto download and schedule the install**, and then enter a time in the **Scheduled install time** dropdown. Alternatively, you can specify that installation will occur during the automatic maintenance time (configured using **Computer Configuration\Administrative Templates\Windows Components\Maintenance Scheduler**).
 
@@ -40,7 +40,7 @@ For a detailed description of these registry keys, see [Registry keys used to ma
 When **Configure Automatic Updates** is enabled in Group Policy, you can enable one of the following additional policies to delay an automatic reboot after update installation:
 
 - **Turn off auto-restart for updates during active hours** prevents automatic restart during active hours.
-- **No auto-restart with logged on users for scheduled automatic updates installations** prevents automatic restart when a user is signed in. If a user schedules the restart in the update notification, the device will restart at the time the user specifies even if a user is signed in at the time. This policy only applies when **Configure Automatic Updates** is set to option **4-Auto download and schedule the install**. 
+- **No auto-restart with logged on users for scheduled automatic updates installations** prevents automatic restart when a user is signed in. If a user schedules the restart in the update notification, the device will restart at the time the user specifies even if a user is signed in at the time. This policy only applies when **Configure Automatic Updates** is set to option **4-Auto download and schedule the install**.
 
 You can also use Registry, to prevent automatic restarts when a user is signed in. Under **HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate\AU**, set **AuOptions** to **4** and enable **NoAutoRebootWithLoggedOnUsers**. As with Group Policy, if a user schedules the restart in the update notification, it will override this setting.
 
@@ -48,9 +48,9 @@ For a detailed description of these registry keys, see [Registry keys used to ma
 
 ## Configure active hours
 
-*Active hours* identify the period of time when you expect the device to be in use. Automatic restarts after an update will occur outside of the active hours. 
+*Active hours* identify the period of time when you expect the device to be in use. Automatic restarts after an update will occur outside of the active hours.
 
-By default, active hours are from 8 AM to 5 PM on PCs and from 5 AM to 11 PM on phones. Users can change the active hours manually. 
+By default, active hours are from 8 AM to 5 PM on PCs and from 5 AM to 11 PM on phones. Users can change the active hours manually.
 
 Starting with Windows 10, version 1703, you can also specify the max active hours range. The specified range will be counted from the active hours start time.
 
@@ -89,7 +89,7 @@ For a detailed description of these registry keys, see [Registry keys used to ma
 
 With Windows 10, version 1703, administrators can specify the max active hours range users can set. This option gives you additional flexibility to leave some of the decision for active hours on the user's side, while making sure you allow enough time for updating. The max range is calculated from active hours start time.
 
-To configure active hours max range through Group Policy, go to **Computer Configuration\Administrative Templates\Windows Components\Windows Update** and open the **Specify active hours range for auto-restarts**. 
+To configure active hours max range through Group Policy, go to **Computer Configuration\Administrative Templates\Windows Components\Windows Update** and open the **Specify active hours range for auto-restarts**.
 
 To configure active hours max range through MDM, use [**Update/ActiveHoursMaxRange**](https://msdn.microsoft.com/windows/hardware/commercialize/customize/mdm/policy-configuration-service-provider?UpdatePolicies#update-activehoursmaxrange).
 
@@ -103,9 +103,9 @@ In Windows 10, version 1703, we have added settings to control restart notificat
 
 ### Auto-restart notifications
 
-Administrators can override the default behavior for the auto-restart required notification. By default, this notification will dismiss automatically. 
+Administrators can override the default behavior for the auto-restart required notification. By default, this notification will dismiss automatically.
 
-To configure this behavior through Group Policy, go to **Computer Configuration\Administrative Templates\Windows Components\Windows Update** and select **Configure auto-restart required notification for updates**. When configured to **2 - User Action**, a user that gets this notification must manually dismiss it. 
+To configure this behavior through Group Policy, go to **Computer Configuration\Administrative Templates\Windows Components\Windows Update** and select **Configure auto-restart required notification for updates**. When configured to **2 - User Action**, a user that gets this notification must manually dismiss it.
 
 To configure this behavior through MDM, use [**Update/AutoRestartRequiredNotificationDismissal**](https://msdn.microsoft.com/windows/hardware/commercialize/customize/mdm/policy-configuration-service-provider?UpdatePolicies#update-AutoRestartRequiredNotificationDismissal)
 
@@ -170,7 +170,7 @@ The following tables list registry values that correspond to the Group Policy se
 | Registry key |	Key type | Value |
 | --- | --- | --- |
 | ActiveHoursEnd	| REG_DWORD | 0-23: set active hours to end at a specific hour</br>starts with 12 AM (0) and ends with 11 PM (23) |
-| ActiveHoursStart | REG_DWORD | 0-23: set active hours to start at a specific hour</br>starts with 12 AM (0) and ends with 11 PM (23) | 
+| ActiveHoursStart | REG_DWORD | 0-23: set active hours to start at a specific hour</br>starts with 12 AM (0) and ends with 11 PM (23) |
 | SetActiveHours | REG_DWORD | 0: disable automatic restart after updates outside of active hours</br>1: enable automatic restart after updates outside of active hours |
 
 **HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate\AU**
@@ -179,32 +179,24 @@ The following tables list registry values that correspond to the Group Policy se
 | --- | --- | --- |
 | AlwaysAutoRebootAtScheduledTime | REG_DWORD | 0: disable automatic reboot after update installation at scheduled time</br>1: enable automatic reboot after update installation at ascheduled time |
 | AlwaysAutoRebootAtScheduledTimeMinutes | REG_DWORD | 15-180: set automatic reboot to occur after given minutes |
-| AUOptions | REG_DWORD | 2: notify for download and automatically install updates</br>3: automatically download and notify for instllation of updates</br>4: Automatically download and schedule installation of updates</br>5: allow the local admin to configure these settings</br>**Note:** To configure restart behavior, set this value to **4** |
-| NoAutoRebootWithLoggedOnUsers | REG_DWORD | 0: disable do not reboot if users are logged on</br>1: do not reboot after an update installation if a user is logged on</br>**Note:** If disabled : Automatic Updates will notify the user that the computer will automatically restarts in 5 minutes to complete the installation  |
+| AUOptions | REG_DWORD | 2: notify for download and automatically install updates</br>3: automatically download and notify for installation of updates</br>4: Automatically download and schedule installation of updates</br>5: allow the local admin to configure these settings</br>**Note:** To configure restart behavior, set this value to **4** |
+| NoAutoRebootWithLoggedOnUsers | REG_DWORD | 0: disable do not reboot if users are logged on</br>1: do not reboot after an update installation if a user is logged on</br>**Note:** If disabled : Automatic Updates will notify the user that the computer will automatically restart in 5 minutes to complete the installation  |
 | ScheduledInstallTime | REG_DWORD | 0-23: schedule update installation time to a specific hour</br>starts with 12 AM (0) and ends with 11 PM (23) |
 
 There are 3 different registry combinations for controlling restart behavior:
 
 - To set active hours, **SetActiveHours** should be **1**, while **ActiveHoursStart** and **ActiveHoursEnd** should define the time range.
 - To schedule a specific installation and reboot time, **AUOptions** should be **4**, **ScheduledInstallTime** should specify the installation time, **AlwaysAutoRebootAtScheduledTime** set to **1** and **AlwaysAutoRebootAtScheduledTimeMinutes** should specify number of minutes to wait before rebooting.
-- To delay rebooting if a user is logged on, **AUOptions** should be **4**, while **NoAutoRebootWithLoggedOnUsers** is set to **1**. 
+- To delay rebooting if a user is logged on, **AUOptions** should be **4**, while **NoAutoRebootWithLoggedOnUsers** is set to **1**.
 
 ## Related topics
 
 - [Update Windows 10 in the enterprise](index.md)
 - [Overview of Windows as a service](waas-overview.md)
-- [Manage updates for Windows 10 Mobile Enterprise and Windows 10 IoT Mobile](waas-mobile-updates.md) 
+- [Manage updates for Windows 10 Mobile Enterprise and Windows 10 IoT Mobile](waas-mobile-updates.md)
 - [Configure Delivery Optimization for Windows 10 updates](waas-delivery-optimization.md)
 - [Configure BranchCache for Windows 10 updates](waas-branchcache.md)
 - [Configure Windows Update for Business](waas-configure-wufb.md)
 - [Integrate Windows Update for Business with management solutions](waas-integrate-wufb.md)
 - [Walkthrough: use Group Policy to configure Windows Update for Business](waas-wufb-group-policy.md)
 - [Walkthrough: use Intune to configure Windows Update for Business](waas-wufb-intune.md)
-
-
-
-
-
-
-
-


### PR DESCRIPTION
**Content:** [Manage device restarts after updates (Windows 10) - Registry keys used to manage restart](https://docs.microsoft.com/en-us/windows/deployment/update/waas-restart#registry-keys-used-to-manage-restart)

**Github Content Source:** [windows/deployment/update/waas-restart.md - Registry keys used to manage restart](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/deployment/update/waas-restart.md#registry-keys-used-to-manage-restart)

**Changes proposed:**

1. Remove surplus/redundant whitespace (blank space/empty lines)

2. Correct the typo "instllation" in the sentence
> 3: automatically download and notify for instllation of updates

=>  3: automatically download and notify for **installation** of updates

3. Correct the typo "restarts" in the sentence
> **Note:** If disabled : Automatic Updates will notify the user that the computer will automatically restarts in 5 minutes to complete the installation

=> **Note:** If disabled : Automatic Updates will notify the user that the computer will automatically **restart** in 5 minutes to complete the installation
***
Please note: the extra bold text is only to highlight the typo corrections, it is not part of the provided change.

**Bonus information:**
The 2 PNG images used in the Github source text are not shown on the Github page, which is caused by a local naming glitch in the extension name `.PNG` instead of the expected `.png` :
- https://github.com/MicrosoftDocs/windows-itpro-docs/raw/master/windows/deployment/update/images/waas-active-hours-policy.png
- https://github.com/MicrosoftDocs/windows-itpro-docs/raw/master/windows/deployment/update/images/waas-active-hours.png

Instead, their current Github filename extensions are uppercase PNG:
- https://raw.githubusercontent.com/MicrosoftDocs/windows-itpro-docs/master/windows/deployment/update/images/waas-active-hours-policy.PNG
- https://raw.githubusercontent.com/MicrosoftDocs/windows-itpro-docs/master/windows/deployment/update/images/waas-active-hours.PNG

Unfortunately, I cannot rename the files `waas-active-hours-policy.PNG` / `waas-active-hours.PNG` to their correct lowercase `.png` names, because I commit using Windows 10 + Git Extensions, which means that GE does not detect a local name change from uppercase to lowercase filename extensions. Therefore I would like to note the ticket I made about the local Github image naming issue, **Deployment/images: uppercase PNG file extension names on Github** #2909