### PR TITLE
Mobile Device Management: duplicate entry in XSD

### DIFF
--- a/windows/client-management/mdm/vpnv2-profile-xsd.md
+++ b/windows/client-management/mdm/vpnv2-profile-xsd.md
@@ -132,7 +132,7 @@ Here's the XSD for the ProfileXML node in VPNv2 CSP for Windows 10 and some pro
               <xs:element name="NativeProtocolType" type="xs:string" minOccurs="0" maxOccurs="1"/>
               <xs:element name="L2tpPsk" type="xs:string" minOccurs="0" maxOccurs="1"/>
               <xs:element name="DisableClassBasedDefaultRoute" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-              <xs:element maxOccurs="unbounded" name="CryptographySuite"minOccurs="0" maxOccurs="1">
+              <xs:element name="CryptographySuite" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                   <xs:sequence>
                     <xs:element name="AuthenticationTransformConstants" type="xs:string" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
**Changes proposed:**

- Remove duplicate entry in the XSD for the ProfileXML node in VPNv2 CSP
- Add 1 space before `minOccurs=` in the same line

**Affected pages:**

- https://docs.microsoft.com/en-us/windows/client-management/mdm/vpnv2-profile-xsd
- https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/client-management/mdm/vpnv2-profile-xsd.md

**Description:**

XSD XML lines can contain the elements
- name
- minOccurs
- maxOccurs

These elements can alter between having the values 0, 1 or unbounded, but can only appear once in each XSD XML element line.

**Caveat:**

I need feedback & verification regarding the correct value for `maxOccurs` in this instance;
`"1"` and `"unbounded"` are both valid values, but I don't know which is the correct one.

Closes #1950