### PR TITLE
Update set-up-enterprise-mode-portal.md

### DIFF
--- a/browsers/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal.md
@@ -43,7 +43,10 @@ You must download the deployment folder (**EMIEWebPortal/**), which includes all
 
    Installs the npm package manager and bulk adds all the third-party libraries back into your codebase.
 
-6. Go back up a directory, open the solution file **EMIEWebPortal.sln** in Visual Studio, and then build the entire solution.
+6. Go back up a directory, open the solution file **EMIEWebPortal.sln** in Visual Studio, open **Web.config** from **EMIEWebPortal/** folder, and replace MSIT-LOB-COMPAT with your server name hosting your database, replace LOBMerged with your database name, and build the entire solution.
+
+        >[!Note]
+        >Step 3 of this topic provides the steps to create your database.
 
 7. Copy the contents of the **EMIEWebPortal/** folder to a dedicated folder on your file system. For example, _D:\EMIEWebApp_. In a later step, you'll designate this folder as your website in the IIS Manager.
 
@@ -104,17 +107,6 @@ Create a new Application Pool and the website, by using the IIS Manager.
 
     >[!Note]
     >You must also make sure that **Anonymous Authentication** is marked as **Enabled**.
-
-10. Return to the **<<i>website_name</i>> Home** pane, and double-click the **Connection Strings** icon.
-
-11. Open the **LOBMergedEntities Connection String** to edit: 
-
-    - **Data source.** Type the name of your local computer.
-
-    - **Initial catalog.** The name of your database.
-
-        >[!Note]
-        >Step 3 of this topic provides the steps to create your database.
 
 ## Step 3 - Create and prep your database
 Create a SQL Server database and run our custom query to create the Enterprise Mode Site List tables.


### PR DESCRIPTION
In previous doc:

Step 3, following sub-step 10 of To create the website will change the connectionstring to like following:

`<add connectionString="Server=ServerName;Database=DatabaseName;Integrated Security=true" name="LOBMergedEntities" providerName="System.Data.EntityClient" />
`

But for Model first connection string, it should be like following as displayed in Web.config in the project folder. 

`
<add name="LOBMergedEntities" connectionString="metadata=res://*/EMIEDataModel.csdl|res://*/EMIEDataModel.ssdl|res://*/EMIEDataModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=jierong-srv;initial catalog=EMIEDatabase;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient"/>
`

This will introduce data access error, throwing "Keyword not supported: 'server'."

2. The fix is in step 1 - 6, just update server name and database name, then remove the manual setting steps in Step 2.