### PR TITLE
addressing broken links in credential-guard-considerations.md

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard-considerations.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-considerations.md
@@ -22,9 +22,6 @@ ms.reviewer:
 -   Windows 10
 -   Windows Server 2016
 
-Prefer video? See [Credentials Protected by Windows Defender Credential Guard](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=mD3geLJyC_8304300474)
-in the **Deep Dive into Windows Defender Credential Guard** video series.
-
 Passwords are still weak. We recommend that in addition to deploying Windows Defender Credential Guard, organizations move away from passwords to other authentication methods, such as physical smart cards, virtual smart cards, or Windows Hello for Business.
 
 Windows Defender Credential Guard uses hardware security, so some features such as Windows To Go, are not supported.
@@ -99,6 +96,6 @@ When data protected with user DPAPI is unusable, then the user loses access to a
 
 ## See also
 
-**Deep Dive into Windows Defender Credential Guard: Related videos**
+**Related videos**
 
-[Virtualization-based security](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=1CoELLJyC_6704300474)
+[What is virtualization-based security?](https://www.linkedin.com/learning/microsoft-cybersecurity-stack-advanced-identity-and-endpoint-protection/what-is-virtualization-based-security)


### PR DESCRIPTION
Context:
* #3513, MVA is being retired and producing broken links
* #3860 Microsoft Virtual Academy video links

This page contains two links to deprecated video content on Microsoft Virtual Academy (MVA).

MVA is being retired. 

In addition, the Deep Dive course the two links point to is already retired, and no replacement course exists.

I removed the first link, as I could not find a similar video narrowly focused on which credentials are covered by Credential Guard. Most of the related material available now describes how to perform a task.

I replaced the second link with a video containing similar material, though it is not a "deep dive" -- it is quite short.

Suggestions on handling this problem, as many pages contain similar links, would be appreciated.