### PR TITLE
Make the multi-user case for automatic triggers more clear

### DIFF
--- a/windows/security/identity-protection/vpn/vpn-auto-trigger-profile.md
+++ b/windows/security/identity-protection/vpn/vpn-auto-trigger-profile.md
@@ -59,7 +59,7 @@ Always On is a feature in Windows 10 which enables the active VPN profile to con
 When the trigger occurs, VPN tries to connect. If an error occurs or any user input is needed, the user is shown a toast notification for additional interaction.
 
 
-When a device has multiple profiles with Always On triggers, the user can specify the active profile in **Settings** > **Network & Internet** > **VPN** > *VPN profile* by selecting the **Let apps automatically use this VPN connection** checkbox. By default, the first MDM-configured profile is marked as **Active**. 
+When a device has multiple profiles with Always On triggers, the user can specify the active profile in **Settings** > **Network & Internet** > **VPN** > *VPN profile* by selecting the **Let apps automatically use this VPN connection** checkbox. By default, the first MDM-configured profile is marked as **Active**. Devices with multiple users have the same restriction: only one profile and therefore only one user will be able to use the Always On triggers.
 
 Preserving user Always On preference
 


### PR DESCRIPTION
Devices with multiple always-on triggers can still only have one profile set to active out of all of the profiles for all of the users on the device.