### PR TITLE
Unfurl the list, perform link maintenance

### DIFF
--- a/mdop/mbam-v1/index.md
+++ b/mdop/mbam-v1/index.md
@@ -10,46 +10,36 @@ ms.prod: w8
 ms.date: 04/19/2017
 ---
 
-
 # Microsoft BitLocker Administration and Monitoring 1 Administrator's Guide
-
 
 Microsoft BitLocker Administration and Monitoring (MBAM) provides a simplified administrative interface that you can use to manage BitLocker drive encryption. With MBAM, you can select BitLocker encryption policy options that are appropriate to your enterprise and then use them to monitor client compliance with those policies. You can also report on the encryption status of an individual computer and on the entire enterprise. In addition, you can access recovery key information when users forget their PIN or password, or when their BIOS or boot record changes.
 
-<a href="" id="getting-started-with-mbam-1-0"></a>[Getting Started with MBAM 1.0](getting-started-with-mbam-10.md)  
+- [Getting Started with MBAM 1.0](getting-started-with-mbam-10.md)  
+  - [About MBAM 1.0](about-mbam-10.md)
+  - [Release Notes for MBAM 1.0](release-notes-for-mbam-10.md)
+  - [Evaluating MBAM 1.0](evaluating-mbam-10.md)
+  - [High Level Architecture for MBAM 1.0](high-level-architecture-for-mbam-10.md)
+  - [Accessibility for MBAM 1.0](accessibility-for-mbam-10.md)
+  - [Privacy Statement for MBAM 1.0](privacy-statement-for-mbam-10.md)
+- [Planning for MBAM 1.0](planning-for-mbam-10.md)  
+  - [Preparing your Environment for MBAM 1.0](preparing-your-environment-for-mbam-10.md)
+  - [MBAM 1.0 Deployment Prerequisites](mbam-10-deployment-prerequisites.md)
+  - [Planning to Deploy MBAM 1.0](planning-to-deploy-mbam-10.md)
+  - [MBAM 1.0 Supported Configurations](mbam-10-supported-configurations.md)
+  - [MBAM 1.0 Planning Checklist](mbam-10-planning-checklist.md)
+- [Deploying MBAM 1.0](deploying-mbam-10.md)  
+  - [Deploying the MBAM 1.0 Server Infrastructure](deploying-the-mbam-10-server-infrastructure.md)
+  - [Deploying MBAM 1.0 Group Policy Objects](deploying-mbam-10-group-policy-objects.md)
+  - [Deploying the MBAM 1.0 Client](deploying-the-mbam-10-client.md)
+  - [Deploying the MBAM 1.0 Language Release Update](deploying-the-mbam-10-language-release-update.md)
+  - [MBAM 1.0 Deployment Checklist](mbam-10-deployment-checklist.md)
+- [Operations for MBAM 1.0](operations-for-mbam-10.md)  
+  - [Administering MBAM 1.0 Features](administering-mbam-10-features.md)
+  - [Monitoring and Reporting BitLocker Compliance with MBAM 1.0](monitoring-and-reporting-bitlocker-compliance-with-mbam-10.md)
+  - [Performing BitLocker Management with MBAM](performing-bitlocker-management-with-mbam.md)
+  - [Administering MBAM 1.0 by Using PowerShell](administering-mbam-10-by-using-powershell.md)
+- [Troubleshooting MBAM 1.0](troubleshooting-mbam-10.md)  
 
-[About MBAM 1.0](about-mbam-10.md)**|**[Evaluating MBAM 1.0](evaluating-mbam-10.md)**|**[High Level Architecture for MBAM 1.0](high-level-architecture-for-mbam-10.md)**|**[Accessibility for MBAM 1.0](accessibility-for-mbam-10.md)**|**[Privacy Statement for MBAM 1.0](privacy-statement-for-mbam-10.md)
-
-<a href="" id="planning-for-mbam-1-0"></a>[Planning for MBAM 1.0](planning-for-mbam-10.md)  
-
-[Preparing your Environment for MBAM 1.0](preparing-your-environment-for-mbam-10.md)**|**[MBAM 1.0 Deployment Prerequisites](mbam-10-deployment-prerequisites.md)**|**[Planning to Deploy MBAM 1.0](planning-to-deploy-mbam-10.md)**|**[MBAM 1.0 Supported Configurations](mbam-10-supported-configurations.md)**|**[MBAM 1.0 Planning Checklist](mbam-10-planning-checklist.md)
-
-<a href="" id="deploying-mbam-1-0"></a>[Deploying MBAM 1.0](deploying-mbam-10.md)  
-
-[Deploying the MBAM 1.0 Server Infrastructure](deploying-the-mbam-10-server-infrastructure.md)**|**[Deploying MBAM 1.0 Group Policy Objects](deploying-mbam-10-group-policy-objects.md)**|**[Deploying the MBAM 1.0 Client](deploying-the-mbam-10-client.md)**|**[Deploying the MBAM 1.0 Language Release Update](deploying-the-mbam-10-language-release-update.md)**|**[MBAM 1.0 Deployment Checklist](mbam-10-deployment-checklist.md)
-
-<a href="" id="operations-for-mbam-1-0"></a>[Operations for MBAM 1.0](operations-for-mbam-10.md)  
-
-[Administering MBAM 1.0 Features](administering-mbam-10-features.md)**|**[Monitoring and Reporting BitLocker Compliance with MBAM 1.0](monitoring-and-reporting-bitlocker-compliance-with-mbam-10.md)**|**[Performing BitLocker Management with MBAM](performing-bitlocker-management-with-mbam.md)**|**[Administering MBAM 1.0 by Using PowerShell](administering-mbam-10-by-using-powershell.md)
-
-<a href="" id="troubleshooting-mbam-1-0"></a>[Troubleshooting MBAM 1.0](troubleshooting-mbam-10.md)  
-
-### More Information
-
-<a href="" id="release-notes-for-mbam-1-0"></a>[Release Notes for MBAM 1.0](release-notes-for-mbam-10.md)  
-View updated product information and known issues for MBAM 1.0.
-
-<a href="" id="mdop-techcenter-page"></a>[MDOP TechCenter Page](https://go.microsoft.com/fwlink/p/?LinkId=225286)  
-Learn about the latest MDOP information and resources.
-
-<a href="" id="mdop-information-experience"></a>[MDOP Information Experience](https://go.microsoft.com/fwlink/p/?LinkId=236032)  
-Find documentation, videos, and other resources for MDOP technologies. You can also [send us feedback](mailto:MDOPDocs@microsoft.com) or learn about updates by following us on [Facebook](https://go.microsoft.com/fwlink/p/?LinkId=242445) or [Twitter](https://go.microsoft.com/fwlink/p/?LinkId=242447).
-
- 
-
- 
-
-
-
-
-
+## More Information
+- [MDOP Information Experience](https://go.microsoft.com/fwlink/p/?LinkId=236032)  
+  Find documentation, videos, and other resources for MDOP technologies.

--- a/mdop/mbam-v2/index.md
+++ b/mdop/mbam-v2/index.md
@@ -10,43 +10,47 @@ ms.prod: w8
 ms.date: 04/19/2017
 ---
 
-
 # Microsoft BitLocker Administration and Monitoring 2 Administrator's Guide
-
 
 Microsoft BitLocker Administration and Monitoring (MBAM) 2.0 provides a simplified administrative interface that you can use to manage BitLocker drive encryption. In BitLocker Administration and Monitoring 2.0, you can select BitLocker drive encryption policy options that are appropriate for your enterprise, and then use them to monitor client compliance with those policies. You can also report on the encryption status of an individual computer and on the enterprise as a whole. In addition, you can access recovery key information when users forget their PIN or password or when their BIOS or boot record changes.
 
-<a href="" id="getting-started-with-mbam-2-0"></a>[Getting Started with MBAM 2.0](getting-started-with-mbam-20-mbam-2.md)  
+## Outline
 
-[About MBAM 2.0](about-mbam-20-mbam-2.md)**|**[Release Notes for MBAM 2.0](release-notes-for-mbam-20-mbam-2.md)**|**[About MBAM 2.0 SP1](about-mbam-20-sp1.md)**|**[Release Notes for MBAM 2.0 SP1](release-notes-for-mbam-20-sp1.md)**|**[Evaluating MBAM 2.0](evaluating-mbam-20-mbam-2.md)**|**[High-Level Architecture for MBAM 2.0](high-level-architecture-for-mbam-20-mbam-2.md)**|**[Accessibility for MBAM 2.0](accessibility-for-mbam-20-mbam-2.md)
+- [Getting Started with MBAM 2.0](getting-started-with-mbam-20-mbam-2.md)
+  - [About MBAM 2.0](about-mbam-20-mbam-2.md)
+  - [Release Notes for MBAM 2.0](release-notes-for-mbam-20-mbam-2.md)
+  - [About MBAM 2.0 SP1](about-mbam-20-sp1.md)
+  - [Release Notes for MBAM 2.0 SP1](release-notes-for-mbam-20-sp1.md)
+  - [Evaluating MBAM 2.0](evaluating-mbam-20-mbam-2.md)
+  - [High-Level Architecture for MBAM 2.0](high-level-architecture-for-mbam-20-mbam-2.md)
+  - [Accessibility for MBAM 2.0](accessibility-for-mbam-20-mbam-2.md)
+- [Planning for MBAM 2.0](planning-for-mbam-20-mbam-2.md)
+  - [Preparing your Environment for MBAM 2.0](preparing-your-environment-for-mbam-20-mbam-2.md)
+  - [MBAM 2.0 Deployment Prerequisites](mbam-20-deployment-prerequisites-mbam-2.md)
+  - [Planning to Deploy MBAM 2.0](planning-to-deploy-mbam-20-mbam-2.md)
+  - [MBAM 2.0 Supported Configurations](mbam-20-supported-configurations-mbam-2.md)
+  - [MBAM 2.0 Planning Checklist](mbam-20-planning-checklist-mbam-2.md)
+- [Deploying MBAM 2.0](deploying-mbam-20-mbam-2.md)
+  - [Deploying the MBAM 2.0 Server Infrastructure](deploying-the-mbam-20-server-infrastructure-mbam-2.md)
+  - [Deploying MBAM 2.0 Group Policy Objects](deploying-mbam-20-group-policy-objects-mbam-2.md)
+  - [Deploying the MBAM 2.0 Client](deploying-the-mbam-20-client-mbam-2.md)
+  - [MBAM 2.0 Deployment Checklist](mbam-20-deployment-checklist-mbam-2.md)
+  - [Upgrading from Previous Versions of MBAM](upgrading-from-previous-versions-of-mbam.md)
+- [Operations for MBAM 2.0](operations-for-mbam-20-mbam-2.md)
+  - [Using MBAM with Configuration Manager](using-mbam-with-configuration-manager.md)
+  - [Administering MBAM 2.0 Features](administering-mbam-20-features-mbam-2.md)
+  - [Monitoring and Reporting BitLocker Compliance with MBAM 2.0](monitoring-and-reporting-bitlocker-compliance-with-mbam-20-mbam-2.md)
+  - [Performing BitLocker Management with MBAM](performing-bitlocker-management-with-mbam-mbam-2.md)
+  - [Maintaining MBAM 2.0](maintaining-mbam-20-mbam-2.md)
+  - [Security and Privacy for MBAM 2.0](security-and-privacy-for-mbam-20-mbam-2.md)
+  - [Administering MBAM 2.0 Using PowerShell](administering-mbam-20-using-powershell-mbam-2.md)
+- [Troubleshooting MBAM 2.0](troubleshooting-mbam-20-mbam-2.md)
 
-<a href="" id="planning-for-mbam-2-0"></a>[Planning for MBAM 2.0](planning-for-mbam-20-mbam-2.md)  
+## More Information
 
-[Preparing your Environment for MBAM 2.0](preparing-your-environment-for-mbam-20-mbam-2.md)**|**[MBAM 2.0 Deployment Prerequisites](mbam-20-deployment-prerequisites-mbam-2.md)**|**[Planning to Deploy MBAM 2.0](planning-to-deploy-mbam-20-mbam-2.md)**|**[MBAM 2.0 Supported Configurations](mbam-20-supported-configurations-mbam-2.md)**|**[MBAM 2.0 Planning Checklist](mbam-20-planning-checklist-mbam-2.md)
+- [MDOP Information Experience](index.md)
 
-<a href="" id="deploying-mbam-2-0"></a>[Deploying MBAM 2.0](deploying-mbam-20-mbam-2.md)  
-
-[Deploying the MBAM 2.0 Server Infrastructure](deploying-the-mbam-20-server-infrastructure-mbam-2.md)**|**[Deploying MBAM 2.0 Group Policy Objects](deploying-mbam-20-group-policy-objects-mbam-2.md)**|**[Deploying the MBAM 2.0 Client](deploying-the-mbam-20-client-mbam-2.md)**|**[MBAM 2.0 Deployment Checklist](mbam-20-deployment-checklist-mbam-2.md)**|**[Upgrading from Previous Versions of MBAM](upgrading-from-previous-versions-of-mbam.md)
-
-<a href="" id="operations-for-mbam-2-0"></a>[Operations for MBAM 2.0](operations-for-mbam-20-mbam-2.md)  
-
-[Using MBAM with Configuration Manager](using-mbam-with-configuration-manager.md)**|**[Administering MBAM 2.0 Features](administering-mbam-20-features-mbam-2.md)**|**[Monitoring and Reporting BitLocker Compliance with MBAM 2.0](monitoring-and-reporting-bitlocker-compliance-with-mbam-20-mbam-2.md)**|**[Performing BitLocker Management with MBAM](performing-bitlocker-management-with-mbam-mbam-2.md)**|**[Maintaining MBAM 2.0](maintaining-mbam-20-mbam-2.md)**|**[Security and Privacy for MBAM 2.0](security-and-privacy-for-mbam-20-mbam-2.md)**|** [Administering MBAM 2.0 Using PowerShell](administering-mbam-20-using-powershell-mbam-2.md)
-
-<a href="" id="troubleshooting-mbam-2-0"></a>[Troubleshooting MBAM 2.0](troubleshooting-mbam-20-mbam-2.md)  
-
-### More Information
-
--   [Release Notes for MBAM 2.0](release-notes-for-mbam-20-mbam-2.md)
-
-    View updated product information and known issues for MBAM 2.0.
-
--   [MDOP TechCenter Page](https://go.microsoft.com/fwlink/p/?LinkId=225286)
-
-    Learn about the latest MDOP information and resources.
-
--   [MDOP Information Experience](https://go.microsoft.com/fwlink/p/?LinkId=236032)
-
-    Find documentation, videos, and other resources for MDOP technologies. You can also [send us feedback](mailto:MDOPDocs@microsoft.com) or learn about updates by following us on [Facebook](https://go.microsoft.com/fwlink/p/?LinkId=242445) or [Twitter](https://go.microsoft.com/fwlink/p/?LinkId=242447).
+  Find documentation, videos, and other resources for MDOP technologies.
 
  
 

--- a/mdop/mbam-v25/index.md
+++ b/mdop/mbam-v25/index.md
@@ -10,13 +10,11 @@ ms.prod: w10
 ms.date: 04/19/2017
 ---
 
-
 # Microsoft BitLocker Administration and Monitoring 2.5
-
 
 Microsoft BitLocker Administration and Monitoring (MBAM) 2.5 provides a simplified administrative interface that you can use to manage BitLocker Drive Encryption. You configure MBAM Group Policy Templates that enable you to set BitLocker Drive Encryption policy options that are appropriate for your enterprise, and then use them to monitor client compliance with those policies. You can also report on the encryption status of an individual computer and on the enterprise as a whole. In addition, you can access recovery key information when users forget their PIN or password or when their BIOS or boot record changes. For a more detailed description of MBAM, see [About MBAM 2.5](about-mbam-25.md).
 
-To obtain MBAM, see [How Do I Get MDOP](https://go.microsoft.com/fwlink/?LinkId=322049) (https://go.microsoft.com/fwlink/?LinkId=322049).
+To obtain MBAM, see [How Do I Get MDOP](index.md#how-to-get-mdop).
 
 ## Outline
 
@@ -57,16 +55,16 @@ To obtain MBAM, see [How Do I Get MDOP](https://go.microsoft.com/fwlink/?LinkId=
   - [Client Event Logs](client-event-logs.md)
   - [Server Event Logs](server-event-logs.md)
 
-### More Information
+## More Information
 
--   [MDOP Information Experience](https://go.microsoft.com/fwlink/p/?LinkId=236032)
+- [MDOP Information Experience](index.md)
 
-    Find documentation, videos, and other resources for MDOP technologies.
+  Find documentation, videos, and other resources for MDOP technologies.
 
--   [MBAM Deployment Guide](https://www.microsoft.com/download/details.aspx?id=38398)
+- [MBAM Deployment Guide](https://www.microsoft.com/download/details.aspx?id=38398)
 
-    Get help in choosing a deployment method for MBAM, including step-by-step instructions for each method.
+  Get help in choosing a deployment method for MBAM, including step-by-step instructions for each method.
     
--   [Apply Hotfixes on MBAM 2.5 SP1 Server](apply-hotfix-for-mbam-25-sp1.md)
+- [Apply Hotfixes on MBAM 2.5 SP1 Server](apply-hotfix-for-mbam-25-sp1.md)
 
-    Guide of how to apply MBAM 2.5 SP1 Server hotfixes
+  Guide of how to apply MBAM 2.5 SP1 Server hotfixes

--- a/mdop/mbam-v25/index.md
+++ b/mdop/mbam-v25/index.md
@@ -16,61 +16,57 @@ ms.date: 04/19/2017
 
 Microsoft BitLocker Administration and Monitoring (MBAM) 2.5 provides a simplified administrative interface that you can use to manage BitLocker Drive Encryption. You configure MBAM Group Policy Templates that enable you to set BitLocker Drive Encryption policy options that are appropriate for your enterprise, and then use them to monitor client compliance with those policies. You can also report on the encryption status of an individual computer and on the enterprise as a whole. In addition, you can access recovery key information when users forget their PIN or password or when their BIOS or boot record changes. For a more detailed description of MBAM, see [About MBAM 2.5](about-mbam-25.md).
 
-To get the MBAM software, see [How Do I Get MDOP](https://go.microsoft.com/fwlink/?LinkId=322049) (https://go.microsoft.com/fwlink/?LinkId=322049).
+To obtain MBAM, see [How Do I Get MDOP](https://go.microsoft.com/fwlink/?LinkId=322049) (https://go.microsoft.com/fwlink/?LinkId=322049).
 
-<a href="" id="getting-started-with-mbam-2-5"></a>[Getting Started with MBAM 2.5](getting-started-with-mbam-25.md)
+## Outline
 
-[About MBAM 2.5](about-mbam-25.md)**|**[Release Notes for MBAM 2.5](release-notes-for-mbam-25.md)**|**[About MBAM 2.5 SP1](about-mbam-25-sp1.md)**|**[Release Notes for MBAM 2.5 SP1](release-notes-for-mbam-25-sp1.md)**|**[Evaluating MBAM 2.5 in a Test Environment](evaluating-mbam-25-in-a-test-environment.md)**|**[High-Level Architecture for MBAM 2.5](high-level-architecture-for-mbam-25.md)**|**[Accessibility for MBAM 2.5](accessibility-for-mbam-25.md)
-
-<a href="" id="planning-for-mbam-2-5"></a>[Planning for MBAM 2.5](planning-for-mbam-25.md)
-
-[Preparing your Environment for MBAM 2.5](preparing-your-environment-for-mbam-25.md)**|**[MBAM 2.5 Deployment Prerequisites](mbam-25-deployment-prerequisites.md)**|**[Planning for MBAM 2.5 Group Policy Requirements](planning-for-mbam-25-group-policy-requirements.md)**|**[Planning for MBAM 2.5 Groups and Accounts](planning-for-mbam-25-groups-and-accounts.md)**|**[Planning How to Secure the MBAM Websites](planning-how-to-secure-the-mbam-websites.md)**|**[Planning to Deploy MBAM 2.5](planning-to-deploy-mbam-25.md)**|**[MBAM 2.5 Supported Configurations](mbam-25-supported-configurations.md)**|**[Planning for MBAM 2.5 High Availability](planning-for-mbam-25-high-availability.md)**|**[MBAM 2.5 Security Considerations](mbam-25-security-considerations.md)**|**[MBAM 2.5 Planning Checklist](mbam-25-planning-checklist.md)
-
-<a href="" id="deploying-mbam-2-5"></a>[Deploying MBAM 2.5](deploying-mbam-25.md)
-
-[Deploying the MBAM 2.5 Server Infrastructure](deploying-the-mbam-25-server-infrastructure.md)**|**[Deploying MBAM 2.5 Group Policy Objects](deploying-mbam-25-group-policy-objects.md)**|**[Deploying the MBAM 2.5 Client](deploying-the-mbam-25-client.md)**|**[MBAM 2.5 Deployment Checklist](mbam-25-deployment-checklist.md)**|**[Upgrading to MBAM 2.5 or MBAM 2.5 SP1 from Previous Versions](upgrading-to-mbam-25-or-mbam-25-sp1-from-previous-versions.md)**|**[Removing MBAM Server Features or Software](removing-mbam-server-features-or-software.md)
-
-<a href="" id="operations-for-mbam-2-5"></a>[Operations for MBAM 2.5](operations-for-mbam-25.md)
-
-[Administering MBAM 2.5 Features](administering-mbam-25-features.md)**|**[Monitoring and Reporting BitLocker Compliance with MBAM 2.5](monitoring-and-reporting-bitlocker-compliance-with-mbam-25.md)**|**[Performing BitLocker Management with MBAM 2.5](performing-bitlocker-management-with-mbam-25.md)**|**[Maintaining MBAM 2.5](maintaining-mbam-25.md)**|**[Using Windows PowerShell to Administer MBAM 2.5](using-windows-powershell-to-administer-mbam-25.md)
-
-<a href="" id="troubleshooting-mbam-2-5"></a>[Troubleshooting MBAM 2.5](troubleshooting-mbam-25.md)
-
-<a href="" id="technical-reference-for-mbam-2-5"></a>[Technical Reference for MBAM 2.5](technical-reference-for-mbam-25.md)
-
-[Client Event Logs](client-event-logs.md)**|**[Server Event Logs](server-event-logs.md)
+- <a href="" id="getting-started-with-mbam-2-5"></a>[Getting Started with MBAM 2.5](getting-started-with-mbam-25.md)
+  - [About MBAM 2.5](about-mbam-25.md)
+  - [Release Notes for MBAM 2.5](release-notes-for-mbam-25.md)
+  - [About MBAM 2.5 SP1](about-mbam-25-sp1.md)
+  - [Release Notes for MBAM 2.5 SP1](release-notes-for-mbam-25-sp1.md)
+  - [Evaluating MBAM 2.5 in a Test Environment](evaluating-mbam-25-in-a-test-environment.md)
+  - [High-Level Architecture for MBAM 2.5](high-level-architecture-for-mbam-25.md)
+  - [Accessibility for MBAM 2.5](accessibility-for-mbam-25.md)
+- <a href="" id="planning-for-mbam-2-5"></a>[Planning for MBAM 2.5](planning-for-mbam-25.md)
+  - [Preparing your Environment for MBAM 2.5](preparing-your-environment-for-mbam-25.md)
+  - [MBAM 2.5 Deployment Prerequisites](mbam-25-deployment-prerequisites.md)
+  - [Planning for MBAM 2.5 Group Policy Requirements](planning-for-mbam-25-group-policy-requirements.md)
+  - [Planning for MBAM 2.5 Groups and Accounts](planning-for-mbam-25-groups-and-accounts.md)
+  - [Planning How to Secure the MBAM Websites](planning-how-to-secure-the-mbam-websites.md)
+  - [Planning to Deploy MBAM 2.5](planning-to-deploy-mbam-25.md)
+  - [MBAM 2.5 Supported Configurations](mbam-25-supported-configurations.md)
+  - [Planning for MBAM 2.5 High Availability](planning-for-mbam-25-high-availability.md)
+  - [MBAM 2.5 Security Considerations](mbam-25-security-considerations.md)
+  - [MBAM 2.5 Planning Checklist](mbam-25-planning-checklist.md)
+- <a href="" id="deploying-mbam-2-5"></a>[Deploying MBAM 2.5](deploying-mbam-25.md)
+  - [Deploying the MBAM 2.5 Server Infrastructure](deploying-the-mbam-25-server-infrastructure.md)
+  - [Deploying MBAM 2.5 Group Policy Objects](deploying-mbam-25-group-policy-objects.md)
+  - [Deploying the MBAM 2.5 Client](deploying-the-mbam-25-client.md)
+  - [MBAM 2.5 Deployment Checklist](mbam-25-deployment-checklist.md)
+  - [Upgrading to MBAM 2.5 or MBAM 2.5 SP1 from Previous Versions](upgrading-to-mbam-25-or-mbam-25-sp1-from-previous-versions.md)
+  - [Removing MBAM Server Features or Software](removing-mbam-server-features-or-software.md)
+- <a href="" id="operations-for-mbam-2-5"></a>[Operations for MBAM 2.5](operations-for-mbam-25.md)
+  - [Administering MBAM 2.5 Features](administering-mbam-25-features.md)
+  - [Monitoring and Reporting BitLocker Compliance with MBAM 2.5](monitoring-and-reporting-bitlocker-compliance-with-mbam-25.md)
+  - [Performing BitLocker Management with MBAM 2.5](performing-bitlocker-management-with-mbam-25.md)
+  - [Maintaining MBAM 2.5](maintaining-mbam-25.md)
+  - [Using Windows PowerShell to Administer MBAM 2.5](using-windows-powershell-to-administer-mbam-25.md)
+- <a href="" id="troubleshooting-mbam-2-5"></a>[Troubleshooting MBAM 2.5](troubleshooting-mbam-25.md)
+- <a href="" id="technical-reference-for-mbam-2-5"></a>[Technical Reference for MBAM 2.5](technical-reference-for-mbam-25.md)
+  - [Client Event Logs](client-event-logs.md)
+  - [Server Event Logs](server-event-logs.md)
 
 ### More Information
 
--   [Release Notes for MBAM 2.5](release-notes-for-mbam-25.md)
-
-    View updated product information and known issues for MBAM 2.5.
-
--   [MDOP TechCenter Page](https://go.microsoft.com/fwlink/p/?LinkId=225286)
-
-    Learn about the latest MDOP information and resources.
-
 -   [MDOP Information Experience](https://go.microsoft.com/fwlink/p/?LinkId=236032)
 
-    Find documentation, videos, and other resources for MDOP technologies. You can also [send us feedback](mailto:MDOPDocs@microsoft.com) or learn about updates by following us on [Facebook](https://go.microsoft.com/fwlink/p/?LinkId=242445) or [Twitter](https://go.microsoft.com/fwlink/p/?LinkId=242447).
+    Find documentation, videos, and other resources for MDOP technologies.
 
 -   [MBAM Deployment Guide](https://www.microsoft.com/download/details.aspx?id=38398)
 
     Get help in choosing a deployment method for MBAM, including step-by-step instructions for each method.
-
+    
 -   [Apply Hotfixes on MBAM 2.5 SP1 Server](apply-hotfix-for-mbam-25-sp1.md)
 
     Guide of how to apply MBAM 2.5 SP1 Server hotfixes
-
-## Got a suggestion for MBAM?
-- Add or vote on suggestions [here](http://mbam.uservoice.com/forums/268571-microsoft-bitlocker-administration-and-monitoring).
-- For MBAM issues, use the [MBAM TechNet Forum](https://social.technet.microsoft.com/Forums/home?forum=mdopmbam).
-
- 
-
- 
-
-
-
-
-


### PR DESCRIPTION
From top to bottom, I propose the following changes without prejudice:

1. Convert the heaped mass of links into an accessible list, compliant with Microsoft Docs guideline.
2. Delete the second, redundant instance of the link to "Release Notes for MBAM 2.5/2.0".
3. Delete the link to "MDOP TechCenter Page". This page is now deleted. The link redirects to "MDOP Information Experience" to which there is already a link in the page.
4. Delete feedback links (email, Twitter, and Facebook). These channels have been defunct since 2015.
5. Delete the entire "Got a suggestion for MBAM" section. Both links in it are dead. The UserVoice channel and TechNet subforum have been gone for a long time now.