### PR TITLE
provided clearer formatting example for csv file in enable-attack-surface-reduction.md

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
@@ -63,9 +63,13 @@ The following procedures for enabling ASR rules include instructions for how to 
 
 2. In the **Endpoint protection** pane, select **Windows Defender Exploit Guard**, then select **Attack Surface Reduction**. Select the desired setting for each ASR rule.
 
-3. Under **Attack Surface Reduction exceptions**, you can enter individual files and folders, or you can select **Import** to import a CSV file that contains files and folders to exclude from ASR rules. Each line in the CSV file should be in the following format:
-	
-   *C:\folder*, *%ProgramFiles%\folder\file*, *C:\path*	
+3. Under **Attack Surface Reduction exceptions**, you can enter individual files and folders, or you can select **Import** to import a CSV file that contains files and folders to exclude from ASR rules. Each line in the CSV file should be separated by a comma and a carriage return (`\r`), like so:
+
+    > C:\Program Files\Common Files\Services\ContosoApp.exe,  
+    > C:\Users\Admin\Documents And Settings\Reskit.txt,  
+    > C:\Windows\logo.png
+
+    Take care that the whitespace between each file listed includes a carriage return character, and not merely a newline (`\n`).
 
 4. Select **OK** on the three configuration panes and then select **Create** if you're creating a new endpoint protection file or **Save** if you're editing an existing one.
 

--- a/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction.md
@@ -67,9 +67,10 @@ The following procedures for enabling ASR rules include instructions for how to 
 
     > C:\Program Files\Common Files\Services\ContosoApp.exe,  
     > C:\Users\Admin\Documents And Settings\Reskit.txt,  
+    > C:\PerfLogs,  
     > C:\Windows\logo.png
 
-    Take care that the whitespace between each file listed includes a carriage return character, and not merely a newline (`\n`).
+    Take care that the whitespace between each file or folder listed includes a carriage return character, and not merely a newline (`\n`).
 
 4. Select **OK** on the three configuration panes and then select **Create** if you're creating a new endpoint protection file or **Save** if you're editing an existing one.
 


### PR DESCRIPTION
Re: Bug 3267382 on MAX

> Under Enable ASR rules in Intune > Step# 3 > It says: Each line in the CSV file should be in the following format – 
>But the example format is missing. 