### PR TITLE
updated the link for msftncsi

### DIFF
--- a/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
+++ b/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services.md
@@ -606,7 +606,7 @@ For a complete list of the Microsoft Edge policies, see [Available policies for 
 
 Network Connection Status Indicator (NCSI) detects Internet connectivity and corporate network connectivity status. NCSI sends a DNS request and HTTP query to http://www.msftconnecttest.com/connecttest.txt to determine if the device can communicate with the Internet. For more info about NCSI, see [The Network Connection Status Icon](https://techcommunity.microsoft.com/t5/Networking-Blog/bg-p/NetworkingBlog).
 
-In versions of Windows 10 prior to Windows 10, version 1607 and Windows Server 2016, the URL was `http://www.msftncsi.com`.
+In versions of Windows 10 prior to Windows 10, version 1607 and Windows Server 2016, the URL was (http://www.msftncsi.com/ncsi.txt).
 
 You can turn off NCSI by doing one of the following:
 


### PR DESCRIPTION
I have updated the URL to NCSI test. From my understading, the networking blog should not be connected here with the network connection status icon. What I feel from a tech point of view, it was just a statement but mistakenly connected with the blog. It should not be connected to the network site blog. 

Additionally, we need to check with someone to bring the archived blog back online or disable the redirect. 

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/4003