### PR TITLE
Security/Threat Protection: insert correct link to Windows Defender System Guard

### DIFF
--- a/windows/security/threat-protection/windows-defender-atp/overview-hardware-based-isolation.md
+++ b/windows/security/threat-protection/windows-defender-atp/overview-hardware-based-isolation.md
@@ -25,8 +25,5 @@ Hardware-based isolation helps protect system integrity in Windows 10 and is int
 | Feature | Description |
 |------------|-------------|
 | [Windows Defender Application Guard](../windows-defender-application-guard/wd-app-guard-overview.md) | Application Guard protects your device from advanced attacks while keeping you productive. Using a unique hardware-based isolation approach, the goal is to isolate untrusted websites and PDF documents inside a lightweight container that is separated from the operating system via the native Windows Hypervisor. If an untrusted site or PDF document turns out to be malicious, it still remains contained within Application Guard’s secure container, keeping the desktop PC protected and the attacker away from your enterprise data. |
-| [Windows Defender System Guard](how-hardware-based-containers-help-protect-windows.md) | System Guard protects and maintains the integrity of the system as it starts and after it's running, and validates system integrity by using attestation.  |
-
-
-
+| [Windows Defender System Guard](../windows-defender-system-guard/how-hardware-based-root-of-trust-helps-protect-windows.md) | System Guard protects and maintains the integrity of the system as it starts and after it's running, and validates system integrity by using attestation.  |
 

--- a/windows/security/threat-protection/windows-defender-atp/overview-hardware-based-isolation.md
+++ b/windows/security/threat-protection/windows-defender-atp/overview-hardware-based-isolation.md
@@ -25,5 +25,5 @@ Hardware-based isolation helps protect system integrity in Windows 10 and is int
 | Feature | Description |
 |------------|-------------|
 | [Windows Defender Application Guard](../windows-defender-application-guard/wd-app-guard-overview.md) | Application Guard protects your device from advanced attacks while keeping you productive. Using a unique hardware-based isolation approach, the goal is to isolate untrusted websites and PDF documents inside a lightweight container that is separated from the operating system via the native Windows Hypervisor. If an untrusted site or PDF document turns out to be malicious, it still remains contained within Application Guard’s secure container, keeping the desktop PC protected and the attacker away from your enterprise data. |
-| [Windows Defender System Guard](../windows-defender-system-guard/how-hardware-based-root-of-trust-helps-protect-windows.md) | System Guard protects and maintains the integrity of the system as it starts and after it's running, and validates system integrity by using attestation.  |
+| [Windows Defender System Guard](../windows-defender-system-guard/system-guard-how-hardware-based-root-of-trust-helps-protect-windows.md) | System Guard protects and maintains the integrity of the system as it starts and after it's running, and validates system integrity by using attestation.  |
 


### PR DESCRIPTION
**Suggested changes:**
- Repair the broken link to "Windows Defender System Guard" in the page file
  [`overview-hardware-based-isolation.md`](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/windows-defender-atp/overview-hardware-based-isolation.md)
- Remove 3 redundant blank lines at the end of the page.

Thanks to @Sherd21 for finding and providing the correct link.

Closes #2813