### PR TITLE
Minor typo; Fixes #4066

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/customize-exploit-protection.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/customize-exploit-protection.md
@@ -208,7 +208,7 @@ Where:
  For example, to enable Arbitrary Code Guard (ACG) in audit mode for the *testing.exe* used in the example above, you'd use the following command:
 
  ```PowerShell
-Set-ProcesMitigation -Name c:\apps\lob\tests\testing.exe -Enable AuditDynamicCode
+Set-ProcessMitigation -Name c:\apps\lob\tests\testing.exe -Enable AuditDynamicCode
 ```
 
 You can disable audit mode by using the same command but replacing `-Enable` with `-Disable`.


### PR DESCRIPTION
>"Set-ProcesMitigation" is missing an "s" in the below example:
>>For example, to enable Arbitrary Code Guard (ACG) in audit mode for the testing.exe used in the example above, you'd use the following command:
>>PowerShell
>>Copy
>>Set-ProcesMitigation -Name c:\apps\lob\tests\testing.exe -Enable AuditDynamicCode
>>You can disable audit mode by using the same command but replacing -Enable with -Disable.