### PR TITLE
Include information for behavior when specifying multiple WMI queries…

### DIFF
--- a/windows/security/threat-protection/windows-firewall/create-wmi-filters-for-the-gpo.md
+++ b/windows/security/threat-protection/windows-firewall/create-wmi-filters-for-the-gpo.md
@@ -89,6 +89,8 @@ First, create the WMI filter and configure it to look for a specified version (o
 
 10. Click **Save** to save your completed filter.
 
+** Add further explanation for how multiple WMI queries on the same filter are handled (see notes)
+
 ## To link a WMI filter to a GPO
 
 After you have created a filter with the correct query, link the filter to the GPO. Filters can be reused with many GPOs simultaneously; you do not have to create a new one for each GPO if an existing one meets your needs.


### PR DESCRIPTION
… in the same filter

There seems to be a lot of misinformation in various blogs around the behavior of specifying multiple WMI queries in the same WMI filter.

For example, if I have these two queries on one filter:-

1. Select * from Win32_ComputerSystem WHERE Model = "Optiplex 7060" or Model = "Optiplex 3060"
2. Select * from Win32_OperatingSystem WHERE Version LIKE "10.0.%" and ProductType = "1"

Would both have to return True for the Filter to return True?

An explanation of whether multiple queries on the same filter are treated as AND/OR would be helpful.
Thanks, Ben