### PR TITLE
Microsoft Store for Business and Education: Typo

### DIFF
--- a/store-for-business/acquire-apps-microsoft-store-for-business.md
+++ b/store-for-business/acquire-apps-microsoft-store-for-business.md
@@ -38,7 +38,7 @@ There are a couple of things we need to know when you pay for apps. You can add 
 ## Allow users to shop
 
 **Allow users to shop** controls the shopping experience in Microsoft Store for Education. When this setting is on, **Purchasers** and **Basic Purchasers** can purchase products and services from Microsoft Store for Education. If your school chooses to closely control how purchases are made, admins can turn off **Allow users to shop**. When the setting is off:
-- The shopping experience is not availalbe 
+- The shopping experience is not available 
 - **Purchasers** and **Basic Purchasers** can't purchase products and services from Microsoft Store for Education
 - Admins can't assign shopping roles to users
 - Products and services previously purchased by **Basic Purchasers** can be managed by admins. 


### PR DESCRIPTION
**Description:**

A typo has been found in [**Acquire apps in Microsoft Store for Business and Education**](https://docs.microsoft.com/en-us/microsoft-store/acquire-apps-microsoft-store-for-business#allow-users-to-shop)

> - The shopping experience is not availalbe

The correct form is **available**.

Closes #4000