### PR TITLE
NT SERVICE\WdiServiceHost was missing in Doc

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/profile-system-performance.md
+++ b/windows/security/threat-protection/security-policy-settings/profile-system-performance.md
@@ -44,7 +44,7 @@ Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Use
 
 ### Default values
 
-By default this setting is Administrators and NT SERVICE\WdiServiceHost on domain controllers and on stand-alone servers.
+By default, this setting is Administrators and NT SERVICE\WdiServiceHost on domain controllers and on stand-alone servers.
 
 The following table lists the actual and effective default policy values for the most recent supported versions of Windows. Default values are also listed on the policy’s property page.
 

--- a/windows/security/threat-protection/security-policy-settings/profile-system-performance.md
+++ b/windows/security/threat-protection/security-policy-settings/profile-system-performance.md
@@ -44,7 +44,7 @@ Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Use
 
 ### Default values
 
-By default this setting is Administrators on domain controllers and on stand-alone servers.
+By default this setting is Administrators and NT SERVICE\WdiServiceHost on domain controllers and on stand-alone servers.
 
 The following table lists the actual and effective default policy values for the most recent supported versions of Windows. Default values are also listed on the policy’s property page.
 


### PR DESCRIPTION
The default value for this policy is Administrators and NT SERVICE\WdiServiceHost where as NT SERVICE\WdiServiceHost was missing in the doc. I have updated the doc accordingly.