### PR TITLE
corrected formatting of XML example section

### DIFF
--- a/windows/application-management/app-v/appv-connection-group-virtual-environment.md
+++ b/windows/application-management/app-v/appv-connection-group-virtual-environment.md
@@ -27,7 +27,20 @@ The connection group that is used is based on the order in which a package appea
 Consider the following example section:
 
 ```XML
-<appv:Packages><appv:PackagePackageId="A8731008-4523-4713-83A4-CD1363907160"VersionId="E889951B-7F30-418B-A69C-B37283BC0DB9"/><appv:PackagePackageId="1DC709C8-309F-4AB4-BD47-F75926D04276"VersionId="01F1943B-C778-40AD-BFAD-AC34A695DF3C"/><appv:PackagePackageId="04220DCA-EE77-42BE-A9F5-96FD8E8593F2"VersionId="E15EFFE9-043D-4C01-BC52-AD2BD1E8BAFA"/></appv:Packages>
+<appv:Packages>
+  <appv:Package
+    PackageId="A8731008-4523-4713-83A4-CD1363907160"
+    VersionId="E889951B-7F30-418B-A69C-B37283BC0DB9"
+  />
+  <appv:Package
+    PackageId="1DC709C8-309F-4AB4-BD47-F75926D04276"
+    VersionId="01F1943B-C778-40AD-BFAD-AC34A695DF3C"
+  />
+  <appv:Package
+    PackageId="04220DCA-EE77-42BE-A9F5-96FD8E8593F2"
+    VersionId="E15EFFE9-043D-4C01-BC52-AD2BD1E8BAFA"
+  />
+</appv:Packages>
 ```
 
 Assume that same DWORD value ABC (HKEY\_LOCAL\_MACHINE\\software\\contoso\\finapp\\region) is defined in the first and third package.


### PR DESCRIPTION
In the XML example on this page, the whitespace had been stripped out, so there were no spaces between adjacent attribute values or keys.

This made it hard to read, though the original formatting allowed for a scroll bar, so the text was not running into the side of the page (compare to https://github.com/MicrosoftDocs/windows-itpro-docs/pull/3847 and https://github.com/MicrosoftDocs/windows-itpro-docs/pull/3850, where the uncorrected formatting forced the text to overlap with the side menu).