### PR TITLE
Surface Hub: note for creating accounts using EAC

### DIFF
--- a/devices/surface-hub/create-a-device-account-using-office-365.md
+++ b/devices/surface-hub/create-a-device-account-using-office-365.md
@@ -218,7 +218,7 @@ In order to enable Skype for Business, your environment will need to meet the fo
 ## <a href="" id="create-device-acct-eac"></a>Create a device account using the Exchange Admin Center
 
 >[!NOTE]
-> This method will only work if you are syncing from an on-premises Active Directory.
+>This method will only work if you are syncing from an on-premises Active Directory.
 
 You can use the Exchange Admin Center to create a device account:
 

--- a/devices/surface-hub/create-a-device-account-using-office-365.md
+++ b/devices/surface-hub/create-a-device-account-using-office-365.md
@@ -217,6 +217,8 @@ In order to enable Skype for Business, your environment will need to meet the fo
 
 ## <a href="" id="create-device-acct-eac"></a>Create a device account using the Exchange Admin Center
 
+>[!NOTE]
+>This method will only work if you have an on-premises Active Directory that you are syncing from.
 
 You can use the Exchange Admin Center to create a device account:
 

--- a/devices/surface-hub/create-a-device-account-using-office-365.md
+++ b/devices/surface-hub/create-a-device-account-using-office-365.md
@@ -218,7 +218,7 @@ In order to enable Skype for Business, your environment will need to meet the fo
 ## <a href="" id="create-device-acct-eac"></a>Create a device account using the Exchange Admin Center
 
 >[!NOTE]
->This method will only work if you have an on-premises Active Directory that you are syncing from.
+> This method will only work if you are syncing from an on-premises Active Directory.
 
 You can use the Exchange Admin Center to create a device account:
 


### PR DESCRIPTION
**Description:**

According to user feedback, using the Exchange Admin Center to create Surface Hub device user accounts requires on-premises Active Directory to synchronize from, for that method to work.

**Change proposed:**

Add a note saying
> **This method will only work if you are syncing from an on-premises Active Directory.**

directly below the header title of the second section.

***
Closes #3295