### PR TITLE
Update credential-guard-manage.md

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard-manage.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-manage.md
@@ -128,8 +128,7 @@ DG_Readiness_Tool_v3.5.ps1 -Ready
 ```
 
 > [!NOTE]
-
-For client machines that are running Windows 10 1703, LsaIso.exe is running whenever virtualization-based security is enabled for other features.
+> For client machines that are running Windows 10 1703, LsaIso.exe is running whenever virtualization-based security is enabled for other features.
 
 -   We recommend enabling Windows Defender Credential Guard before a device is joined to a domain. If Windows Defender Credential Guard is enabled after domain join, the user and device secrets may already be compromised. In other words, enabling Credential Guard will not help to secure a device or identity that has already been compromised, which is why we recommend turning on Credential Guard as early as possible.
 

--- a/windows/security/identity-protection/credential-guard/credential-guard-manage.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-manage.md
@@ -20,6 +20,7 @@ ms.date: 03/01/2019
 **Applies to**
 -   Windows 10
 -   Windows Server 2016
+-   Windows Server 2019
 
 Prefer video? See [Windows Defender Credential Guard Deployment](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=sRcyvLJyC_3304300474) in the Deep Dive into Windows Defender Credential Guard video series.
 
@@ -150,13 +151,14 @@ To disable Windows Defender Credential Guard, you can use the following set of p
 1.  If you used Group Policy, disable the Group Policy setting that you used to enable Windows Defender Credential Guard (**Computer Configuration** -&gt; **Administrative Templates** -&gt; **System** -&gt; **Device Guard** -&gt; **Turn on Virtualization Based Security**).
 2.  Delete the following registry settings:
     - HKEY\_LOCAL\_MACHINE\\System\\CurrentControlSet\\Control\\LSA\LsaCfgFlags
+    - HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\Windows\\DeviceGuard\\LsaCfgFlags
+3.  If you also wish to disable virtualization-based security delete the following registry settings:
     - HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\Windows\\DeviceGuard\\EnableVirtualizationBasedSecurity
     - HKEY\_LOCAL\_MACHINE\\Software\\Policies\\Microsoft\\Windows\\DeviceGuard\\RequirePlatformSecurityFeatures
-
     > [!IMPORTANT]
     > If you manually remove these registry settings, make sure to delete them all. If you don't remove them all, the device might go into BitLocker recovery.
 
-3.  Delete the Windows Defender Credential Guard EFI variables by using bcdedit. From an elevated command prompt, type the following commands:
+4.  Delete the Windows Defender Credential Guard EFI variables by using bcdedit. From an elevated command prompt, type the following commands:
 
     ``` syntax
     mountvol X: /s
@@ -164,18 +166,20 @@ To disable Windows Defender Credential Guard, you can use the following set of p
     bcdedit /create {0cb3b571-2f2e-4343-a879-d86a476d7215} /d "DebugTool" /application osloader
     bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} path "\EFI\Microsoft\Boot\SecConfig.efi"
     bcdedit /set {bootmgr} bootsequence {0cb3b571-2f2e-4343-a879-d86a476d7215}
-    bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} loadoptions DISABLE-LSA-ISO,DISABLE-VBS
+    bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} loadoptions DISABLE-LSA-ISO
     bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} device partition=X:
-    bcdedit /set hypervisorlaunchtype off
     mountvol X: /d
     ```
 
-2.  Restart the PC.
-3.  Accept the prompt to disable Windows Defender Credential Guard.
-4.  Alternatively, you can disable the virtualization-based security features to turn off Windows Defender Credential Guard.
+5.  Restart the PC.
+6.  Accept the prompt to disable Windows Defender Credential Guard.
+7.  Alternatively, you can disable the virtualization-based security features to turn off Windows Defender Credential Guard.
 
 > [!NOTE]
-> The PC must have one-time access to a domain controller to decrypt content, such as files that were encrypted with EFS. If you want to turn off both Windows Defender Credential Guard and virtualization-based security, run the following bcdedit command after turning off all virtualization-based security Group Policy and registry settings: bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} loadoptions DISABLE-LSA-ISO,DISABLE-VBS
+> The PC must have one-time access to a domain controller to decrypt content, such as files that were encrypted with EFS. If you want to turn off both Windows Defender Credential Guard and virtualization-based security, run the following bcdedit commands after turning off all virtualization-based security Group Policy and registry settings:
+
+    bcdedit /set {0cb3b571-2f2e-4343-a879-d86a476d7215} loadoptions DISABLE-LSA-ISO,DISABLE-VBS
+    bcdedit /set vsmlaunchtype off
 
 > [!NOTE]
 > Credential Guard and Device Guard are not currently supported when using Azure IaaS VMs. These options will be made available with future Gen 2 VMs.


### PR DESCRIPTION
Added Server 2019
Added registry key for disabling Credential Guard
Separated the process for disabling Credential Guard from virtualization-based security
Changed bcdedit entries to vsmlaunchtype instead of hypervisorlaunchtype, as this would avoid disabling a hypervisor if already in use.