### PR TITLE
added  two new commands for  exporting and importing .xml files

### DIFF
--- a/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
@@ -70,7 +70,7 @@ When you have configured exploit protection to your desired state (including bot
 
 Change `filename` to any name or location of your choosing.
 
-example command
+Example command
 **Get-ProcessMitigation -RegistryConfigFilePath C:\ExploitConfigfile.xml**
 
 > [!IMPORTANT]

--- a/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
@@ -94,7 +94,7 @@ After importing, the settings will be instantly applied and can be reviewed in t
 
 Change `filename` to the location and name of the exploit protection XML file.
 
-example command
+Example command
 **Set-ProcessMitigation -PolicyFilePath C:\ExploitConfigfile.xml**
 
 

--- a/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/windows-defender-exploit-guard/import-export-exploit-protection-emet-xml.md
@@ -70,6 +70,9 @@ When you have configured exploit protection to your desired state (including bot
 
 Change `filename` to any name or location of your choosing.
 
+example command
+**Get-ProcessMitigation -RegistryConfigFilePath C:\ExploitConfigfile.xml**
+
 > [!IMPORTANT]
 > When you deploy the configuration using Group Policy, all machines that will use the configuration must be able to access the configuration file. Ensure you place the file in a shared location. 
 
@@ -90,6 +93,10 @@ After importing, the settings will be instantly applied and can be reviewed in t
     ```
 
 Change `filename` to the location and name of the exploit protection XML file.
+
+example command
+**Set-ProcessMitigation -PolicyFilePath C:\ExploitConfigfile.xml**
+
 
 >[!IMPORTANT]
 >
@@ -151,6 +158,7 @@ You can use Group Policy to deploy the configuration you've created to multiple 
     - C:\MitigationSettings\Config.XML
     -  \\\Server\Share\Config.xml
     -  https://localhost:8080/Config.xml
+    - C:\ExploitConfigfile.xml
 
 8. Click **OK** and [Deploy the updated GPO as you normally do](https://msdn.microsoft.com/library/ee663280(v=vs.85).aspx). 
 


### PR DESCRIPTION
Taken example from Windows 10 v1903  build no 18362.207. 
added  two commands  under export of configuration file  and  import of configuration  file

add this exploit configuration file.xml is  created by me  with windows 10 v1903
 
[ExploitConfigfile.zip](https://github.com/MicrosoftDocs/windows-itpro-docs/files/3338834/ExploitConfigfile.zip)
