### PR TITLE
addressing broken mva links, #3817

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard.md
@@ -23,8 +23,6 @@ ms.date: 08/17/2017
 -   Windows 10
 -   Windows Server 2016
 
-Prefer video? See [Credential Theft and Lateral Traversal](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=cfGBPlIyC_9404300474) in the Deep Dive into Windows Defender Credential Guard video series.
-
 Introduced in Windows 10 Enterprise and Windows Server 2016, Windows Defender Credential Guard uses virtualization-based security to isolate secrets so that only privileged system software can access them. Unauthorized access to these secrets can lead to credential theft attacks, such as Pass-the-Hash or Pass-The-Ticket. Windows Defender Credential Guard prevents these attacks by protecting NTLM password hashes, Kerberos Ticket Granting Tickets, and credentials stored by applications as domain credentials.
 
 By enabling Windows Defender Credential Guard, the following features and solutions are provided:
@@ -45,10 +43,3 @@ By enabling Windows Defender Credential Guard, the following features and soluti
 - [What's New in Kerberos Authentication for Windows Server 2012](https://technet.microsoft.com/library/hh831747.aspx)
 - [Authentication Mechanism Assurance for AD DS in Windows Server 2008 R2 Step-by-Step Guide](https://technet.microsoft.com/library/dd378897.aspx)
 - [Trusted Platform Module](/windows/device-security/tpm/trusted-platform-module-overview)
- 
-
-## See also
-
-**Deep Dive into Windows Defender Credential Guard: Related videos**
-
-[Credentials protected by Windows Defender Credential Guard](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=pdc37LJyC_1204300474)


### PR DESCRIPTION
Context:
* #3513, MVA is being retired and producing broken links
* #3817, Another broken link

This page contains two links to deprecated video content on Microsoft Virtual Academy (MVA).

MVA is being retired. 

In addition, the Deep Dive course the two links point to is already retired, and no replacement course exists.

I removed the first link, as we no longer have a video with similar content for a similar audience. The most likely candidate is https://www.linkedin.com/learning/programming-foundations-web-security-2/types-of-credential-attacks, which is more general and for a less technical audience. 

I removed the second link and the _See Also_ section, as I could not find a similar video narrowly focused on which credentials are covered by Credential Guard. Most of the related material available now describes how to perform a task.