### PR TITLE
CC certification updates for Win 10 1803

### DIFF
--- a/windows/security/threat-protection/windows-platform-common-criteria.md
+++ b/windows/security/threat-protection/windows-platform-common-criteria.md
@@ -9,7 +9,7 @@ manager: dansimp
 ms.collection: M365-identity-device-management
 ms.topic: article
 ms.localizationpriority: medium
-ms.date: 10/8/2018
+ms.date: 3/20/2019
 ---
 
 # Common Criteria Certifications
@@ -22,6 +22,7 @@ Microsoft is committed to optimizing the security of its products and services. 
 
 The Security Target describes security functionality and assurance measures used to evaluate Windows.
 
+  - [Microsoft Windows 10 (April 2018 Update)](http://download.microsoft.com/download/0/7/6/0764E933-DD0B-45A7-9144-1DD9F454DCEF/Windows%2010%201803%20GP%20OS%20Security%20Target.pdf)
   - [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/B/6/A/B6A5EC2C-6351-4FB9-8FF1-643D4BD5BE6E/Windows%2010%201709%20GP%20OS%20Security%20Target.pdf)
   - [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/e/8/b/e8b8c42a-a0b6-4ba1-9bdc-e704e8289697/windows%2010%20version%201703%20gp%20os%20security%20target%20-%20public%20\(january%2016,%202018\)\(final\)\(clean\).pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/1/c/3/1c3b5ab0-e064-4350-a31f-48312180d9b5/st_vid10823-st.pdf)
@@ -58,6 +59,7 @@ These documents describe how to configure Windows to replicate the configuration
 **Windows 10, Windows 10 Mobile, Windows Server 2016, Windows Server 2012 R2**
 
   
+  - [Microsoft Windows 10 (April 2018 Update)](http://download.microsoft.com/download/6/C/1/6C13FBFF-9CB0-455F-A1C8-3E3CB0ACBD7B/Windows%2010%201803%20GP%20OS%20Administrative%20Guide.pdf)
   - [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/5/D/2/5D26F473-0FCE-4AC4-9065-6AEC0FE5B693/Windows%2010%201709%20GP%20OS%20Administrative%20Guide.pdf)
   - [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/e/9/7/e97f0c7f-e741-4657-8f79-2c0a7ca928e3/windows%2010%20cu%20gp%20os%20operational%20guidance%20\(jan%208%202017%20-%20public\).pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/d/c/4/dc40b5c8-49c2-4587-8a04-ab3b81eb6fc4/st_vid10823-agd.pdf)
@@ -134,6 +136,7 @@ These documents describe how to configure Windows to replicate the configuration
 
 An Evaluation Technical Report (ETR) is a report submitted to the Common Criteria certification authority for how Windows complies with the claims made in the Security Target. A Certification / Validation Report provides the results of the evaluation by the validation team.
 
+  - [Microsoft Windows 10 (Spring 2018 Update)](http://download.microsoft.com/download/6/7/1/67167BF2-885D-4646-A61E-96A0024B52BB/Windows%2010%201803%20GP%20OS%20Certification%20Report.pdf)
   - [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/2/C/2/2C20D013-0610-4047-B2FA-516819DFAE0A/Windows%2010%201709%20GP%20OS%20Certification%20Report.pdf) 
   - [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/a/3/3/a336f881-4ac9-4c79-8202-95289f86bb7a/st_vid10823-vr.pdf)

--- a/windows/security/threat-protection/windows-platform-common-criteria.md
+++ b/windows/security/threat-protection/windows-platform-common-criteria.md
@@ -136,7 +136,7 @@ These documents describe how to configure Windows to replicate the configuration
 
 An Evaluation Technical Report (ETR) is a report submitted to the Common Criteria certification authority for how Windows complies with the claims made in the Security Target. A Certification / Validation Report provides the results of the evaluation by the validation team.
 
-  - [Microsoft Windows 10 (Spring 2018 Update)](http://download.microsoft.com/download/6/7/1/67167BF2-885D-4646-A61E-96A0024B52BB/Windows%2010%201803%20GP%20OS%20Certification%20Report.pdf)
+  - [Microsoft Windows 10 (April 2018 Update)](http://download.microsoft.com/download/6/7/1/67167BF2-885D-4646-A61E-96A0024B52BB/Windows%2010%201803%20GP%20OS%20Certification%20Report.pdf)
   - [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/2/C/2/2C20D013-0610-4047-B2FA-516819DFAE0A/Windows%2010%201709%20GP%20OS%20Certification%20Report.pdf) 
   - [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
   - [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/a/3/3/a336f881-4ac9-4c79-8202-95289f86bb7a/st_vid10823-vr.pdf)


### PR DESCRIPTION
This PR includes additions to the Common Criteria Certification page.  Windows 10 version 1803 / April 2018 Update has now been certified, so I've added the 3 bullets + links for the certification documents (on Download Center) and updated the ms.date field to reflect today. 