### PR TITLE
Policy CSP/DeviceInstallation: add missing path folder DeviceInstallation

### DIFF
--- a/windows/client-management/mdm/policy-csp-deviceinstallation.md
+++ b/windows/client-management/mdm/policy-csp-deviceinstallation.md
@@ -422,7 +422,7 @@ To enable this policy, use the following SyncML. This example prevents Windows f
             <CmdID>$CmdID$</CmdID>
             <Item>
                 <Target>
-                    <LocURI>./Device/Vendor/MSFT/Policy/Config/PreventInstallationOfDevicesNotDescribedByOtherPolicySettings</LocURI>
+                    <LocURI>./Device/Vendor/MSFT/Policy/Config/DeviceInstallation/PreventInstallationOfDevicesNotDescribedByOtherPolicySettings</LocURI>
                 </Target>
                 <Meta>
                     <Format xmlns="syncml:metinf">string</Format>


### PR DESCRIPTION
**Proposed change:**
- Add the omitted folder name to the LocURI path in the SyncML sample for [DeviceInstallation/PreventInstallationOfDevicesNotDescribedByOtherPolicySettings](https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#deviceinstallation-preventinstallationofdevicesnotdescribedbyotherpolicysettings)

All the other SyncML samples contain the correct path, except for this one.
**Even the section title** for this sample states that the key sorts under "DeviceInstallation",
as well as the DeviceInstallation policies list (link list) on top of the page.

The policy path format is also documented in the page https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider .

Resolves #2988

**ToDo/Unsolved cases:**

I have not searched for other occurrences of this omission error, but I have asked the OP in issue #2988 if he knows of/has found this error on any other pages.