### PR TITLE
Update manage-windows-1809-endpoints.md

### DIFF
--- a/windows/privacy/manage-windows-1809-endpoints.md
+++ b/windows/privacy/manage-windows-1809-endpoints.md
@@ -457,6 +457,10 @@ If you [turn off traffic for these endpoints](manage-connections-from-windows-op
 | svchost | HTTPS   | *.update.microsoft.com |
 | svchost | HTTPS   | *.delivery.mp.microsoft.com  |
 
+These are dependent on enabling:
+- [Device authentication](manage-windows-1809-endpoints.md#device-authentication)
+- [Microsoft account](manage-windows-1809-endpoints.md#microsoft-account)
+
 The following endpoint is used for content regulation.
 If you [turn off traffic for this endpoint](manage-connections-from-windows-operating-system-components-to-microsoft-services.md#bkmk-wu), the Windows Update Agent will be unable to contact the endpoint and fallback behavior will be used. This may result in content being either incorrectly downloaded or not downloaded at all.
 


### PR DESCRIPTION
We'd like to include references to the Device authentication and Microsoft account endpoints, which must also be enabled for Windows Update to offer OS updates and App updates successfully. Without these additional endpoints enabled, Windows Update will fail to offer the updates targeted for those devices.