### PR TITLE
Reboot CSP: sentence end closing HTML tag restored

### DIFF
--- a/windows/client-management/mdm/reboot-csp.md
+++ b/windows/client-management/mdm/reboot-csp.md
@@ -30,7 +30,7 @@ The following diagram shows the Reboot configuration service provider management
 > [!Note]  
 > If this node is set to execute during a sync session, the device will reboot at the end of the sync session.
 
-<p style="margin-left: 20px">The supported operations are Execute and Get.
+<p style="margin-left: 20px">The supported operations are Execute and Get.</p>
 
 <a href="" id="schedule"></a>**Schedule**  
 <p style="margin-left: 20px">The supported operation is Get.</p>


### PR DESCRIPTION
Excerpt from the docs.microsoft.com page before restoring the HTML tag:

> The supported operations are Execute and Get. **Schedule**

Ref. closed issue ticket #3471 (**How to set null**)

**Additional note:**

@MariciaAlforque - do you happen to know the purpose of the non-linking `<a href=` HTML tags in this document?

Example: `<a href="" id="schedule"></a>**Schedule**`
As you can see, the href does not link to anything. 

Is there any other feature used by this type of source code in the document?
- https://docs.microsoft.com/windows/client-management/mdm/reboot-csp
- https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/client-management/mdm/reboot-csp.md