### PR TITLE
Windows/Privacy: URL correction update

### DIFF
--- a/windows/privacy/windows-endpoints-1809-non-enterprise-editions.md
+++ b/windows/privacy/windows-endpoints-1809-non-enterprise-editions.md
@@ -98,7 +98,7 @@ We used the following methodology to derive these network endpoints:
 | *.e-msedge.net	| HTTPS |	Used by OfficeHub to get the metadata of Office apps. |
 | *.g.akamaiedge.net	| HTTPS |	Used to check for updates to maps that have been downloaded for offline use. |
 | *.s-msedge.net	| HTTPS |	Used by OfficeHub to get the metadata of Office apps. |
-| *.tlu.dl.delivery.mp.microsoft.com/* | HTTP | Enables connections to Windows Update. |
+| \*.tlu.dl.delivery.mp.microsoft.com/\* | HTTP | Enables connections to Windows Update. |
 | *geo-prod.dodsp.mp.microsoft.com.nsatc.net	| HTTPS |	Enables connections to Windows Update. |
 | arc.msn.com.nsatc.net	| HTTPS |	Used to retrieve Windows Spotlight metadata. |
 | au.download.windowsupdate.com/* | HTTP | Enables connections to Windows Update. |


### PR DESCRIPTION
**Description:**

This is a follow-up to my previous PR #3305 (Windows/Privacy: change formatting code to text).
I have found one URL that I missed in my previous solution.
> *.tlu.dl.delivery.mp.microsoft.com/*

Thanks to @beerisgood for commenting again in issue #3304, otherwise I would not have noticed the italics in this URL.

**Proposed change:**

This is a 1 line change, making the starting and ending asterisk show up on the page, instead of formatting the text as italics.

**Follow-up to:**

- Microsoft Docs issue ticket #3304 (**Domain misspelling**)
- PR #3305 (**Windows/Privacy: change formatting code to text**)

**Additional notes:**

Addendum: For future web page documentation, it might be a good idea to use the HTML codes `&#42;` + `&#92;` for `*` and `\` respectively, to avoid situations where pages look OK on Github, but not translating well to the docs.microsoft.com pages.

There are many web pages documenting the HTML codes (as well as HTML entity, Unicode & Hex code) for the special characters. I found the site https://www.toptal.com/designers/htmlarrows/punctuation/ to be particularly helpful in my other PR (USMT ScanState Syntax: hidden unescaped characters #3376) where ordinary asterisks and backslashes become misinterpreted and therefore treated as formatting code.
