### PR TITLE
Windows 10 1903 Removed Features: updates and clarifications

### DIFF
--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -17,7 +17,7 @@ New features are added in each version of Windows 10. Occasionally features are 
 
 **Note**: Join the [Windows Insider program](https://insider.windows.com) to get early access to new Windows 10 builds and test these changes yourself.
 
-## Features we removed or will remove soon
+## Features that have been removed or will be removed soon
 
 The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps depending on these features won't function in this release.   
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -13,7 +13,7 @@ ms.topic: article
 
 > Applies to: Windows 10, version 1903
 
-Each version of Windows 10 adds new features. Occasionally, we also remove features, often because we've added a better option. Below are the details about the features that we've removed in Windows 10, version 1903. **The list below is subject to change and might not include every affected feature.** 
+New features are added in each version of Windows 10. Occasionally features are also removed, often because a better option has been added. Details about features that have been removed in Windows 10, version 1903 are listed below. **The list is subject to change and might not include every affected feature.** 
 
 **Note**: Join the [Windows Insider program](https://insider.windows.com) to get early access to new Windows 10 builds and test these changes yourself.
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -29,14 +29,14 @@ The following features are removed from the installed product image for Windows 
 
 ## Features we’re no longer developing
 
-We're no longer actively developing these features, and may remove them from a future update. Some features have been replaced with other features , while others are now available from different sources. 
+We're no longer developing these features, and may remove them in a future release. Some features have been replaced with other features , while others are now available from different sources. 
 
 If you have feedback about the proposed replacement of any of these features, you can use the [Feedback Hub app](https://support.microsoft.com/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app). 
 
 |Feature    |Details|
 |-----------|---------------------|
 | Taskbar settings roaming| Roaming of taskbar settings is no longer being developed and we plan to disable this capability in a future release|
-|Wi-Fi WEP and TKIP|In this release a warning message will appear when connecting to Wi-Fi networks secured with WEP or TKIP, which are not as secure as those using WPA2 or WPA3. In a future release, any connection to a Wi-Fi network using these old ciphers will be disallowed. Wi-Fi routers should be updated to use AES ciphers, available with WPA2 or WPA3. |
-|Windows To Go|Windows To Go is no longer being developed. It does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB flash drive no longer supported by many OEMs.|
+|Wi-Fi WEP and TKIP|In this release, a warning message appears when connecting to Wi-Fi networks secured with WEP or TKIP, which are not as secure as those using WPA2 or WPA3. In a future release, any connection to a Wi-Fi network using these old ciphers will be disallowed. Wi-Fi routers should be updated to use AES ciphers, available with WPA2 or WPA3. |
+|Windows To Go|Windows To Go is no longer developed. It does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB flash drive that OEMs no longer produce.|
 |Print 3D app|Going forward, 3D Builder is the recommended 3D printing app. To 3D print objects on new Windows devices, customers must first install 3D Builder from the Store.|
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -13,23 +13,23 @@ ms.topic: article
 
 > Applies to: Windows 10, version 1903
 
-Each version of Windows 10 adds new features and functionality; occasionally we also remove features and functionality, often because we've added a better option. Below are the details about the features and functionalities that we removed in Windows 10, version 1903. **The list below is subject to change and might not include every affected feature or functionality.** 
+Each version of Windows 10 adds new features. Occasionally, we also remove features, often because we've added a better option. Below are the details about the features that we've removed in Windows 10, version 1903. **The list below is subject to change and might not include every affected feature.** 
 
 **Note**: Join the [Windows Insider program](https://insider.windows.com) to get early access to new Windows 10 builds and test these changes yourself.
 
 ## Features we removed or will remove soon
 
-The following features and functionalities are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Applications or code that depend on these features won't function in this release unless you use another method.   
+The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps that depend on these features won't function in this release.   
 
 
 |                      Feature                      |                                                                                                                                                                                                                                                                                    Details                                                                                                                                                                                                                                                                                    |
 |---------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|         XDDM-based remote display driver          | Starting with this release the Remote Desktop Services uses a Windows Display Driver Model (WDDM) based Indirect Display Driver (IDD) for a single session remote desktop. The support for Windows 2000 Display Driver Model (XDDM) based remote display drivers will be removed in a future release. Independent Software Vendors that use XDDM-based remote display driver should plan a migration to the WDDM driver model. For more information on implementing remote indirect display driver ISVs can reach out to [rdsdev@microsoft.com](mailto:rdsdev@microsoft.com). |
-| Desktop messaging app doesn't offer messages sync |                                                                                                                          The messaging app on Desktop has a sync feature that can be used to sync SMS text messages received from Windows Mobile and keep a copy of them on the Desktop. The sync feature has been removed from all devices. Due to this change, you will only be able to access messages from the device that received the message.                                                                                                                          |
+|         XDDM-based remote display driver          | Starting with this release, Remote Desktop Services uses an Indirect Display Driver (IDD)—based on Windows Display Driver Model (WDDM)—a single session remote desktop. The support for remote display drivers based on Windows 2000 Display Driver Model (XDDM) will be removed in a future release. Independent Software Vendors (ISVs) that use XDDM-based remote display driver should plan a migration to the WDDM driver model. For more information on implementing remote indirect display driver, ISVs can reach out to [rdsdev@microsoft.com](mailto:rdsdev@microsoft.com). |
+| The Messaging app on desktop doesn't offer messages sync |                                                                                                                          The desktop version of the Messaging app has a sync feature that can be used to sync SMS text messages received from Windows Mobile and keep a copy of them on the desktop. The sync feature has been removed. Because of this change, you will only be able to access messages from the device that have received them.                                                                                                                          |
 
 ## Features we’re no longer developing
 
-We're no longer actively developing these features and may remove them from a future update. Some features have been replaced with other features or functionality, while others are now available from different sources. 
+We're no longer actively developing these features, and may remove them from a future update. Some features have been replaced with other features , while others are now available from different sources. 
 
 If you have feedback about the proposed replacement of any of these features, you can use the [Feedback Hub app](https://support.microsoft.com/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app). 
 
@@ -37,6 +37,6 @@ If you have feedback about the proposed replacement of any of these features, yo
 |-----------|---------------------|
 | Taskbar settings roaming| Roaming of taskbar settings is no longer being developed and we plan to disable this capability in a future release|
 |Wi-Fi WEP and TKIP|In this release a warning message will appear when connecting to Wi-Fi networks secured with WEP or TKIP, which are not as secure as those using WPA2 or WPA3. In a future release, any connection to a Wi-Fi network using these old ciphers will be disallowed. Wi-Fi routers should be updated to use AES ciphers, available with WPA2 or WPA3. |
-|Windows To Go|Windows To Go is no longer being developed. <br><br>The feature does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB that is no longer supported by many OEMs.|
+|Windows To Go|Windows To Go is no longer being developed. It does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB flash driver that is no longer supported by many OEMs.|
 |Print 3D app|Going forward, 3D Builder is the recommended 3D printing app. To 3D print objects on new Windows devices, customers must first install 3D Builder from the Store.|
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -19,7 +19,7 @@ New features are added in each version of Windows 10. Occasionally features are 
 
 ## Features that have been removed or will be removed soon
 
-The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps depending on these features won't function in this release.   
+The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps that depend on these features won't function in this release.   
 
 
 |                      Feature                      |                                                                                                                                                                                                                                                                                    Details                                                                                                                                                                                                                                                                                    |

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -37,6 +37,6 @@ If you have feedback about the proposed replacement of any of these features, yo
 |-----------|---------------------|
 | Taskbar settings roaming| Roaming of taskbar settings is no longer being developed and we plan to disable this capability in a future release|
 |Wi-Fi WEP and TKIP|In this release a warning message will appear when connecting to Wi-Fi networks secured with WEP or TKIP, which are not as secure as those using WPA2 or WPA3. In a future release, any connection to a Wi-Fi network using these old ciphers will be disallowed. Wi-Fi routers should be updated to use AES ciphers, available with WPA2 or WPA3. |
-|Windows To Go|Windows To Go is no longer being developed. It does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB flash driver that is no longer supported by many OEMs.|
+|Windows To Go|Windows To Go is no longer being developed. It does not support feature updates and therefore does not enable you to stay current. It also requires a specific type of USB flash drive no longer supported by many OEMs.|
 |Print 3D app|Going forward, 3D Builder is the recommended 3D printing app. To 3D print objects on new Windows devices, customers must first install 3D Builder from the Store.|
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -29,7 +29,7 @@ The following features are removed from the installed product image for Windows 
 
 ## Features that are no longer being developed
 
-We're no longer developing these features, and may remove them in a future release. Some features have been replaced with other features , while others are now available from different sources. 
+These features are no longer being developed, and may be removed in a future release. Some features have been replaced, while others are now available from different sources. 
 
 If you have feedback about the proposed replacement of any of these features, you can use the [Feedback Hub app](https://support.microsoft.com/help/4021566/windows-10-send-feedback-to-microsoft-with-feedback-hub-app). 
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -27,7 +27,7 @@ The following features are removed from the installed product image for Windows 
 |         XDDM-based remote display driver          | Starting with this release, Remote Desktop Services uses an Indirect Display Driver (IDD)—based on Windows Display Driver Model (WDDM)—a single session remote desktop. The support for remote display drivers based on Windows 2000 Display Driver Model (XDDM) will be removed in a future release. Independent Software Vendors (ISVs) that use XDDM-based remote display driver should plan a migration to the WDDM driver model. For more information on implementing remote indirect display driver, ISVs can reach out to [rdsdev@microsoft.com](mailto:rdsdev@microsoft.com). |
 | The Messaging app on desktop doesn't offer messages sync |                                                                                                                          The desktop version of the Messaging app has a sync feature that can be used to sync SMS text messages received from Windows Mobile and keep a copy of them on the desktop. The sync feature has been removed. Because of this change, you will only be able to access messages from the device that have received them.                                                                                                                          |
 
-## Features we’re no longer developing
+## Features that are no longer being developed
 
 We're no longer developing these features, and may remove them in a future release. Some features have been replaced with other features , while others are now available from different sources. 
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -19,7 +19,7 @@ Each version of Windows 10 adds new features. Occasionally, we also remove featu
 
 ## Features we removed or will remove soon
 
-The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps that depend on these features won't function in this release.   
+The following features are removed from the installed product image for Windows 10, version 1903, or are planned for removal in an upcoming release. Apps depending on these features won't function in this release.   
 
 
 |                      Feature                      |                                                                                                                                                                                                                                                                                    Details                                                                                                                                                                                                                                                                                    |


### PR DESCRIPTION
Copyedited for:

1. Missing words: "flash drive" was missing from "USB".
2. Redundancies: This article kept saying "features and functionality". This is redundant. In software, all features are functional; we have no non-functional features. Hence, "features" alone is enough. Likewise, "unless you use another method" was redundant. Try replacing it with its opposite and see how meaningless the sentence becomes.
3. The name of the app that has lost the sync feature is "Messaging", not "Desktop".