### PR TITLE
Update response-actions-windows-defender-advanced-threat-protection.md, issue #2943

### DIFF
--- a/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
@@ -31,7 +31,7 @@ ms.date: 11/12/2017
 You can take response actions on machines and files to quickly respond to detected attacks so that you can contain or reduce and prevent further damage caused by malicious attackers in your organization.
 
 >[!NOTE]
-> These response actions are only available for machines on Windows 10 (version  1703 or higher), Windows Server 1803 and Windows Server 2019.
+> The machine related response actions are only available for machines on Windows 10 (version 1703 or higher), Windows Server, version 1803 and Windows Server 2019.
 
 ## In this section
 Topic | Description

--- a/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
@@ -30,9 +30,6 @@ ms.date: 11/12/2017
 
 You can take response actions on machines and files to quickly respond to detected attacks so that you can contain or reduce and prevent further damage caused by malicious attackers in your organization.
 
->[!NOTE]
-> These response actions are only available for machines on Windows 10, version  1703 or higher.
-
 ## In this section
 Topic | Description
 :---|:---

--- a/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/response-actions-windows-defender-advanced-threat-protection.md
@@ -30,6 +30,9 @@ ms.date: 11/12/2017
 
 You can take response actions on machines and files to quickly respond to detected attacks so that you can contain or reduce and prevent further damage caused by malicious attackers in your organization.
 
+>[!NOTE]
+> These response actions are only available for machines on Windows 10 (version  1703 or higher), Windows Server 1803 and Windows Server 2019.
+
 ## In this section
 Topic | Description
 :---|:---


### PR DESCRIPTION
issue #2943, remove the "Note" section, as it doesn't make any sense since Windows Defender ATP’s endpoint detection & response is now available for all actual OS (Windows 7 or later for desktops, Windows Server 2012r2 or later for servers).
Source: 
1. [Microsoft finally brings Windows Defender ATP’s endpoint detection & response to Windows 7 and Windows 8.1](https://mspoweruser.com/microsoft-finally-brings-windows-defender-atps-endpoint-detection-response-to-windows-7-and-windows-8-1/)
2. [Protecting Windows Server with Windows Defender ATP](https://techcommunity.microsoft.com/t5/Windows-Defender-ATP/Protecting-Windows-Server-with-Windows-Defender-ATP/ba-p/267114#M128)
