### PR TITLE
Updating Windows Update endpoint to list Device auth and MSA endpoint requirement

### DIFF
--- a/windows/privacy/manage-windows-1709-endpoints.md
+++ b/windows/privacy/manage-windows-1709-endpoints.md
@@ -422,6 +422,10 @@ If you [turn off traffic for these endpoints](manage-connections-from-windows-op
 | svchost | HTTPS   | *.update.microsoft.com |
 | svchost | HTTPS   | *.delivery.mp.microsoft.com  |
 
+These are dependent on enabling:
+- [Device authentication](manage-windows-1709-endpoints.md#device-authentication)
+- [Microsoft account](manage-windows-1709-endpoints.md#microsoft-account)
+
 The following endpoint is used for content regulation.
 If you [turn off traffic for this endpoint](manage-connections-from-windows-operating-system-components-to-microsoft-services.md#bkmk-wu), the Windows Update Agent will be unable to contact the endpoint and fallback behavior will be used. This may result in content being either incorrectly downloaded or not downloaded at all.
 

--- a/windows/privacy/manage-windows-1803-endpoints.md
+++ b/windows/privacy/manage-windows-1803-endpoints.md
@@ -427,6 +427,10 @@ If you [turn off traffic for these endpoints](manage-connections-from-windows-op
 | svchost | HTTPS   | *.update.microsoft.com |
 | svchost | HTTPS   | *.delivery.mp.microsoft.com  |
 
+These are dependent on enabling:
+- [Device authentication](manage-windows-1803-endpoints.md#device-authentication)
+- [Microsoft account](manage-windows-1803-endpoints.md#microsoft-account)
+
 The following endpoint is used for content regulation.
 If you [turn off traffic for this endpoint](manage-connections-from-windows-operating-system-components-to-microsoft-services.md#bkmk-wu), the Windows Update Agent will be unable to contact the endpoint and fallback behavior will be used. This may result in content being either incorrectly downloaded or not downloaded at all.
 

--- a/windows/privacy/manage-windows-1903-endpoints.md
+++ b/windows/privacy/manage-windows-1903-endpoints.md
@@ -146,8 +146,8 @@ Office|The following endpoints are used to connect to the Office 365 portal's sh
 |||HTTP|cs9.wac.phicdn.net|
 |||HTTP|emdl.ws.microsoft.com|
 ||The following endpoints are used to download operating system patches, updates, and apps from Microsoft Store. If you turn off traffic for these endpoints, the device will not be able to download updates for the operating system.|HTTP|*.dl.delivery.mp.microsoft.com|
-|||HTTP|*.windowsupdate.com*|
-||The following endpoints enable connections to Windows Update, Microsoft Update, and the online services of the Store. If you turn off traffic for these endpoints, the device will not be able to connect to Windows Update and Microsoft Update to help keep the device secure. Also, the device will not be able to acquire and update apps from the Store.|HTTPS|*.delivery.mp.microsoft.com|
+|||HTTP|*.windowsupdate.com|
+||The following endpoints enable connections to Windows Update, Microsoft Update, and the online services of the Store. If you turn off traffic for these endpoints, the device will not be able to connect to Windows Update and Microsoft Update to help keep the device secure. Also, the device will not be able to acquire and update apps from the Store. These are dependent on also enabling "Device authentication" and "Microsoft Account" endpoints.|HTTPS|*.delivery.mp.microsoft.com|
 |||HTTPS|*.update.microsoft.com|
 ||The following endpoint is used for content regulation. If you turn off traffic for this endpoint, the Windows Update Agent will be unable to contact the endpoint and fallback behavior will be used. This may result in content being either incorrectly.|HTTPS|tsfe.trafficshaping.dsp.mp.microsoft.com|
 


### PR DESCRIPTION
The Device Authentication and Microsoft Account endpoints also need to be enabled for Windows Update to function properly and find Windows Updates. This PR adds a reference to those two sections so that IT admins know to enable those endpoints as well.