### PR TITLE
Deployment/Update: netsh winsock reset command order correction

### DIFF
--- a/windows/deployment/update/windows-update-resources.md
+++ b/windows/deployment/update/windows-update-resources.md
@@ -106,7 +106,7 @@ The following resources provide additional information about using Windows Updat
    - regsvr32.exe wuwebv.dll 
 7. Reset Winsock. To do this, type the following command at a command prompt, and then press ENTER:  
    ```
-   netsh reset winsock 
+   netsh winsock reset 
    ```
 8. If you are running Windows XP or Windows Server 2003, you have to set the proxy settings. To do this, type the following command at a command prompt, and then press ENTER:  
    ```


### PR DESCRIPTION
The correct order of the command `netsh winsock reset` is required.
The argument 'winsock' is the **context** and can not be rearranged.
In this context, 'reset' is the parameter to the context, not the context itself.
The correct command / context order is unchanged since Windows 2000.

Current order in the example is incorrect and needs to be amended:

-  `netsh reset winsock` does not work, it returns an error message.
-  `netsh winsock reset` is the correct order of context and parameter.

Closes #3157
Closes #3193 (if not closed already)