### PR TITLE
replaced whitespace char that displayed incorrectly

### DIFF
--- a/windows/security/threat-protection/windows-defender-atp/machine-tags-windows-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/windows-defender-atp/machine-tags-windows-defender-advanced-threat-protection.md
@@ -33,7 +33,7 @@ You can add tags on machines using the following ways:
 - By setting a registry key value
 - By using the portal
 
-## Add machine tags by setting a registry key value
+## Add machine tags by setting a registry key value
 Add tags on machines which can be used as a filter in Machines list view. You can limit the machines in the list by selecting the Tag filter on the Machines list.
 
 >[!NOTE]


### PR DESCRIPTION
Re: Issue https://github.com/MicrosoftDocs/windows-itpro-docs/issues/3681

Page contained a whitespace char, �, which was not displaying correctly in some browsers, including Edge. Replaced with a standard space.