### PR TITLE
Corrected UseProxyForLocalAddresses error

### DIFF
--- a/windows/client-management/mdm/networkproxy-csp.md
+++ b/windows/client-management/mdm/networkproxy-csp.md
@@ -76,8 +76,8 @@ The data type is string. Supported operations are Get and Replace. Starting in W
 Specifies whether the proxy server should be used for local (intranet) addresses. 
 Valid values:
 <ul>
-<li>0 (default) - Do not use proxy server for local addresses</li>
-<li>1 - Use proxy server for local addresses</li>
+<li>0 (default) - Use proxy server for local addresses</li>
+<li>1 - Do not use proxy server for local addresses</li>
 </ul>
 
 The data type is int. Supported operations are Get and Replace. Starting in Window 10, version 1803, the Delete operation is also supported.


### PR DESCRIPTION
Switched definitions of 0 and 1 for UseProxyForLocalAddresses (should be 0 use proxy for local, 1 means don't).