### PR TITLE
Windows Hello For Business overview: URL correction

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-overview.md
+++ b/windows/security/identity-protection/hello-for-business/hello-overview.md
@@ -97,7 +97,7 @@ Windows Hello for Business can use either keys (hardware or software) or certifi
 
 ## Learn more
 
-[Implementing Windows Hello for Business at Microsoft](https://www.microsoft.com/itshowcase/Article/Content/830/Implementing-Windows-Hello-for-Business-at-Microsoft)
+[Implementing Windows Hello for Business at Microsoft](https://www.microsoft.com/en-us/itshowcase/implementing-windows-hello-for-business-at-microsoft)
 
 [Introduction to Windows Hello](https://go.microsoft.com/fwlink/p/?LinkId=786649), video presentation on Microsoft Virtual Academy
 


### PR DESCRIPTION
**Description:**

Under the "**Learn more**" section:
- The link to "[Implementing Windows Hello for Business at Microsoft](https://www.microsoft.com/itshowcase/Article/Content/830/Implementing-Windows-Hello-for-Business-at-Microsoft)" no longer points to the correct Showcase page, but goes to the main Showcase page (Showcase portal) instead.

**Proposed change:**

- insert the correct link to the working (en-us only) page (https://www.microsoft.com/en-us/itshowcase/implementing-windows-hello-for-business-at-microsoft)
Unfortunately, there is no localization for this page yet.

Closes #3728