### PR TITLE
FixBrokenLinks: User Story 1562968

### DIFF
--- a/devices/hololens/hololens-kiosk.md
+++ b/devices/hololens/hololens-kiosk.md
@@ -46,7 +46,6 @@ For HoloLens devices running Windows 10, version 1803, there are three methods t
 
 For HoloLens devices running Windows 10, version 1607, you can [use the Windows Device Portal](#portal-kiosk) to configure single-app kiosks.
 
-<span id="start-kiosk"/>
 ## Start layout for HoloLens 
 
 If you use [MDM, Microsoft Intune](#intune-kiosk), or a [provisioning package](#ppkg-kiosk) to configure a multi-app kiosk, the procedure requires a Start layout. Start layout customization isn't supported in Holographic for Business, so you'll need to use a placeholder Start layout. 
@@ -54,7 +53,6 @@ If you use [MDM, Microsoft Intune](#intune-kiosk), or a [provisioning package](#
 >[!NOTE]
 >Because a single-app kiosk launches the kiosk app when a user signs in, there is no Start screen displayed.
 
-<span id="start-layout-file-for-intune" />
 ### Start layout file for MDM (Intune and others)
 
 Save the following sample as an XML file. You will select this file when you configure the kiosk in Microsoft Intune (or in another MDM service that provides a kiosk profile).
@@ -102,7 +100,6 @@ You will [create an XML file](#ppkg-kiosk) to define the kiosk configuration to 
             <!-- This section is required for parity with Desktop Assigned Access. It is not currently used on HoloLens -->
 ``` 
 
-<span id="intune-kiosk"/>
 ## Set up kiosk mode using Microsoft Intune or MDM (Windows 10, version 1803)
 
 For HoloLens devices that are managed by Microsoft Intune, you [create a device profile](https://docs.microsoft.com/intune/device-profile-create) and configure the [Kiosk settings](https://docs.microsoft.com/intune/kiosk-settings).
@@ -110,8 +107,6 @@ For HoloLens devices that are managed by Microsoft Intune, you [create a device 
 For other MDM services, check your provider's documentation for instructions. If you need to use a custom setting and full XML configuration to set up a kiosk in your MDM service, [create an XML file that defines the kiosk configuration](#create-xml-file), and make sure to include the [Start layout](#start-layout-for-a-provisioning-package) in the XML file.  
 
 
-
-<span id="ppkg-kiosk"/>
 ## Setup kiosk mode using a provisioning package (Windows 10, version 1803)
 
 Process:
@@ -119,7 +114,6 @@ Process:
 2. [Add the XML file to a provisioning package.](#add-xml)
 3. [Apply the provisioning package to HoloLens.](#apply-ppkg)
 
-<span id="create-xml-file"/>
 ### Create a kiosk configuration XML file
 
 Follow [the instructions for creating a kiosk configuration XML file for desktop](https://docs.microsoft.com/windows/configuration/lock-down-windows-10-to-specific-apps#configure-a-kiosk-using-a-provisioning-package), with the following exceptions:
@@ -127,7 +121,6 @@ Follow [the instructions for creating a kiosk configuration XML file for desktop
 - Do not include Classic Windows applications (Win32) since they aren't supported on HoloLens.
 - Use the [placeholder Start XML](#start-kiosk) for HoloLens.
 
-<span id="guest" />
 #### Add guest access to the kiosk configuration (optional)
 
 In the [Configs section of the XML file](https://docs.microsoft.com/windows/configuration/lock-down-windows-10-to-specific-apps#configs), you can configure a special group named **Visitor** to allow guests to use the kiosk. When the kiosk is configured with the **Visitor** special group, a "**Guest**" option is added to the sign-in page. The **Guest** account does not require a password, and any data associated with the account is deleted when the account signs out.
@@ -143,8 +136,6 @@ Use the following snippet in your kiosk configuration XML to enable the **Guest*
 </Configs> 
 ```
 
-
-<span id="add-xml"/>
 ### Add the kiosk configuration XML file to a provisioning package
 
 1. Open [Windows Configuration Designer](https://www.microsoft.com/store/apps/9nblggh4tx22).
@@ -174,8 +165,6 @@ Use the following snippet in your kiosk configuration XML to enable the **Guest*
 16. Click **Build** to start building the package. The provisioning package doesn't take long to build. The project information is displayed in the build page and the progress bar indicates the build status.
 
     
-
-<span id="apply-ppkg"/>
 ### Apply the provisioning package to HoloLens
 
 1. Connect HoloLens via USB to a PC and start the device, but do not continue past the **Fit** page of OOBE (the first page with the blue box).
@@ -191,7 +180,6 @@ Use the following snippet in your kiosk configuration XML to enable the **Guest*
 7. You will see whether the package was applied successfully or not. If it failed, you can fix your package and try again. If it succeeded, proceed with OOBE.
 
 
-<span id="portal-kiosk"/>
 ## Set up kiosk mode using the Windows Device Portal (Windows 10, version 1607 and version 1803) 
 
 1. [Set up the HoloLens to use the Windows Device Portal](https://developer.microsoft.com/windows/mixed-reality/using_the_windows_device_portal#setting_up_hololens_to_use_windows_device_portal). The Device Portal is a web server on your HoloLens that you can connect to from a web browser on your PC. 


### PR DESCRIPTION
I'm fixing broken links for User Story 1562968 (Intune repo). A link goes to the page I changed but the heading markdown is not rendering correctly. I've removed the span tag on the affected heading (and others) so they render correctly. 

@Dansimp you are listed as the author of the article. Just wanted to let you know why I'm touching anything. Let me know if you have any questions or feedback.