### PR TITLE
fix: MD042/no-empty-links

### DIFF
--- a/browsers/internet-explorer/ie11-faq/faq-ie11-blocker-toolkit.md
+++ b/browsers/internet-explorer/ie11-faq/faq-ie11-blocker-toolkit.md
@@ -20,11 +20,11 @@ Get answers to commonly asked questions about the Internet Explorer 11 Blocker T
 >[!Important]
 >If you administer your company’s environment using an update management solution, such as Windows Server Update Services (WSUS) or System Center 2012 Configuration Manager, you don’t need to use the Internet Explorer 11 Blocker Toolkit. Update management solutions let you completely manage your Windows Updates and Microsoft Updates, including your Internet Explorer 11 deployment.
 
--   [Automatic updates delivery process]()
+-   [Automatic updates delivery process](#automatic-updates-delivery-process)
 
--   [How the Internet Explorer 11 Blocker Toolkit works]()
+-   [How the Internet Explorer 11 Blocker Toolkit works](#how-the-internet-explorer-11-blocker-toolkit-works)
 
--   [Internet Explorer 11 Blocker Toolkit and other update services]()
+-   [Internet Explorer 11 Blocker Toolkit and other update services](#internet-explorer-11-blocker-toolkit-and-other-update-services)
 
 ## Automatic Updates delivery process
 
@@ -50,7 +50,7 @@ other update management solution.
 **Q. Why don’t we just block URL access to Windows Update or Microsoft Update?**  
 A. Blocking the Windows Update or Microsoft Update URLs also stops delivery of critical security and reliability updates for all of the supported versions of the Windows operating system; leaving your computers more vulnerable.
 
-How the Internet Explorer 11 Blocker Toolkit works
+## How the Internet Explorer 11 Blocker Toolkit works
 
 **Q. How should I test the Internet Explorer 11 Blocker Toolkit in my company?**  
 A. Because the toolkit only sets a registry key to turn on and off the delivery of Internet Explorer 11, there should be no additional impact or side effects to your environment. No additional testing should be necessary.  

--- a/devices/surface-hub/surface-hub-site-readiness-guide.md
+++ b/devices/surface-hub/surface-hub-site-readiness-guide.md
@@ -89,7 +89,7 @@ The 55” Surface Hub requires two people to safely lift and mount. The 84” Su
 
 ## Mounting and setup
 
-See the your mounting guide at http://www.microsoft.com/surface/support/surface-hub, for detailed instructions. 
+See your mounting guide at http://www.microsoft.com/surface/support/surface-hub for detailed instructions. 
 
 There are three ways to mount your Surface Hub:
 

--- a/devices/surface-hub/surface-hub-site-readiness-guide.md
+++ b/devices/surface-hub/surface-hub-site-readiness-guide.md
@@ -89,7 +89,7 @@ The 55” Surface Hub requires two people to safely lift and mount. The 84” Su
 
 ## Mounting and setup
 
-See the [Technical information]() section, or your mounting guide at http://www.microsoft.com/surface/support/surface-hub, for detailed instructions. 
+See the your mounting guide at http://www.microsoft.com/surface/support/surface-hub, for detailed instructions. 
 
 There are three ways to mount your Surface Hub:
 
@@ -97,7 +97,7 @@ There are three ways to mount your Surface Hub:
 - **Floor support mount**: Supports Surface Hub on the floor while it is permanently anchored to a conference space wall.
 - **Rolling stand**: Supports Surface Hub and lets you move it to other conference locations. For links to guides that provide details about each mounting method, including building requirements, see http://www.microsoft.com/surface/support/surface-hub.
 
-For specifications on available mounts for the original Surfae Hub, see the following:
+For specifications on available mounts for the original Surface Hub, see the following:
 
 - [Surface Hub Mounts and Stands Datasheet](http://download.microsoft.com/download/5/0/1/501F98D9-1BCC-4448-A1DB-47056CEE33B6/20160711_Surface_Hub_Mounts_and_Stands_Datasheet.pdf)
 - [Surface Hub Stand and Wall Mount Specifications](http://download.microsoft.com/download/7/A/7/7A75BD0F-5A46-4BCE-B313-A80E47AEB581/20160720_Combined_Stand_Wall_Mount_Drawings.pdf)

--- a/mdop/TOC.md
+++ b/mdop/TOC.md
@@ -1,21 +1,21 @@
 # [Microsoft Desktop Optimization Pack](index.md)
 ## [Advanced Group Policy Management](agpm/index.md)
-## [Application Virtualization]()
+## Application Virtualization
 ### [Application Virtualization 5](appv-v5/index.md)
 ### [Application Virtualization 4](appv-v4/index.md)
 ### [SoftGrid Application Virtualization](softgrid-application-virtualization.md)
-## [Diagnostics and Recovery Toolset]()
+## Diagnostics and Recovery Toolset
 ### [Diagnostics and Recovery Toolset 10](dart-v10/index.md)
 ### [Diagnostics and Recovery Toolset 8](dart-v8/index.md)
 ### [Diagnostics and Recovery Toolset 7](dart-v7/index.md)
 ### [Diagnostics and Recovery Toolset 6.5](dart-v65.md)
-## [Microsoft Bitlocker Administration and Monitoring]()
+## Microsoft Bitlocker Administration and Monitoring
 ### [Microsoft Bitlocker Administration and Monitoring 2.5](mbam-v25/index.md)
 ### [Microsoft Bitlocker Administration and Monitoring 2](mbam-v2/index.md)
 ### [Microsoft Bitlocker Administration and Monitoring 1](mbam-v1/index.md)
-## [Microsoft Enterprise Desktop Virtualization]()
+## Microsoft Enterprise Desktop Virtualization
 ### [Microsoft Enterprise Desktop Virtualization 2](medv-v2/index.md)
-## [User Experience Virtualization]()
+## User Experience Virtualization
 ### [User Experience Virtualization 2](uev-v2/index.md)
 ### [User Experience Virtualization 1](uev-v1/index.md)
 ## [MDOP Solutions and Scenarios](solutions/index.md)

--- a/mdop/appv-v4/applications-results-pane-in-server-management-console.md
+++ b/mdop/appv-v4/applications-results-pane-in-server-management-console.md
@@ -36,8 +36,6 @@ Organizes the icons in the **Results** pane.
 <a href="" id="help"></a>**Help**  
 Displays the help system for the Application Virtualization Management Console.
 
-[]()  
-
 Right-click any application in the **Results** pane to display a pop-up menu that contains the following elements.
 
 <a href="" id="move"></a>**Move**  

--- a/mdop/appv-v5/app-v-50-security-considerations.md
+++ b/mdop/appv-v5/app-v-50-security-considerations.md
@@ -126,35 +126,3 @@ The following will help you plan how to ensure that virtualized packages are sec
 
 
 During App-V 5.0 Setup, setup log files are created in the **%temp%** folder of the installing user.
-
-[]()  
-
-[]()  
-
-[]()  
-
-[]()  
-
-[]()  
-
-[]()  
-
-[]()  
-
-****
-
-[]()  
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/mdop/appv-v5/how-to-install-the-app-v-databases-and-convert-the-associated-security-identifiers--by-using-powershell.md
+++ b/mdop/appv-v5/how-to-install-the-app-v-databases-and-convert-the-associated-security-identifiers--by-using-powershell.md
@@ -41,332 +41,119 @@ Before attempting this procedure, you should read and understand the information
 
 2. To open a PowerShell console click **Start** and type **PowerShell**. Right-click **Windows PowerShell** and select **Run as Administrator**.
 
-   ``` syntax
+   ```powershell
    <#
-   ```
-
-   ``` syntax
    .SYNOPSIS
-   ```
-
-   ``` syntax
    This PowerShell script will take an array of account names and try to convert each of them to the corresponding SID in standard and hexadecimal formats.
-   ```
 
-   ``` syntax
    .DESCRIPTION
-   ```
-
-   ``` syntax
    This is a PowerShell script that converts any number of Active Directory (AD) user or machine accounts into formatted Security Identifiers (SIDs) both in the standard format and in the hexadecimal format used by SQL server when running SQL scripts.
-   ```
 
-   ``` syntax
    .INPUTS
-   ```
-
-   ``` syntax
    The account(s) to convert to SID format. This can be a single account name or an array of account names. Please see examples below.
-   ```
 
-   ``` syntax
    .OUTPUTS
-   ```
-
-   ``` syntax
    A list of account names with the corresponding SID in standard and hexadecimal formats
-   ```
 
-   ``` syntax
    .EXAMPLE
-   ```
-
-   ``` syntax
    .\ConvertToSID.ps1 DOMAIN\user_account1 DOMAIN\machine_account1$ DOMAIN\user_account2 | Format-List
-   ```
 
-   ``` syntax
    .EXAMPLE
-   ```
-
-   ``` syntax
    $accountsArray = @("DOMAIN\user_account1", "DOMAIN\machine_account1$", "DOMAIN_user_account2")
-   ```
 
-   ``` syntax
    .\ConvertToSID.ps1 $accountsArray | Write-Output -FilePath .\SIDs.txt -Width 200
-   ```
-
-   ``` syntax
    #>
-   ```
 
-   ``` syntax
-   ```
-
-   []()  
-
-   []()  
-
-   ``` syntax
    function ConvertSIDToHexFormat
-   ```
-
    {
+      param([System.Security.Principal.SecurityIdentifier]$sidToConvert)
 
-      param(\[System.Security.Principal.SecurityIdentifier\]$sidToConvert)
-
-   ``` syntax
-   ```
-
-   ``` syntax
       $sb = New-Object System.Text.StringBuilder
-   ```
 
-   ``` syntax
-       [int] $binLength = $sidToConvert.BinaryLength
-   ```
+      [int] $binLength = $sidToConvert.BinaryLength
 
-   ``` syntax
-       [Byte[]] $byteArray = New-Object Byte[] $binLength
-   ```
+      [Byte[]] $byteArray = New-Object Byte[] $binLength
 
-   ``` syntax
       $sidToConvert.GetBinaryForm($byteArray, 0)
-   ```
 
-   ``` syntax
       foreach($byte in $byteArray)
-   ```
-
-   ``` syntax
       {
-   ```
-
-   ``` syntax
-      $sb.Append($byte.ToString("X2")) |Out-Null
-   ```
-
-   ``` syntax
+          $sb.Append($byte.ToString("X2")) |Out-Null
       }
-   ```
-
-   ``` syntax
       return $sb.ToString()
-   ```
-
-   ``` syntax
    }
-   ```
 
-   ``` syntax
-    [string[]]$myArgs = $args
-   ```
+   [string[]]$myArgs = $args
 
-   ``` syntax
+
+
    if(($myArgs.Length -lt 1) -or ($myArgs[0].CompareTo("/?") -eq 0))
-   ```
-
    {
-
-   ``` syntax
-    [string]::Format("{0}====== Description ======{0}{0}" +
-   ```
-
-   ``` syntax
-   "  Converts any number of user or machine account names to string and hexadecimal SIDs.{0}" +
-   ```
-
-   ``` syntax
+       [string]::Format("{0}====== Description ======{0}{0}" +
+                  "  Converts any number of user or machine account names to string and hexadecimal SIDs.{0}" +
                   "  Pass the account(s) as space separated command line parameters. (For example 'ConvertToSID.exe DOMAIN\\Account1 DOMAIN\\Account2 ...'){0}" +
-   ```
-
-   ``` syntax
                   "  The output is written to the console in the format 'Account name    SID as string   SID as hexadecimal'{0}" +
-   ```
-
-   ``` syntax
                   "  And can be written out to a file using standard PowerShell redirection{0}" +
-   ```
-
-   ``` syntax
-                  "  Please specify user accounts in the format 'DOMAIN\username'{0}" + 
-   ```
-
-   ``` syntax
+                  "  Please specify user accounts in the format 'DOMAIN\username'{0}" +
                   "  Please specify machine accounts in the format 'DOMAIN\machinename$'{0}" +
-   ```
-
-   ``` syntax
-                  "  For more help content, please run 'Get-Help ConvertToSID.ps1'{0}" + 
-   ```
-
-   ``` syntax
+                  "  For more help content, please run 'Get-Help ConvertToSID.ps1'{0}" +
                   "{0}====== Arguments ======{0}" +
-   ```
 
-   ``` syntax
-                  "{0}  /?    Show this help message", [Environment]::NewLine) 
-   ```
 
-   ``` syntax
-   {
-   ```
 
-   ``` syntax
+                  "{0}  /?    Show this help message", [Environment]::NewLine)
+   }
    else
-   ```
-
-   ``` syntax
-   {  
+   {
        #If an array was passed in, try to split it
-   ```
-
-   ``` syntax
        if($myArgs.Length -eq 1)
-   ```
-
-   ``` syntax
        {
-   ```
-
-   ``` syntax
            $myArgs = $myArgs.Split(' ')
-   ```
-
-   ``` syntax
        }
-   ```
-
-   ``` syntax
 
        #Parse the arguments for account names
-   ```
-
-   ``` syntax
        foreach($accountName in $myArgs)
-   ```
-
-   ``` syntax
-       {    
-   ```
-
-   ``` syntax
+       {
            [string[]] $splitString = $accountName.Split('\')  # We're looking for the format "DOMAIN\Account" so anything that does not match, we reject
-   ```
 
-   ``` syntax
            if($splitString.Length -ne 2)
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                $message = [string]::Format("{0} is not a valid account name. Expected format 'Domain\username' for user accounts or 'DOMAIN\machinename$' for machine accounts.", $accountName)
-   ```
 
-   ``` syntax
                Write-Error -Message $message
-   ```
-
-   ``` syntax
                continue
-   ```
-
-   ``` syntax
            }
-   ```
 
-   ``` syntax
-            
-   ```
-
-   ``` syntax
            #Convert any account names to SIDs
-   ```
-
-   ``` syntax
            try
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                [System.Security.Principal.NTAccount] $account = New-Object System.Security.Principal.NTAccount($splitString[0], $splitString[1])
-   ```
 
-   ``` syntax
                [System.Security.Principal.SecurityIdentifier] $SID = [System.Security.Principal.SecurityIdentifier]($account.Translate([System.Security.Principal.SecurityIdentifier]))
-   ```
-
-   ``` syntax
            }
-   ```
-
-   ``` syntax
            catch [System.Security.Principal.IdentityNotMappedException]
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                $message = [string]::Format("Failed to translate account object '{0}' to a SID. Please verify that this is a valid user or machine account.", $account.ToString())
-   ```
 
-   ``` syntax
                Write-Error -Message $message
-   ```
 
-   ``` syntax
                continue
-   ```
-
-   ``` syntax
            }
-   ```
-
-   ``` syntax
 
            #Convert regular SID to binary format used by SQL
-   ```
 
-   ``` syntax
            $hexSIDString = ConvertSIDToHexFormat $SID
-   ```
 
-   ``` syntax
-            
            $SIDs = New-Object PSObject
-   ```
 
-   ``` syntax
            $SIDs | Add-Member NoteProperty Account $accountName
-   ```
 
-   ``` syntax
            $SIDs | Add-Member NoteProperty SID $SID.ToString()
-   ```
 
-   ``` syntax
            $SIDs | Add-Member NoteProperty Hexadecimal $hexSIDString
-   ```
-
-   ``` syntax
 
            Write-Output $SIDs
-   ```
-
-   ``` syntax
        }
-   ```
-
-   ``` syntax
    }
    ```
 
@@ -384,12 +171,3 @@ Before attempting this procedure, you should read and understand the information
 
 
 [Administering App-V by Using PowerShell](administering-app-v-by-using-powershell.md)
-
- 
-
- 
-
-
-
-
-

--- a/mdop/appv-v5/how-to-install-the-app-v-databases-and-convert-the-associated-security-identifiers--by-using-powershell51.md
+++ b/mdop/appv-v5/how-to-install-the-app-v-databases-and-convert-the-associated-security-identifiers--by-using-powershell51.md
@@ -3,7 +3,7 @@ title: How to Install the App-V Databases and Convert the Associated Security Id
 description: How to Install the App-V Databases and Convert the Associated Security Identifiers by Using PowerShell
 author: dansimp
 ms.assetid: 2be6fb72-f3a6-4550-bba1-6defa78ca08a
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ms.author: dansimp
 ms.pagetype: mdop, appcompat, virtualization
@@ -41,335 +41,96 @@ Before attempting this procedure, you should read and understand the information
 
 2. To open a PowerShell console click **Start** and type **PowerShell**. Right-click **Windows PowerShell** and select **Run as Administrator**.
 
-   ``` syntax
+   ```powershell
    <#
-   ```
-
-   ``` syntax
    .SYNOPSIS
-   ```
-
-   ``` syntax
    This PowerShell script will take an array of account names and try to convert each of them to the corresponding SID in standard and hexadecimal formats.
-   ```
-
-   ``` syntax
    .DESCRIPTION
-   ```
-
-   ``` syntax
    This is a PowerShell script that converts any number of Active Directory (AD) user or machine accounts into formatted Security Identifiers (SIDs) both in the standard format and in the hexadecimal format used by SQL server when running SQL scripts.
-   ```
-
-   ``` syntax
    .INPUTS
-   ```
-
-   ``` syntax
    The account(s) to convert to SID format. This can be a single account name or an array of account names. Please see examples below.
-   ```
-
-   ``` syntax
    .OUTPUTS
-   ```
-
-   ``` syntax
    A list of account names with the corresponding SID in standard and hexadecimal formats
-   ```
-
-   ``` syntax
    .EXAMPLE
-   ```
-
-   ``` syntax
    .\ConvertToSID.ps1 DOMAIN\user_account1 DOMAIN\machine_account1$ DOMAIN\user_account2 | Format-List
-   ```
-
-   ``` syntax
    .EXAMPLE
-   ```
-
-   ``` syntax
    $accountsArray = @("DOMAIN\user_account1", "DOMAIN\machine_account1$", "DOMAIN_user_account2")
-   ```
-
-   ``` syntax
    .\ConvertToSID.ps1 $accountsArray | Write-Output -FilePath .\SIDs.txt -Width 200
-   ```
-
-   ``` syntax
    #>
-   ```
 
-   ``` syntax
-   ```
-
-   []()  
-
-   []()  
-
-   ``` syntax
    function ConvertSIDToHexFormat
-   ```
-
    {
 
       param(\[System.Security.Principal.SecurityIdentifier\]$sidToConvert)
 
-   ``` syntax
-   ```
-
-   ``` syntax
       $sb = New-Object System.Text.StringBuilder
-   ```
-
-   ``` syntax
-       [int] $binLength = $sidToConvert.BinaryLength
-   ```
-
-   ``` syntax
-       [Byte[]] $byteArray = New-Object Byte[] $binLength
-   ```
-
-   ``` syntax
+      [int] $binLength = $sidToConvert.BinaryLength
+      [Byte[]] $byteArray = New-Object Byte[] $binLength
       $sidToConvert.GetBinaryForm($byteArray, 0)
-   ```
-
-   ``` syntax
       foreach($byte in $byteArray)
-   ```
-
-   ``` syntax
       {
-   ```
-
-   ``` syntax
-      $sb.Append($byte.ToString("X2")) |Out-Null
-   ```
-
-   ``` syntax
+          $sb.Append($byte.ToString("X2")) |Out-Null
       }
-   ```
-
-   ``` syntax
       return $sb.ToString()
-   ```
-
-   ``` syntax
    }
-   ```
-
-   ``` syntax
     [string[]]$myArgs = $args
-   ```
-
-   ``` syntax
    if(($myArgs.Length -lt 1) -or ($myArgs[0].CompareTo("/?") -eq 0))
-   ```
-
    {
 
-   ``` syntax
     [string]::Format("{0}====== Description ======{0}{0}" +
-   ```
-
-   ``` syntax
-   "  Converts any number of user or machine account names to string and hexadecimal SIDs.{0}" +
-   ```
-
-   ``` syntax
+                  "  Converts any number of user or machine account names to string and hexadecimal SIDs.{0}" +
                   "  Pass the account(s) as space separated command line parameters. (For example 'ConvertToSID.exe DOMAIN\\Account1 DOMAIN\\Account2 ...'){0}" +
-   ```
-
-   ``` syntax
                   "  The output is written to the console in the format 'Account name    SID as string   SID as hexadecimal'{0}" +
-   ```
-
-   ``` syntax
                   "  And can be written out to a file using standard PowerShell redirection{0}" +
-   ```
-
-   ``` syntax
-                  "  Please specify user accounts in the format 'DOMAIN\username'{0}" + 
-   ```
-
-   ``` syntax
+                  "  Please specify user accounts in the format 'DOMAIN\username'{0}" +
                   "  Please specify machine accounts in the format 'DOMAIN\machinename$'{0}" +
-   ```
-
-   ``` syntax
-                  "  For more help content, please run 'Get-Help ConvertToSID.ps1'{0}" + 
-   ```
-
-   ``` syntax
+                  "  For more help content, please run 'Get-Help ConvertToSID.ps1'{0}" +
                   "{0}====== Arguments ======{0}" +
-   ```
-
-   ``` syntax
-                  "{0}  /?    Show this help message", [Environment]::NewLine) 
-   ```
-
-   ``` syntax
-   {
-   ```
-
-   ``` syntax
+                  "{0}  /?    Show this help message", [Environment]::NewLine)
+   }
    else
-   ```
-
-   ``` syntax
-   {  
+   {
        #If an array was passed in, try to split it
-   ```
-
-   ``` syntax
        if($myArgs.Length -eq 1)
-   ```
-
-   ``` syntax
        {
-   ```
-
-   ``` syntax
            $myArgs = $myArgs.Split(' ')
-   ```
-
-   ``` syntax
        }
-   ```
-
-   ``` syntax
 
        #Parse the arguments for account names
-   ```
-
-   ``` syntax
        foreach($accountName in $myArgs)
-   ```
-
-   ``` syntax
-       {    
-   ```
-
-   ``` syntax
+       {
            [string[]] $splitString = $accountName.Split('\')  # We're looking for the format "DOMAIN\Account" so anything that does not match, we reject
-   ```
-
-   ``` syntax
            if($splitString.Length -ne 2)
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                $message = [string]::Format("{0} is not a valid account name. Expected format 'Domain\username' for user accounts or 'DOMAIN\machinename$' for machine accounts.", $accountName)
-   ```
-
-   ``` syntax
                Write-Error -Message $message
-   ```
-
-   ``` syntax
                continue
-   ```
-
-   ``` syntax
            }
-   ```
 
-   ``` syntax
-            
-   ```
-
-   ``` syntax
            #Convert any account names to SIDs
-   ```
-
-   ``` syntax
            try
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                [System.Security.Principal.NTAccount] $account = New-Object System.Security.Principal.NTAccount($splitString[0], $splitString[1])
-   ```
-
-   ``` syntax
                [System.Security.Principal.SecurityIdentifier] $SID = [System.Security.Principal.SecurityIdentifier]($account.Translate([System.Security.Principal.SecurityIdentifier]))
-   ```
-
-   ``` syntax
            }
-   ```
-
-   ``` syntax
            catch [System.Security.Principal.IdentityNotMappedException]
-   ```
-
-   ``` syntax
            {
-   ```
-
-   ``` syntax
                $message = [string]::Format("Failed to translate account object '{0}' to a SID. Please verify that this is a valid user or machine account.", $account.ToString())
-   ```
-
-   ``` syntax
                Write-Error -Message $message
-   ```
-
-   ``` syntax
                continue
-   ```
-
-   ``` syntax
            }
-   ```
-
-   ``` syntax
 
            #Convert regular SID to binary format used by SQL
-   ```
-
-   ``` syntax
            $hexSIDString = ConvertSIDToHexFormat $SID
-   ```
 
-   ``` syntax
-            
            $SIDs = New-Object PSObject
-   ```
-
-   ``` syntax
            $SIDs | Add-Member NoteProperty Account $accountName
-   ```
-
-   ``` syntax
            $SIDs | Add-Member NoteProperty SID $SID.ToString()
-   ```
-
-   ``` syntax
            $SIDs | Add-Member NoteProperty Hexadecimal $hexSIDString
-   ```
-
-   ``` syntax
 
            Write-Output $SIDs
-   ```
-
-   ``` syntax
        }
-   ```
-
-   ``` syntax
    }
-   ```
-
 3. Run the script you saved in step one of this procedure passing the accounts to convert as arguments.
 
    For example,
@@ -384,12 +145,3 @@ Before attempting this procedure, you should read and understand the information
 
 
 [Administering App-V 5.1 by Using PowerShell](administering-app-v-51-by-using-powershell.md)
-
- 
-
- 
-
-
-
-
-

--- a/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
+++ b/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
@@ -606,7 +606,7 @@ For a complete list of the Microsoft Edge policies, see [Available policies for 
 
 Network Connection Status Indicator (NCSI) detects Internet connectivity and corporate network connectivity status. NCSI sends a DNS request and HTTP query to http://www.msftconnecttest.com/connecttest.txt to determine if the device can communicate with the Internet. For more info about NCSI, see [The Network Connection Status Icon](http://blogs.technet.com/b/networking/archive/2012/12/20/the-network-connection-status-icon.aspx).
 
-In versions of Windows 10 prior to Windows 10, version 1607 and Windows Server 2016, the URL was [http://www.msftncsi.com]().
+In versions of Windows 10 prior to Windows 10, version 1607 and Windows Server 2016, the URL was `http://www.msftncsi.com`.
 
 You can turn off NCSI by doing one of the following:
 


### PR DESCRIPTION

No empty links
- Some powershell examples were split oddly
- Add heading markup
- Remove empty links in TOC