### PR TITLE
removed link to retired video re: #3867

### DIFF
--- a/windows/security/identity-protection/credential-guard/additional-mitigations.md
+++ b/windows/security/identity-protection/credential-guard/additional-mitigations.md
@@ -611,9 +611,3 @@ write-host $tmp -Foreground Red
 
 > [!NOTE]  
 > If you're having trouble running this script, try replacing the single quote after the ConvertFrom-StringData parameter.
-
-## See also
-
-**Deep Dive into Windows Defender Credential Guard: Related videos**
-
-[Protecting privileged users with Windows Defender Credential Guard](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=JNbjYMJyC_8104300474)


### PR DESCRIPTION
Context:
* #3513, MVA is being retired and producing broken links
* #3867, Dead MVA link 

This page contains a broken link to deprecated video content on Microsoft Virtual Academy (MVA).

MVA is being retired. 

In addition, the Deep Dive course is already retired, and no replacement course exists.

I removed the whole _See Also_ section, as I could not find a replacement video covering how to protect privileged users with Credential Guard. 

The most likely candidate is too short and general: https://www.linkedin.com/learning/cism-cert-prep-1-information-security-governance/privileged-account-management