### PR TITLE
Addressing dead MVA links, #3818

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard-how-it-works.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-how-it-works.md
@@ -35,14 +35,8 @@ Here's a high-level overview on how the LSA is isolated by using virtualization-
 
 ![Windows Defender Credential Guard overview](images/credguard.png)  
 
-<br>
-
 ## See also
 
-**Deep Dive into Windows Defender Credential Guard: Related videos**
+**Related videos**
 
-[Credential Theft and Lateral Traversal](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=cfGBPlIyC_9404300474)
-
-[Virtualization-based security](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=1CoELLJyC_6704300474)
-
-[Credentials protected by Windows Defender Credential Guard](https://mva.microsoft.com/en-us/training-courses/deep-dive-into-credential-guard-16651?l=pdc37LJyC_1204300474)
+[What is virtualization-based security?](https://www.linkedin.com/learning/microsoft-cybersecurity-stack-advanced-identity-and-endpoint-protection/what-is-virtualization-based-security)


### PR DESCRIPTION
This page, like its fellows in the mva-links label, contains links to a retired video course on a website that is retiring soon.

The links listed by the user in issue #3818 were also on several other pages, related to Credentials Guard. 

These links were addressed in the pull requests #3875, #3872, and #3871

Credentials threat & lateral threat link: removed (see PR #3875 for reasoning) 
Virtualization link: replaced (see #3871 for reasoning)
Credentials protected link: removed (see #3872 for reasoning)