### PR TITLE
resolves #4426

### DIFF
--- a/windows/security/threat-protection/intelligence/macro-malware.md
+++ b/windows/security/threat-protection/intelligence/macro-malware.md
@@ -45,6 +45,6 @@ We've seen macro malware download threats from the following families:
 
 * Enterprises can prevent macro malware from running executable content using [ASR rules](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction#enable-and-audit-attack-surface-reduction-rules)
 
-For more tips on protecting yourself from malicious emails, see [phishing](phishing.md). 
+For more tips on protecting yourself from supicious emails, see [phishing](phishing.md). 
 
 For more general tips, see [prevent malware infection](prevent-malware-infection.md). 

--- a/windows/security/threat-protection/intelligence/macro-malware.md
+++ b/windows/security/threat-protection/intelligence/macro-malware.md
@@ -45,6 +45,6 @@ We've seen macro malware download threats from the following families:
 
 * Enterprises can prevent macro malware from running executable content using [ASR rules](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction#enable-and-audit-attack-surface-reduction-rules)
 
-For more tips on protecting yourself from supicious emails, see [phishing](phishing.md). 
+For more tips on protecting yourself from suspicious emails, see [phishing](phishing.md). 
 
 For more general tips, see [prevent malware infection](prevent-malware-infection.md). 

--- a/windows/security/threat-protection/intelligence/macro-malware.md
+++ b/windows/security/threat-protection/intelligence/macro-malware.md
@@ -45,4 +45,6 @@ We've seen macro malware download threats from the following families:
 
 * Enterprises can prevent macro malware from running executable content using [ASR rules](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction#enable-and-audit-attack-surface-reduction-rules)
 
-For more general tips, see [prevent malware infection](prevent-malware-infection.md).
+For more tips on protecting yourself from malicious emails, see [phishing](phishing.md). 
+
+For more general tips, see [prevent malware infection](prevent-malware-infection.md). 


### PR DESCRIPTION
Issue #4426, Avoid malware

> The Macro Malware page is very brief, I was thinking some more information would help. At the end you have <snip> For more general tips, see prevent malware infection<https://docs.microsoft.com/en-us/windows/security/threat-protection/intelligence/prevent-malware-infection>. </snip> Since much macro malware is delivered as part of Phishing attempts, I was thinking if you added a link to the phishing page would help shorten the users search for specific information ie <snip> For more specific tips see https://docs.microsoft.com/en-us/windows/security/threat-protection/intelligence/phishing </snip>

I added the link to the phishing page. Although the general tips page also include a link to the phishing page, a shorter path to what the reader needs couldn't hurt?