### PR TITLE
Remove reference to Microsoft Virtual Academy training video

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard-manage.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-manage.md
@@ -22,7 +22,6 @@ ms.date: 03/01/2019
 -   Windows Server 2016
 
 
-
 ## Enable Windows Defender Credential Guard
 Windows Defender Credential Guard can be enabled either by using [Group Policy](#enable-credential-guard-by-using-group-policy), the [registry](#enable-credential-guard-by-using-the-registry), or the Windows Defender Device Guard and Windows Defender Credential Guard [hardware readiness tool](#hardware-readiness-tool). Windows Defender Credential Guard can also protect secrets in a Hyper-V virtual machine, just as it would on a physical machine.
 The same set of procedures used to enable Windows Defender Credential Guard on physical machines applies also to virtual machines.

--- a/windows/security/identity-protection/credential-guard/credential-guard-manage.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-manage.md
@@ -21,7 +21,7 @@ ms.date: 03/01/2019
 -   Windows 10
 -   Windows Server 2016
 
-Prefer video? See [Windows Defender Credential Guard Deployment](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=sRcyvLJyC_3304300474) in the Deep Dive into Windows Defender Credential Guard video series.
+
 
 ## Enable Windows Defender Credential Guard
 Windows Defender Credential Guard can be enabled either by using [Group Policy](#enable-credential-guard-by-using-group-policy), the [registry](#enable-credential-guard-by-using-the-registry), or the Windows Defender Device Guard and Windows Defender Credential Guard [hardware readiness tool](#hardware-readiness-tool). Windows Defender Credential Guard can also protect secrets in a Hyper-V virtual machine, just as it would on a physical machine.


### PR DESCRIPTION
I corrected an error in the original pull request and closed the comments, but it does not look like it has been merged. 