### PR TITLE
Defender Exploit guard: update troubleshoot-np.md

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/troubleshoot-np.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/troubleshoot-np.md
@@ -72,11 +72,11 @@ If you've tested the feature with the demo site and with audit mode, and network
 When you report a problem with network protection, you are asked to collect and submit diagnostic data that can be used by Microsoft support and engineering teams to help troubleshoot issues. 
 
 1. Open an elevated command prompt and change to the Windows Defender directory:
-   ```console
+   ```
    cd c:\program files\windows defender
    ```
 2. Run this command to generate the diagnostic logs:
-   ```console
+   ```
    mpcmdrun -getfiles
    ```
 3. By default, they are saved to C:\ProgramData\Microsoft\Windows Defender\Support\MpSupportFiles.cab. Attach the file to the submission form. 


### PR DESCRIPTION
**Description:**

The section **Collect diagnostic data for file submissions**
contains 2 command lines with MarkDown code block fences,
but before this change, they were presumptuously tagged
as ```console instead of only the 3 back ticks.

**Proposed change:**

This MarkDown code works fine on Github, but does not translate correctly 
to the HTML pages on docs.microsoft.com - hence this removal.

Closes #3282