### PR TITLE
attempting to fix broken link re: #3779

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/configure-notifications-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/configure-notifications-windows-defender-antivirus.md
@@ -73,7 +73,7 @@ Hiding notifications can be useful in situations where you can't hide the entire
 > [!NOTE]
 > Hiding notifications will only occur on endpoints to which the policy has been deployed. Notifications related to actions that must be taken (such as a reboot) will still appear on the [System Center Configuration Manager Endpoint Protection monitoring dashboard and reports](https://docs.microsoft.com/sccm/protect/deploy-use/monitor-endpoint-protection).
 
-See [Customize the Windows Security app for your organization](/windows/security/threat-protection/windows-defender-security-center/windows-defender-security-center.md) for instructions to add custom contact information to the notifications that users see on their machines.
+See [Customize the Windows Security app for your organization](../windows-defender-security-center/windows-defender-security-center.md) for instructions to add custom contact information to the notifications that users see on their machines.
 
 **Use Group Policy to hide notifications:**
 


### PR DESCRIPTION
[#3779 - The 'Customize the Windows Security app for your organization' does not resolve](https://github.com/MicrosoftDocs/windows-itpro-docs/issues/3779)

Link to another article in a separate subdirectory was unable to resolve in the published version, but worked fine in the Github file

This is possibly due to the link to the subdirectory pointing to the root rather than to the 2 articles' shared (upper) subdirectory.

I just now tested that the link fix works, by creating a preview build in the private repo. The link resolved correctly.