### PR TITLE
Change "Windows Management Instruction"

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/configuration-management-reference-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/configuration-management-reference-windows-defender-antivirus.md
@@ -26,7 +26,7 @@ You can manage and configure Windows Defender Antivirus with the following tools
 - System Center Configuration Manager
 - Group Policy
 - PowerShell cmdlets
-- Windows Management Instruction (WMI)
+- Windows Management Instrumentation (WMI)
 - The mpcmdrun.exe utility
 
 The topics in this section provide further information, links, and resources for using these tools to manage and configure Windows Defender Antivirus.


### PR DESCRIPTION
Proposing the correct the phrase "Windows Management Instruction" to "Windows Management Instrumentation" to more accurately reflect the proper meaning of the acronym WMI in this context, and to match the rest of the topic's use of "WMI".