### PR TITLE
Section header was missing

### DIFF
--- a/windows/security/identity-protection/user-account-control/user-account-control-security-policy-settings.md
+++ b/windows/security/identity-protection/user-account-control/user-account-control-security-policy-settings.md
@@ -95,6 +95,7 @@ This policy setting controls whether the elevation request prompt is displayed o
 
 -   **Enabled** (Default) All elevation requests go to the secure desktop regardless of prompt behavior policy settings for administrators and standard users.
 -   **Disabled** All elevation requests go to the interactive user's desktop. Prompt behavior policy settings for administrators and standard users are used.
+
 ## User Account Control: Virtualize file and registry write failures to per-user locations
 
 This policy setting controls whether application write failures are redirected to defined registry and file system locations. This policy setting mitigates applications that run as administrator and write run-time application data to %ProgramFiles%, %Windir%, %Windir%\\system32, or HKLM\\Software.


### PR DESCRIPTION
In the article, section header User Account Control: Virtualize file and registry write failures to per-user locations was not formatted.

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/2991