### PR TITLE
Re: #3909 broken pdf link

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/use-apis.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/use-apis.md
@@ -20,7 +20,7 @@ ms.topic: conceptual
 
 # Microsoft Defender ATP APIs
 
-**Applies to:** [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://wincom.blob.core.windows.net/documents/Windows10_Commercial_Comparison.pdf)
+**Applies to:** [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
 
 > Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/en-us/WindowsForBusiness/windows-atp?ocid=docs-wdatp-exposedapis-abovefoldlink) 
 


### PR DESCRIPTION
Top link is broken, #3909 

> The link here does not work:
> Applies to: Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)

The link to the pdf describing MDATP was broken.

Thankfully, [this commit](https://github.com/MicrosoftDocs/windows-itpro-docs/commit/adb1fced13cae6c92a48cd5ee21e90ab20b73db1) updated the same link in many pages some time ago, so I didn't have to go hunting for an equivalent.