### PR TITLE
Windows/Deployment: Notes & Warnings formatting

### DIFF
--- a/windows/deployment/deploy-windows-mdt/create-a-windows-10-reference-image.md
+++ b/windows/deployment/deploy-windows-mdt/create-a-windows-10-reference-image.md
@@ -24,8 +24,8 @@ ms.topic: article
 Creating a reference image is important because that image serves as the foundation for the devices in your organization. In this topic, you will learn how to create a Windows 10 reference image using the Microsoft Deployment Toolkit (MDT). You will create a deployment share, configure rules and settings, and import all the applications and operating system files required to build a Windows 10 reference image. After completing the steps outlined in this topic, you will have a Windows 10 reference image that can be used in your deployment solution.
 For the purposes of this topic, we will use four machines: DC01, MDT01, HV01, and PC0001. DC01 is a domain controller, PC0001 is a Windows 10 Enterprise x64 client, and MDT01 is a Windows Server 2012 R2 standard server. HV01 is a Hyper-V host server, but HV01 could be replaced by PC0001 as long as PC0001 has enough memory and is capable of running Hyper-V. MDT01, HV01, and PC0001 are members of the domain contoso.com for the fictitious Contoso Corporation.
 
->[!NOTE]
->For important details about the setup for the steps outlined in this article, please see [Deploy Windows 10 with the Microsoft Deployment Toolkit](deploy-windows-10-with-the-microsoft-deployment-toolkit.md#proof).
+> [!NOTE]
+> For important details about the setup for the steps outlined in this article, please see [Deploy Windows 10 with the Microsoft Deployment Toolkit](deploy-windows-10-with-the-microsoft-deployment-toolkit.md#proof).
  
 ![figure 1](../images/mdt-08-fig01.png)
 
@@ -80,9 +80,9 @@ This section will show you how to populate the MDT deployment share with the Win
 
 MDT supports adding both full source Windows 10 DVDs (ISOs) and custom images that you have created. In this case, you create a reference image, so you add the full source setup files from Microsoft.
 
->[!NOTE]
->Due to the Windows limits on path length, we are purposely keeping the operating system destination directory short, using the folder name W10EX64RTM rather than a more descriptive name like Windows 10 Enterprise x64 RTM.
- 
+> [!NOTE]
+> Due to the Windows limits on path length, we are purposely keeping the operating system destination directory short, using the folder name W10EX64RTM rather than a more descriptive name like Windows 10 Enterprise x64 RTM.
+
 ### Add Windows 10 Enterprise x64 (full source)
 
 In these steps we assume that you have copied the content of a Windows 10 Enterprise x64 ISO to the **E:\\Downloads\\Windows 10 Enterprise x64** folder.
@@ -120,9 +120,9 @@ By storing configuration items as MDT applications, it is easy to move these obj
 
 In these examples, we assume that you downloaded the software in this list to the E:\\Downloads folder. The first application is added using the UI, but because MDT supports Windows PowerShell, you add the other applications using Windows PowerShell.
 
->[!NOTE]
->All the Microsoft Visual C++ downloads can be found on [The latest supported Visual C++ downloads](https://go.microsoft.com/fwlink/p/?LinkId=619523).
- 
+> [!NOTE]
+> All the Microsoft Visual C++ downloads can be found on [The latest supported Visual C++ downloads](https://go.microsoft.com/fwlink/p/?LinkId=619523).
+
 ### Create the install: Microsoft Office Professional Plus 2013 x86
 
 You can customize Office 2013. In the volume license versions of Office 2013, there is an Office Customization Tool you can use to customize the Office installation. In these steps we assume you have copied the Office 2013 installation files to the E:\\Downloads\\Office2013 folder.
@@ -138,8 +138,8 @@ You also can customize the Office installation using a Config.xml file. But we r
 
     Figure 5. The Install - Microsoft Office 2013 Pro Plus - x86 application properties.
 
-    >[!NOTE]
-    >If you don't see the Office Products tab, verify that you are using a volume license version of Office. If you are deploying Office 365, you need to download the Admin folder from Microsoft.
+    > [!NOTE]
+    > If you don't see the Office Products tab, verify that you are using a volume license version of Office. If you are deploying Office 365, you need to download the Admin folder from Microsoft.
      
 3.  In the Office Customization Tool dialog box, select the Create a new Setup customization file for the following product option, select the Microsoft Office Professional Plus 2013 (32-bit) product, and click OK.
 4.  Use the following settings to configure the Office 2013 setup to be fully unattended:
@@ -160,9 +160,9 @@ You also can customize the Office installation using a Config.xml file. But we r
         -   In the **Microsoft Office 2013** node, expand **Privacy**, select **Trust Center**, and enable the Disable Opt-in Wizard on first run setting.
 5.  From the **File** menu, select **Save**, and save the configuration as 0\_Office2013ProPlusx86.msp in the **E:\\MDTBuildLab\\Applications\\Install - Microsoft Office 2013 Pro Plus - x86\\Updates** folder.
 
-    >[!NOTE]
-    >The reason for naming the file with a 0 (zero) at the beginning is that the Updates folder also handles Microsoft Office updates,          and they are installed in alphabetical order. The Office 2013 setup works best if the customization file is installed before any updates.
-     
+    > [!NOTE]
+    > The reason for naming the file with a 0 (zero) at the beginning is that the Updates folder also handles Microsoft Office updates, and they are installed in alphabetical order. The Office 2013 setup works best if the customization file is installed before any updates.
+
 6.  Close the Office Customization Tool, click Yes in the dialog box, and in the **Install - Microsoft Office 2013 Pro Plus - x86 Properties** window, click **OK**.
 
 ### Connect to the deployment share using Windows PowerShell
@@ -376,11 +376,11 @@ Figure 9. The Windows 10 desktop with the Resume Task Sequence shortcut.
 
 When using MDT, you don't need to edit the Unattend.xml file very often because most configurations are taken care of by MDT. However if, for example, you want to configure Internet Explorer 11 behavior, then you can edit the Unattend.xml for this. Editing the Unattend.xml for basic Internet Explorer settings is easy, but for more advanced settings, you will want to use Internet Explorer Administration Kit (IEAK).
 
->[!WARNING]
->Do not use **SkipMachineOOBE** or **SkipUserOOBE** in your Unattend.xml file. These settings are deprecated and can have unintended effects if used.
+> [!WARNING]
+> Do not use **SkipMachineOOBE** or **SkipUserOOBE** in your Unattend.xml file. These settings are deprecated and can have unintended effects if used.
 
->[!NOTE]
->You also can use the Unattend.xml to enable components in Windows 10, like the Telnet Client or Hyper-V client. Normally we prefer to do this via the **Install Roles and Features** action, or using Deployment Image Servicing and Management (DISM) command-line tools, because then we can add that as an application, being dynamic, having conditions, and so forth. Also, if you are adding packages via Unattend.xml, it is version specific, so Unattend.xml must match the exact version of the operating system you are servicing.
+> [!NOTE]
+> You also can use the Unattend.xml to enable components in Windows 10, like the Telnet Client or Hyper-V client. Normally we prefer to do this via the **Install Roles and Features** action, or using Deployment Image Servicing and Management (DISM) command-line tools, because then we can add that as an application, being dynamic, having conditions, and so forth. Also, if you are adding packages via Unattend.xml, it is version specific, so Unattend.xml must match the exact version of the operating system you are servicing.
  
 Follow these steps to configure Internet Explorer settings in Unattend.xml for the Windows 10 Enterprise x64 RTM Default Image task sequence:
 
@@ -460,9 +460,9 @@ For that reason, add only a minimal set of rules to Bootstrap.ini, such as which
 
     Figure 12. The boot image rules for the MDT Build Lab deployment share.
 
-    >[!NOTE]
-    >For security reasons, you normally don't add the password to the Bootstrap.ini file; however, because this deployment share is for creating reference image builds only, and should not be published to the production network, it is acceptable to do so in this situation.
-     
+    > [!NOTE]
+    > For security reasons, you normally don't add the password to the Bootstrap.ini file; however, because this deployment share is for creating reference image builds only, and should not be published to the production network, it is acceptable to do so in this situation.
+
 4.  In the **Windows PE** tab, in the **Platform** drop-down list, select **x86**.
 5.  In the **Lite Touch Boot Image Settings** area, configure the following settings:
     1.  Image description: MDT Build Lab x86
@@ -473,9 +473,9 @@ For that reason, add only a minimal set of rules to Bootstrap.ini, such as which
     2.  ISO file name: MDT Build Lab x64.iso
 8.  Click **OK**.
 
->[!NOTE]
->In MDT, the x86 boot image can deploy both x86 and x64 operating systems (except on computers based on Unified Extensible Firmware Interface).
- 
+> [!NOTE]
+> In MDT, the x86 boot image can deploy both x86 and x64 operating systems (except on computers based on Unified Extensible Firmware Interface).
+
 
 ### Update the deployment share
 
@@ -484,9 +484,9 @@ After the deployment share has been configured, it needs to be updated. This is 
 1.  Using the Deployment Workbench, right-click the **MDT Build Lab deployment share** and select **Update Deployment Share**.
 2.  Use the default options for the Update Deployment Share Wizard.
 
->[!NOTE]
->The update process will take 5 to 10 minutes.
- 
+> [!NOTE]
+> The update process will take 5 to 10 minutes.
+
 ### The rules explained
 
 Now that the MDT Build Lab deployment share (the share used to create the reference images) has been configured, it is time to explain the various settings used in the Bootstrap.ini and CustomSettings.ini files.
@@ -495,9 +495,9 @@ The Bootstrap.ini and CustomSettings.ini files work together. The Bootstrap.ini 
 
 The CustomSettings.ini file is normally stored on the server, in the Deployment share\\Control folder, but also can be stored on the media (when using offline media).
 
->[!NOTE]
->The settings, or properties, that are used in the rules (CustomSettings.ini and Bootstrap.ini) are listed in the MDT documentation, in the Microsoft Deployment Toolkit Reference / Properties / Property Definition section.
- 
+> [!NOTE]
+> The settings, or properties, that are used in the rules (CustomSettings.ini and Bootstrap.ini) are listed in the MDT documentation, in the Microsoft Deployment Toolkit Reference / Properties / Property Definition section.
+
 ### The Bootstrap.ini file
 
 The Bootstrap.ini file is available via the deployment share's Properties dialog box, or via the E:\\MDTBuildLab\\Control folder on MDT01.
@@ -518,14 +518,14 @@ So, what are these settings?
 -   **DeployRoot.** This is the location of the deployment share. Normally, this value is set by MDT, but you need to update the DeployRoot value if you move to another server or other share. If you don't specify a value, the Windows Deployment Wizard prompts you for a location.
 -   **UserDomain, UserID, and UserPassword.** These values are used for automatic log on to the deployment share. Again, if they are not specified, the wizard prompts you.
 
-    >[!WARNING]
-    >Caution is advised. These values are stored in clear text on the boot image. Use them only for the MDT Build Lab deployment share and not for the MDT Production deployment share that you learn to create in the next topic.
-     
+    > [!WARNING]
+    > Caution is advised. These values are stored in clear text on the boot image. Use them only for the MDT Build Lab deployment share and not for the MDT Production deployment share that you learn to create in the next topic.
+
 -   **SkipBDDWelcome.** Even if it is nice to be welcomed every time we start a deployment, we prefer to skip the initial welcome page of the Windows Deployment Wizard.
 
->[!NOTE]
->All properties beginning with "Skip" control only whether to display that pane in the Windows Deployment Wizard. Most of the panes also require you to actually set one or more values.
- 
+> [!NOTE]
+> All properties beginning with "Skip" control only whether to display that pane in the Windows Deployment Wizard. Most of the panes also require you to actually set one or more values.
+
 ### The CustomSettings.ini file
 
 The CustomSettings.ini file, whose content you see on the Rules tab of the deployment share Properties dialog box, contains most of the properties used in the configuration.


### PR DESCRIPTION
**Description:**

This page is only able to show the first Note correctly formatted.
11 Note sections and 2 Warning sections are affected.

- https://docs.microsoft.com/en-us/windows/deployment/deploy-windows-mdt/create-a-windows-10-reference-image

Compare with the page "SharedPC CSP" (https://docs.microsoft.com/en-us/windows/client-management/mdm/sharedpc-csp)
where 13 Notes are displayed correctly by including a space between the angle bracket (Less-Than character) and the square bracket.

**Changes proposed:**

This PR only changes the spacing by adding necessary ones and removing a few redundant spaces.