### PR TITLE
chore: Add MS Docs Authoring extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "docsmsft.docs-authoring-pack"
+    ]
+}


### PR DESCRIPTION

Suggests install of the MS Docs Authoring extension for editors using vs code