### PR TITLE
Registry Path was Incorrect

### DIFF
--- a/browsers/edge/includes/allow-tab-preloading-include.md
+++ b/browsers/edge/includes/allow-tab-preloading-include.md
@@ -35,8 +35,9 @@ ms:topic: include
 - **Data type:** Integer
 
 #### Registry settings
-- **Path:** HKLM\SOFTWARE\Policies\Microsoft\MicrosoftEdge\TabPreloader
-- **Value name:** AllowTabPreloading
+- **Path:** HKCU\SOFTWARE\Policies\Microsoft\MicrosoftEdge\Main
+- **Create Value name:** AllowPrelaunch
 - **Value type:** REG_DWORD
+- **DWORD Value:** 1
 
 <hr>


### PR DESCRIPTION
Registry path for file TabPreloader was missing and location was not correct. I have updated the values. 

Problem:https://github.com/MicrosoftDocs/windows-itpro-docs/issues/2342