### PR TITLE
fixed markdown headers that needed preceding line break

### DIFF
--- a/windows/configuration/customize-and-export-start-layout.md
+++ b/windows/configuration/customize-and-export-start-layout.md
@@ -78,8 +78,6 @@ To prepare a Start layout for export, you simply customize the Start layout on a
 >
 >In earlier versions of Windows 10, no tile would be pinned.
 
-<span id="bmk-exportstartscreenlayout" />
-
 ## Export the Start layout
 
 When you have the Start layout that you want your users to see, use the [Export-StartLayout](https://docs.microsoft.com/powershell/module/startlayout/export-startlayout?view=win10-ps) cmdlet in Windows PowerShell to export the Start layout to an .xml file. Start layout is located by default at C:\Users\username\AppData\Local\Microsoft\Windows\Shell\

--- a/windows/configuration/customize-and-export-start-layout.md
+++ b/windows/configuration/customize-and-export-start-layout.md
@@ -46,8 +46,8 @@ You can deploy the resulting .xml file to devices using one of the following met
 -   [Mobile device management (MDM)](customize-windows-10-start-screens-by-using-mobile-device-management.md)
 
 <span id="bkmkcustomizestartscreen" />
-## Customize the Start screen on your test computer
 
+## Customize the Start screen on your test computer
 
 To prepare a Start layout for export, you simply customize the Start layout on a test computer.
 
@@ -58,6 +58,7 @@ To prepare a Start layout for export, you simply customize the Start layout on a
 2.  Create a new user account that you will use to customize the Start layout.
 
 <a href="" id="bmk-customize-start"></a>
+
 **To customize Start**
 
 1.  Sign in to your test computer with the user account that you created.
@@ -82,8 +83,8 @@ To prepare a Start layout for export, you simply customize the Start layout on a
 >In earlier versions of Windows 10, no tile would be pinned.
 
 <span id="bmk-exportstartscreenlayout" />
-## Export the Start layout
 
+## Export the Start layout
 
 When you have the Start layout that you want your users to see, use the [Export-StartLayout](https://docs.microsoft.com/powershell/module/startlayout/export-startlayout?view=win10-ps) cmdlet in Windows PowerShell to export the Start layout to an .xml file. Start layout is located by default at C:\Users\username\AppData\Local\Microsoft\Windows\Shell\
 

--- a/windows/configuration/customize-and-export-start-layout.md
+++ b/windows/configuration/customize-and-export-start-layout.md
@@ -45,8 +45,6 @@ You can deploy the resulting .xml file to devices using one of the following met
 
 -   [Mobile device management (MDM)](customize-windows-10-start-screens-by-using-mobile-device-management.md)
 
-<span id="bkmkcustomizestartscreen" />
-
 ## Customize the Start screen on your test computer
 
 To prepare a Start layout for export, you simply customize the Start layout on a test computer.
@@ -56,8 +54,6 @@ To prepare a Start layout for export, you simply customize the Start layout on a
 1.  Set up a test computer on which to customize the Start layout. Your test computer should have the operating system that is installed on the users’ computers (Windows 10 Pro, Enterprise, or Education). Install all apps and services that the Start layout should display.
 
 2.  Create a new user account that you will use to customize the Start layout.
-
-<a href="" id="bmk-customize-start"></a>
 
 **To customize Start**
 


### PR DESCRIPTION
These headers currently look like this on docs.microsoft.com:

![customize the start screen](https://user-images.githubusercontent.com/2458645/60725333-d5f90e00-9f06-11e9-9d3e-0943d7d49082.png)

![export the start layout](https://user-images.githubusercontent.com/2458645/60725340-d98c9500-9f06-11e9-991a-d75aa67112be.png)
