### PR TITLE
Updated Info on TPM 2.0 with Legacy \ CSM Mode.

### DIFF
--- a/windows/security/information-protection/tpm/tpm-recommendations.md
+++ b/windows/security/information-protection/tpm/tpm-recommendations.md
@@ -70,7 +70,9 @@ TPM 2.0 products and systems have important security advantages over TPM 1.2, in
 -   While TPM 1.2 parts are discrete silicon components which are typically soldered on the motherboard, TPM 2.0 is available as a **discrete (dTPM)** silicon component in a single semiconductor package, an **integrated** component incorporated in one or more semiconductor packages - alongside other logic units in the same package(s) - and as a **firmware (fTPM)** based component running in a trusted execution environment (TEE) on a general purpose SoC.
 
 > [!NOTE]
-> TPM 2.0 requires UEFI firmware. A computer with legacy BIOS and TPM 2.0 won't work as expected.
+> TPM 2.0 is not supported in Legacy and CSM Modes of the BIOS. Devices with TPM 2.0 must have their BIOS mode configured as Native UEFI only. The Legacy and Compatibility Support Module (CSM) options must be disabled. For added security Enable the Secure Boot feature.
+
+> Installed Operating System on hardware in legacy mode will stop the OS from booting when the BIOS mode is changed to UEFI. Use the tool [MBR2GPT](https://docs.microsoft.com/en-us/windows/deployment/mbr-to-gpt) before changing the BIOS mode which will prepare the OS and the disk to support UEFI.
 
 ## Discrete, Integrated or Firmware TPM?
 


### PR DESCRIPTION
The info on the page lacks the complete info and this had led customer open a support cases with us where Bitlocker does not work when they have TPM 2.0 in legacy Mode. This Note will help readers get a complete rationale.