### PR TITLE
Updates considered to be out-of-date

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
@@ -60,7 +60,7 @@ Microsoft Update allows for rapid releases, which means it will download small d
 The WSUS, Configuration Manager, and MMPC sources will deliver less frequent updates. The size of the updates may be slightly larger than the frequent release from Microsoft Update (as the delta, or differences between the latest version and what is on the endpoint will be larger). This ensures consistent protection without increasing ad hoc network usage (although the amount of data may be the same or increased as the updates will be fewer, but may be slightly larger).
 
 > [!IMPORTANT]
-> If you have set MMPC as a fallback source after WSUS or Microsoft Update, updates will only be downloaded from MMPC when the current update is considered to be out-of-date (by default, this is 2 consecutive days of not being able to apply updates from the WSUS or Microsoft Update services).
+> If you have set MMPC as a fallback source after WSUS or Microsoft Update, updates will only be downloaded from MMPC when the current update is considered to be out-of-date (by default, this is 14 consecutive days of not being able to apply updates from the WSUS or Microsoft Update services).
 > You can, however, [set the number of days before protection is reported as out-of-date](https://docs.microsoft.com/windows/threat-protection/windows-defender-antivirus/manage-outdated-endpoints-windows-defender-antivirus#set-the-number-of-days-before-protection-is-reported-as-out-of-date).
 
 Each source has typical scenarios that depend on how your network is configured, in addition to how often they publish updates, as described in the following table:


### PR DESCRIPTION
The description in the Group Policy Editor says: "By default, this value is set to 14 days." for both: "Define the number of days before spyware security intelligence is considered out of date" and "Define the number of days before virus security intelligence is considered out of date".

The Link refers to those two settings.