### PR TITLE
Added Info on TPM 2.0 with Legacy \ CSM Mode

### DIFF
--- a/windows/security/information-protection/bitlocker/bitlocker-overview-and-requirements-faq.md
+++ b/windows/security/information-protection/bitlocker/bitlocker-overview-and-requirements-faq.md
@@ -51,6 +51,11 @@ Two partitions are required to run BitLocker because pre-startup authentication 
 
 BitLocker supports TPM version 1.2 or higher. BitLocker support for TPM 2.0 requires Unified Extensible Firmware Interface (UEFI) for the device. 
 
+> [!NOTE]
+> TPM 2.0 is not supported in Legacy and CSM Modes of the BIOS. Devices with TPM 2.0 must have their BIOS mode configured as Native UEFI only. The Legacy and Compatibility Support Module (CSM) options must be disabled. For added security Enable the Secure Boot feature.
+
+> Installed Operating System on hardware in legacy mode will stop the OS from booting when the BIOS mode is changed to UEFI. Use the tool [MBR2GPT](https://docs.microsoft.com/en-us/windows/deployment/mbr-to-gpt) before changing the BIOS mode which will prepare the OS and the disk to support UEFI.
+
 ## How can I tell if a TPM is on my computer?
 
 Beginning with Windows 10, version 1803, you can check TPM status in **Windows Defender Security Center** > **Device Security** > **Security processor details**. In previous versions of Windows, open the TPM MMC console (tpm.msc) and look under the **Status** heading.


### PR DESCRIPTION
The info on the page lacks the complete info and this had led customer open a support cases with us where Bitlocker does not work when they have TPM 2.0 in legacy Mode. This Note will help readers get a complete rationale.