### PR TITLE
How to Move MBAM 2.5 Databases: file name correction

### DIFF
--- a/mdop/mbam-v25/how-to-move-the-mbam-25-databases.md
+++ b/mdop/mbam-v25/how-to-move-the-mbam-25-databases.md
@@ -142,7 +142,7 @@ Stop-Website "Microsoft BitLocker Administration and Monitoring"
 
 ### Move the Recovery Database from Server A to Server B
 
-Use Windows Explorer to move the **MBAM Compliance Status Database Data.bak** file from Server A to Server B.
+Use Windows Explorer to move the **MBAM Recovery Database Data.bak** file from Server A to Server B.
 
 To automate this procedure, you can use Windows PowerShell to run a command that is similar to the following:
 


### PR DESCRIPTION
**Description:**

The file name "MBAM Recovery Database Data.bak" was incorrectly replaced by "MBAM Compliance Status Database Data.bak" in one of the lines describing the procedure.

**Proposed change:**

Copy-Paste error correction: This commit resolves the issue, making the number of occurrences of those 2 file names equal and appropriate for their separate sections in this article page.

**Issue ticket closure or reference:**

Closes #3988