### PR TITLE
Inactive machines: typo correction - support ticket ticket

### DIFF
--- a/windows/security/threat-protection/windows-defender-atp/fix-unhealhty-sensors-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/fix-unhealhty-sensors-windows-defender-advanced-threat-protection.md
@@ -49,7 +49,7 @@ If the machine was offboarded it will still appear in machines list. After 7 day
 If the machine is not sending any signals for more than 7 days to any of the Windows Defender ATP channels for any reason including conditions that fall under misconfigured machines classification, a machine can be considered inactive. 
 
 
-Do you expect a machine to be in ‘Active’ status? [Open a support ticket ticket](https://support.microsoft.com/getsupport?wf=0&tenant=ClassicCommercial&oaspworkflow=start_1.0.0.0&locale=en-us&supportregion=en-us&pesid=16055&ccsid=636206786382823561).
+Do you expect a machine to be in ‘Active’ status? [Open a support ticket](https://support.microsoft.com/getsupport?wf=0&tenant=ClassicCommercial&oaspworkflow=start_1.0.0.0&locale=en-us&supportregion=en-us&pesid=16055&ccsid=636206786382823561).
 
 ## Misconfigured machines
 Misconfigured machines can further be classified to:


### PR DESCRIPTION
**Current behaviour:**

On the page "**[Fix unhealthy sensors in Windows Defender ATP](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-atp/fix-unhealhty-sensors-windows-defender-advanced-threat-protection)**", under the section "**[Inactive machines](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-atp/fix-unhealhty-sensors-windows-defender-advanced-threat-protection#inactive-machines)**", the link text to open a support ticket with Microsoft Support reads as follows:

> Do you expect a machine to be in ‘Active’ status? [Open a support ticket ticket.](https://support.microsoft.com/getsupport?wf=0&tenant=ClassicCommercial&oaspworkflow=start_1.0.0.0&locale=en-us&supportregion=en-us&pesid=16055&ccsid=636206786382823561)

**Proposed change:**

Simplify the link text "Open a support ticket ticket." by removing one occurrence of "ticket",
making it read simply "Open a support ticket."

Closes #3258