### PR TITLE
Update enterprise-mode-schema-version-2-guidance.md

### DIFF
--- a/browsers/internet-explorer/ie11-deploy-guide/enterprise-mode-schema-version-2-guidance.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/enterprise-mode-schema-version-2-guidance.md
@@ -19,11 +19,11 @@ ms.date: 12/04/2017
 
 **Applies to:**
 
--   Windows 10
+-   Windows 10 (>= v1709)
 -   Windows 8.1
 -   Windows 7
 
-Use the Enterprise Mode Site List Manager to create and update your site list for devices running Windows 7, Windows 8.1, and Windows 10, using the version 2.0 (v.2) of the Enterprise Mode schema. If you don't want to use the Enterprise Mode Site List Manager, you also have the option to update your XML schema using Notepad, or any other XML-editing app.
+Use the Enterprise Mode Site List Manager to create and update your site list for devices running Windows 7, Windows 8.1, and Windows 10 (>= v1709), using the version 2.0 (v.2) of the Enterprise Mode schema. If you don't want to use the Enterprise Mode Site List Manager, you also have the option to update your XML schema using Notepad, or any other XML-editing app.
 
 **Important**<br>
 If you're running Windows 7 or Windows 8.1 and you've been using the version 1.0 (v.1) of the schema, you can continue to do so, but you won't get the benefits that come with the updated schema. For info about the v.1 schema, see [Enterprise Mode schema v.1 guidance](enterprise-mode-schema-version-1-guidance.md).


### PR DESCRIPTION
Added more details on the release of Windows 10 for which schema v2 applies.
allow-redirect flag is only available starting from RS3 (v 1709)