### PR TITLE
Update windows-10-upgrade-paths.md

### DIFF
--- a/windows/deployment/upgrade/windows-10-upgrade-paths.md
+++ b/windows/deployment/upgrade/windows-10-upgrade-paths.md
@@ -42,7 +42,6 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td>Windows 10 Pro Education</td>
         <td>Windows 10 Education</td>
         <td>Windows 10 Enterprise</td>
-        <td>Windows 10 Enterprise LTSC</td>
         <td>Windows 10 Mobile</td>
         <td>Windows 10 Mobile Enterprise</td>
     </tr>
@@ -261,17 +260,6 @@ D = Edition downgrade; personal data is maintained, applications and settings ar
         <td>✔</td>
         <td>✔</td>
         <td></td>
-        <td></td>
-        <td></td>
-    </tr>
-    <tr>
-        <td>Enterprise LTSC</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>✔</td>
-        <td>✔</td>
         <td></td>
         <td></td>
     </tr>


### PR DESCRIPTION
Per discussion w/Greg Lindsey, I'm removing references to the Enterprise LTSC from the table.  Upgrades from an LTSB/LTSC release to a SAC release can only be done with an in-place upgrade and not with a transmog operation.