### PR TITLE
Restore broken link in windows-analytics-FAQ-troubleshooting.md

### DIFF
--- a/windows/deployment/update/windows-analytics-FAQ-troubleshooting.md
+++ b/windows/deployment/update/windows-analytics-FAQ-troubleshooting.md
@@ -53,7 +53,7 @@ If you've followed the steps in the [Enrolling devices in Windows Analytics](win
 
 In Log Analytics, go to **Settings > Connected sources > Windows telemetry** and verify that you are subscribed to the Windows Analytics solutions you intend to use.
 
-Even though devices can take 2-3 days after enrollment to show up due to latency in the system, you can now verify the status of your devices with a few hours of running the deployment script as described in [You can now check on the status of your computers within hours of running the deployment script](https://blogs.technet.microsoft.com/upgradeanalytics/2017/05/12/wheres-my-data/) on the Windows Analytics blog.
+Even though devices can take 2-3 days after enrollment to show up due to latency in the system, you can now verify the status of your devices with a few hours of running the deployment script as described in [You can now check on the status of your computers within hours of running the deployment script](https://techcommunity.microsoft.com/t5/Windows-Analytics-Blog/You-can-now-check-on-the-status-of-your-computers-within-hours/ba-p/187213) on the Windows Analytics blog.
 
 >[!NOTE]
 > If you generate the status report and get an error message saying "Sorry! We’re not recognizing your Commercial Id," go to **Settings > Connected sources > Windows telemetry** remove the Upgrade Readiness solution, and then re-add it.


### PR DESCRIPTION
**Description:**

The Windows Analytics blog page
 "[You can now check on the status of your computers within hours of running the deployment script](https://blogs.technet.microsoft.com/upgradeanalytics/2017/05/12/wheres-my-data/)" is reported as a Broken Link in issue ticket #3211, because the page has been moved from blogs.technet.microsoft.com to techcommunity.microsoft.com and can be found at

- https://techcommunity.microsoft.com/t5/Windows-Analytics-Blog/You-can-now-check-on-the-status-of-your-computers-within-hours/ba-p/187213

**Proposed change:**

Restore the blog page link by replacing the old link with the new one (shown above).

Closes #3211