### PR TITLE
Minor typo correction in enable-attack-surface-reduction.md

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
@@ -17,7 +17,7 @@ ms.author: v-anbic
 
 [Attack surface reduction rules](attack-surface-reduction-exploit-guard.md) help prevent actions and apps that malware often uses to infect computers. You can set attack surface reduction rules for computers running Windows 10 or Windows Server 2019. 
 
-To use ASR rules, you need either a Windows 10 Enterprise E3 or E5 license. We recommend an E5 license so you can take advantage of the advanced monitoring and reporting capabilities available in Windows Defender Advanced Threat Protection (Windows Defender ATP). These advanced capabilities aren't available with an E3 license, but you can develop your own monitoring and reporting tools to use in conjuction with ASR rules.
+To use ASR rules, you need either a Windows 10 Enterprise E3 or E5 license. We recommend an E5 license so you can take advantage of the advanced monitoring and reporting capabilities available in Windows Defender Advanced Threat Protection (Windows Defender ATP). These advanced capabilities aren't available with an E3 license, but you can develop your own monitoring and reporting tools to use in conjunction with ASR rules.
 
 ## Exclude files and folders from ASR rules
 


### PR DESCRIPTION
**Change proposed:**
- `conjuction` => conjunction

Ref. #3170 (previous attempt)

BTW: Would it be useful to change "admins" to "local administrators" in the paragraph shown below, or is the current wording enough to cover the factual meaning as is?
> The rule **Block executable files from running unless they meet a prevalence, age, or trusted list criterion** with GUID 01443614-cd74-433a-b99e-2ecdc07bfc25 is owned by Microsoft and is not specified by admins.