### PR TITLE
Updated the Policy location for Win Version

### DIFF
--- a/windows/security/threat-protection/windows-defender-security-center/wdsc-hide-notifications.md
+++ b/windows/security/threat-protection/windows-defender-security-center/wdsc-hide-notifications.md
@@ -20,7 +20,7 @@ manager: dansimp
 
 **Applies to**
 
-- Windows 10, version 1709 and later
+- Windows 10, version 1809 and above
 
 **Audience**
 
@@ -54,13 +54,13 @@ This can only be done in Group Policy.
 >[!IMPORTANT]
 >### Requirements
 >
->You must have Windows 10, version 1709 or later. The ADMX/ADML template files for earlier versions of Windows do not include these Group Policy settings. 
+>You must have Windows 10, version 1903. The ADMX/ADML template files for earlier versions of Windows do not include these Group Policy settings. 
 
 1.  On your Group Policy management machine, open the [Group Policy Management Console](https://technet.microsoft.com/library/cc731212.aspx), right-click the Group Policy Object you want to configure and click **Edit**.
 
 3.  In the **Group Policy Management Editor** go to **Computer configuration** and click **Administrative templates**.
 
-5.  Expand the tree to **Windows components > Windows Security > Notifications**.
+5.  Expand the tree to **Windows components > Windows Security > Notifications**. For Windows 10 version 1803 and below the path would       be **Windows components > Windows Defender Security Center > Notifications**
 
 6.  Open the **Hide non-critical notifications** setting and set it to **Enabled**. Click **OK**.
 
@@ -76,13 +76,13 @@ This can only be done in Group Policy.
 >[!IMPORTANT]
 >### Requirements
 >
->You must have Windows 10, version 1709 or later. The ADMX/ADML template files for earlier versions of Windows do not include these Group Policy settings. 
+>You must have Windows 10, version 1903. The ADMX/ADML template files for earlier versions of Windows do not include these Group Policy settings. 
 
 1.  On your Group Policy management machine, open the [Group Policy Management Console](https://technet.microsoft.com/library/cc731212.aspx), right-click the Group Policy Object you want to configure and click **Edit**.
 
 3.  In the **Group Policy Management Editor** go to **Computer configuration** and click **Administrative templates**.
 
-5.  Expand the tree to **Windows components > Windows Security > Notifications**.
+5.  Expand the tree to **Windows components > Windows Security > Notifications**. For Windows 10 version 1803 and below the path would       be **Windows components > Windows Defender Security Center > Notifications**
 
 6.  Open the **Hide all notifications** setting and set it to **Enabled**. Click **OK**.
 


### PR DESCRIPTION
The policy location in Win 10 version 1803 and below and 1809 and above was different. I have updated the document accordingly. 

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/4274