### PR TITLE
Windows Defender Application Control/AppLocker: typo correction & remove blanks

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/applocker/administer-applocker.md
+++ b/windows/security/threat-protection/windows-defender-application-control/applocker/administer-applocker.md
@@ -37,7 +37,7 @@ AppLocker helps administrators control how users can access and use files, such 
 
 | Topic | Description |
 | - | - |
-| [Administer AppLocker using Mobile Device Management (MDM)](administer-applocker-using-mdm.md) | This topic describes how to used MDM to manage AppLocker policies. |
+| [Administer AppLocker using Mobile Device Management (MDM)](administer-applocker-using-mdm.md) | This topic describes how to use MDM to manage AppLocker policies. |
 | [Maintain AppLocker policies](maintain-applocker-policies.md) | This topic describes how to maintain rules within AppLocker policies. |
 | [Edit an AppLocker policy](edit-an-applocker-policy.md) | This topic for IT professionals describes the steps required to modify an AppLocker policy. |
 | [Test and update an AppLocker policy](test-and-update-an-applocker-policy.md) | This topic discusses the steps required to test an AppLocker policy prior to deployment. |
@@ -71,5 +71,3 @@ You must have Edit Setting permission to edit a GPO. By default, members of the
 ## Using Windows PowerShell to administer AppLocker
 
 For how-to info about administering AppLocker with Windows PowerShell, see [Use the AppLocker Windows PowerShell Cmdlets](use-the-applocker-windows-powershell-cmdlets.md). For reference info and examples how to administer AppLocker with Windows PowerShell, see the [AppLocker cmdlets](https://technet.microsoft.com/library/hh847210.aspx).
- 
- 


### PR DESCRIPTION
**Proposed changes:**
- Correction: change "how to used" to read "how to use".
- Removal: remove 2 redundant blank lines at the end of the document.

**Ref. issue ticket:**
- #1230 (**No data?**)

**Please note:**
- if the Microsoft Docs Team already has got material for this page,
feel free to close this Pull Request without merging it, especially
if your material contains improvements to the same page
(and may be ready to be pushed quite soon).