### PR TITLE
Windows/Security: show asterisks in wildcard table

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/configure-extension-file-exclusions-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/configure-extension-file-exclusions-windows-defender-antivirus.md
@@ -185,34 +185,34 @@ The following table describes how the wildcards can be used and provides some ex
 <table>
     <tr>
         <th>Wildcard</th>
-        <th>Use in file and file extension exclusions</th>
+        <th>Use in file name and file extension exclusions</th>
         <th>Use in folder exclusions</th>
         <th>Example use</th>
-        <th>Example matches&gt;</th>
+        <th>Example matches</th>
     </tr>
     <tr>
-        <td><b><em></b> (asterisk)</td>
+        <td><b>*</b> (asterisk)</td>
         <td>Replaces any number of characters. <br />Only applies to files in the last folder defined in the argument. </td>
-        <td>Replaces a single folder. <br />Use multiple <b></em></b> with folder slashes <b>\</b> to indicate multiple, nested folders. </br>After matching to the number of wilcarded and named folders, all subfolders will also be included.</td>
+        <td>Replaces a single folder. <br />Use multiple <b>*</b> with folder slashes <b>\</b> to indicate multiple, nested folders. </br>After matching the number of wilcarded and named folders, all subfolders will also be included.</td>
         <td>
             <ol>
-                <li>C:\MyData\<b><em></b>.txt</li>
-                <li>C:\somepath\<b></em></b>\Data</li>
-                <li>C:\Serv\<b><em></b>\<b></em></b>\Backup
+                <li>C:\MyData\<b>*</b>.txt</li>
+                <li>C:\somepath\<b>*</b>\Data</li>
+                <li>C:\Serv\<b>*</b>\<b>*</b>\Backup
             </ol>
         </td>
         <td>
             <ol>
-                <li><i>C:\MyData\<b>notes</b>.txt</i></li>
+                <li>C:\MyData\<b>notes</b>.txt</li>
                 <li>Any file in:
                     <ul>
-                        <li><i>C:\somepath\<b>Archives</b>\Data</i> and its subfolders</li>
-                        <li><i>C:\somepath\<b>Authorized</b>\Data</i> and its subfolders</li>
+                        <li>C:\somepath\<b>Archives</b>\Data and its subfolders</li>
+                        <li>C:\somepath\<b>Authorized</b>\Data and its subfolders</li>
                     </ul>
                 <li>Any file in:
                 <ul>
-                    <li><i>C:\Serv\<b>Primary</b>\<b>Denied</b>\Backup</i> and its subfolders</li>
-                    <li><i>C:\Serv\<b>Secondary</b>\<b>Allowed</b>\Backup</i> and its subfolders</li>
+                    <li>C:\Serv\<b>Primary</b>\<b>Denied</b>\Backup and its subfolders</li>
+                    <li>C:\Serv\<b>Secondary</b>\<b>Allowed</b>\Backup and its subfolders</li>
                 </ul>
             </ol>
         </td>
@@ -227,7 +227,7 @@ The following table describes how the wildcards can be used and provides some ex
         </td>
         <td>
             Replaces a single character in a folder name. </br>
-            After matching to the number of wilcarded and named folders, all subfolders will also be included.
+            After matching the number of wilcarded and named folders, all subfolders will also be included.
         </td>
         <td>
             <ol>
@@ -238,9 +238,9 @@ The following table describes how the wildcards can be used and provides some ex
         </td>
         <td>
             <ol>
-                <li><i>C:\MyData\my<b>1</b>.zip</i></li>
-                <li>Any file in <i>C:\somepath\<b>P</b>\Data</i> and its subfolders</li>
-                <li>Any file in <i>C:\somepath\test0<b>1</b>\Data</i> and its subfolders</li>
+                <li>C:\MyData\my<b>1</b>.zip</li>
+                <li>Any file in C:\somepath\<b>P</b>\Data and its subfolders</li>
+                <li>Any file in C:\somepath\test0<b>1</b>\Data and its subfolders</li>
             </ol>
         </td>
     </tr>
@@ -255,7 +255,7 @@ The following table describes how the wildcards can be used and provides some ex
         </td>
         <td>
             <ol>
-                <li><i><b>C:\ProgramData</b>\CustomLogFiles\Folder1\file1.txt</i></li>
+                <li><b>C:\ProgramData</b>\CustomLogFiles\Folder1\file1.txt</li>
             </ol>
         </td>
     </tr>


### PR DESCRIPTION
**Description:**

Asterisks are not showing up in this table due to some sort of HTML conversion.

**Proposed changes:**

- replace unwanted `<em>` and `</em>` tags with actual asterisk (`*`)
- remove `<i>` and `</i>` formatting from path names for readability
- simplify "matching to" => 'matching' (2 occurrences in this table)
- remove a misplaced `&gt;` ( &gt; ) character from the table
- add a missing word **name** in "file name" in the table heading

Closes #4068