### PR TITLE
Fix typo in one header

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-how-it-works-provisioning.md
+++ b/windows/security/identity-protection/hello-for-business/hello-how-it-works-provisioning.md
@@ -56,7 +56,7 @@ Windows Hello for Business provisioning enables a user to enroll a new, strong, 
 |C | The application sends the ADRS token, ukpub, attestation data, and device information to ADRS for user key registration.  Azure DRS validates MFA claim remains current.  On successful validation, Azure DRS locates the user's object in Azure Active Directory, writes the key information to a multi-values attribute. The key information includes a reference to the device from which it was created. Azure Active Directory returns key ID to the application which signals the end of user provisioning and the application exits.|
 
 [Return to top](#windows-hello-for-business-provisioning)
-## Hybrid Azure AD joined provisioning in a Key Trust deployment in a Managed envrionment
+## Hybrid Azure AD joined provisioning in a Key Trust deployment in a Managed environment
 ![Hybrid Azure AD joined provisioning in a Key Trust deployment in a Managed ennvironment](images/howitworks/prov-haadj-keytrust-managed.png)
 
 | Phase  | Description  |


### PR DESCRIPTION
Fix typo in the header for "Hybrid Azure AD joined provisioning in a Key Trust deployment in a Managed environment"

Link at the top of the article to that header was not working due to the typo.