### PR TITLE
Correction to group policy merge table

### DIFF
--- a/windows/security/threat-protection/auditing/advanced-security-auditing-faq.md
+++ b/windows/security/threat-protection/auditing/advanced-security-auditing-faq.md
@@ -83,7 +83,7 @@ The rules that govern how Group Policy settings are applied propagate to the sub
 | - | - | - | -|
 | Detailed File Share Auditing | Success | Failure | Success |
 | Process Creation Auditing | Disabled | Success | Disabled |
-| Logon Auditing | Success | Failure | Success |
+| Logon Auditing | Failure | Success | Failure |
 
 ## <a href="" id="bkmk-14"></a>What is the difference between an object DACL and an object SACL?
 


### PR DESCRIPTION
Document states

'a logon audit setting that is applied at the OU level will override a conflicting logon audit setting that is applied at the domain level' 

Corrected the table to show so the resulting policy for the target computer is taken from the setting applied at the OU level.