### PR TITLE
Windows Autopilot: WDAP/WPAD typo correction

### DIFF
--- a/windows/deployment/windows-autopilot/user-driven-hybrid.md
+++ b/windows/deployment/windows-autopilot/user-driven-hybrid.md
@@ -32,7 +32,7 @@ To perform a user-driven hybrid AAD joined deployment using Windows Autopilot:
 - The device must be connected to the Internet and have access to an Active Directory domain controller.
 - The Intune Connector for Active Directory must be installed.
     - Note: The Intune Connector will perform an on-prem AD join, therefore users do not need on-prem AD-join permission, assuming the Connector is [configured to perform this action](https://docs.microsoft.com/intune/windows-autopilot-hybrid#increase-the-computer-account-limit-in-the-organizational-unit) on the user's behalf. 
-- If using Proxy, WDAP Proxy settings option must be enabled and configured.
+- If using Proxy, WPAD Proxy settings option must be enabled and configured.
 
 **AAD device join**: The hybrid AAD join process uses the system context to perform device AAD join, therefore it is not affected by user based AAD join permission settings. In addition, all users are enabled to join devices to AAD by default.
 


### PR DESCRIPTION
**Proposed change:**

Simple typo correction:
- WPAD (Web Proxy Auto-Discovery) was misspelled as WDAP

Closes #3283