### PR TITLE
Client Management/MDM: typo corrections & clarification in uefi-csp.md

### DIFF
--- a/windows/client-management/mdm/uefi-csp.md
+++ b/windows/client-management/mdm/uefi-csp.md
@@ -18,7 +18,7 @@ The UEFI configuration service provider (CSP) interfaces to UEFI's Device Firmwa
 > The UEFI CSP version published in Windows 10, version 1803 is replaced with this one (version 1809).
 
 > [!Note]  
-> The production UEFI CSP is present in 1809, but it depends upon the Devicie Firmware Configuration Interface (DFCI) and UEFI firmware the complies with this interface.  The specification for this interface and compatible firmware is not yet available.
+> The production UEFI CSP is present in 1809, but it depends upon the Device Firmware Configuration Interface (DFCI) and UEFI firmware to comply with this interface.  The specification for this interface and compatible firmware is not yet available.
 
 The following diagram shows the UEFI CSP in tree format.
 


### PR DESCRIPTION
**Proposed changes:**
- Typo corrections: "Devicie" -> Device (obvious typo) - and "the complies"
- Clarification: "the complies with this interface" -> "to comply with this interface"

Reasoning behind the clarification change: This is about the UEFI CSP depending upon the
Device Firmware Configuration Interface (DFCI) and UEFI firmware to be compliant,
not as I first thought in PR #2770, that it would depend on which DFCI/UEFI is being used.

Ref. #2770 (as above)