### PR TITLE
Windows Team for Surface Hub missing

### DIFF
--- a/windows/deployment/update/waas-overview.md
+++ b/windows/deployment/update/waas-overview.md
@@ -22,6 +22,7 @@ ms.topic: article
 - Windows 10
 - Windows 10 Mobile
 - Windows 10 IoT Mobile
+- Windows 10 Team (Surface Hub)
 
 > **Looking for consumer information?** See [Windows Update: FAQ](https://support.microsoft.com/help/12373/windows-update-faq) 
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/windows-itpro-docs/issues/2536

According to https://docs.microsoft.com/en-us/surface-hub/manage-windows-updates-for-surface-hub

"Surface Hub uses the Windows 10 servicing model, referred to as Windows as a Service (WaaS)."