### PR TITLE
Updating Domain/ComputerName node info

### DIFF
--- a/windows/client-management/mdm/accounts-csp.md
+++ b/windows/client-management/mdm/accounts-csp.md
@@ -26,9 +26,13 @@ Root node.
 Interior node for the account domain information.
 
 <a href="" id="domain-computername"></a>**Domain/ComputerName**  
-This node specifies the name for a device.  This setting can be managed remotely. A couple of macros can be embedded within the value for dynamic substitution:  %RAND:<# of digits>% and %SERIAL%.  
+This node specifies the DNS hostname for a device. This setting can be managed remotely, but note that this not supported for devices hybrid joined to Azure Active Directory and an on-premises Active directory. The server must explicitly reboot the device for this value to take effect. A couple of macros can be embedded within the value for dynamic substitution. Using any of these macros will limit the new name to 15 characters.
 
-Examples: (a) "Test%RAND:6%" will generate a name "Test" followed by 6 random digits (e.g., "Test123456").  (b) "Foo%SERIAL%", will generate a name "Foo" followed by the serial number derived from device's ID. The server must explicitly reboot the device for this value to take effect.
+Available naming macros:
+|Macro|Description|Example|Generated Name|
+|:---|:---|:---|:---|
+|%RAND:<# of digits>|Generates the specified number of random digits.|Test%RAND:6%|Test123456|
+|%SERIAL%|Generates the serial number derived from the device. If the serial number causes the new name to exceed the 15 character limit, the serial number will be truncated from the beginning of the sequence.|Test-Device-%SERIAL%|Test-Device-456|
 
 Supported operation is Add.
 


### PR DESCRIPTION
Incorporating the following info:

•	This node edits the DNS hostname of the computer.
•	If using the %RAND:x% or %SERIAL% macros, the new name is limited to 15 characters
•	If the serial number generated from the %SERIAL% macro is too long, the serial number will be truncated from the beginning of the serial number sequence, not the end. (e.g. 123ABCDEF456 --> CDEF456)
•	If the new name is a constant string (i.e. not using any of the macros) the new name can be up to 63 characters long
•	Validation for accepted characters are based on the SetComputerNameEx function: https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-setcomputernameexa 
•	This node does not work properly for hybrid-joined AAD/AD devices (it only works for fully AAD joined devices)

I would love feedback and additional edits on how to make the proposed changes more customer-doc-friendly. Thanks!