### PR TITLE
Update advanced-troubleshooting-boot-problems.md

### DIFF
--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -153,7 +153,7 @@ If you receive BCD-related errors, follow these steps:
 
 4. You might receive one of the following outputs:
 
-    - Scanning all disks for Windows installations. Please wait, since this may take a while...
+    - Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 0
     The operation completed successfully.
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -14,8 +14,8 @@ ms.topic: troubleshooting
 
 # Advanced troubleshooting for Windows boot problems
 
->[!NOTE]
->This article is intended for use by support agents and IT professionals. If you're looking for more general information about recovery options, see [Recovery options in Windows 10](https://support.microsoft.com/help/12415).
+> [!NOTE]
+> This article is intended for use by support agents and IT professionals. If you're looking for more general information about recovery options, see [Recovery options in Windows 10](https://support.microsoft.com/help/12415).
 
 ## Summary
 
@@ -58,14 +58,14 @@ Here is a summary of the boot sequence, what will be seen on the display, and ty
 
 Each phase has a different approach to troubleshooting. This article provides troubleshooting techniques for problems that occur during the first three phases.
 
->[!NOTE]
->If the computer repeatedly boots to the recovery options, run the following command at a command prompt to break the cycle:
+> [!NOTE]
+> If the computer repeatedly boots to the recovery options, run the following command at a command prompt to break the cycle:
 >
->`Bcdedit /set {default} recoveryenabled no`
+> `Bcdedit /set {default} recoveryenabled no`
 >
->If the F8 options don't work, run the following command:
+> If the F8 options don't work, run the following command:
 >
->`Bcdedit /set {default} bootmenupolicy legacy`
+> `Bcdedit /set {default} bootmenupolicy legacy`
 
 
 ## BIOS phase
@@ -98,8 +98,8 @@ The Startup Repair tool automatically fixes many common problems. The tool also 
 
 To do this, follow these steps.
 
->[!NOTE]
->For additional methods to start WinRE, see [Entry points into WinRE](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
+> [!NOTE]
+> For additional methods to start WinRE, see [Entry points into WinRE](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
 
 1. Start the system to the installation media for the installed version of Windows.  
     **Note** For more information, see [Create installation media for Windows](https://support.microsoft.com/help/15088).
@@ -132,8 +132,8 @@ To repair the boot sector, run the following command:
 BOOTREC /FIXBOOT
 ```
 
->[!NOTE]
->Running **BOOTREC** together with **Fixmbr** overwrites only the master boot code. If the corruption in the MBR affects the partition table, running **Fixmbr** may not fix the problem.
+> [!NOTE]
+> Running **BOOTREC** together with **Fixmbr** overwrites only the master boot code. If the corruption in the MBR affects the partition table, running **Fixmbr** may not fix the problem.
 
 ### Method 3: Fix BCD errors
 
@@ -153,10 +153,12 @@ If you receive BCD-related errors, follow these steps:
 
 4. You might receive one of the following outputs:
 
-    - Scanning all disks for Windows installations. Please wait, since this may take a while...Successfully scanned Windows installations. Total identified Windows installations: 0
+    - Scanning all disks for Windows installations. Please wait, since this may take a while...
+    Successfully scanned Windows installations. Total identified Windows installations: 0
     The operation completed successfully.
 
-    - Scanning all disks for Windows installations. Please wait, since this may take a while... Successfully scanned Windows installations. Total identified Windows installations: 1
+    - Scanning all disks for Windows installations. Please wait, since this may take a while...
+    Successfully scanned Windows installations. Total identified Windows installations: 1
     D:\Windows  
     Add installation to boot list? Yes/No/All:
 
@@ -165,7 +167,7 @@ If the output shows **windows installation: 0**, run the following commands:
 ```dos
 bcdedit /export c:\bcdbackup
 
-attrib c:\\boot\\bcd -h -r –s
+attrib c:\\boot\\bcd -r –s -h
 
 ren c:\\boot\\bcd bcd.old
 
@@ -174,10 +176,12 @@ bootrec /rebuildbcd
 
 After you run the command, you receive the following output:
 
-    Scanning all disks for Windows installations. Please wait, since this may take a while...Successfully scanned Windows installations. Total identified Windows installations: 1{D}:\Windows  
-Add installation to boot list? Yes/No/All: Y
+    Scanning all disks for Windows installations. Please wait, since this may take a while...
+    Successfully scanned Windows installations. Total identified Windows installations: 1
+    {D}:\Windows
+    Add installation to boot list? Yes/No/All: Y
 
-5. Try again to start the system.
+5. Try restarting the system.
 
 ### Method 4: Replace Bootmgr
 
@@ -187,26 +191,24 @@ If methods 1 and 2 do not fix the problem, replace the Bootmgr file from drive C
 
 2. Run the **attrib** command to unhide the file:
     ```dos
-    attrib-s -h -r
+    attrib -r -s -h
     ```
 
 3. Run the same **attrib** command on the Windows (system drive):
     ```dos
-    attrib-s -h –r
+    attrib -r -s -h
     ```
 
 4. Rename the Bootmgr file as Bootmgr.old:
     ```dos
-    ren c:\\bootmgr bootmgr.old
+    ren c:\bootmgr bootmgr.old
     ```
 
-5. Start a text editor, such as Notepad.
+5. Navigate to the system drive.
 
-6. Navigate to the system drive.
+6. Copy the Bootmgr file, and then paste it to the System Reserved partition.
 
-7.  Copy the Bootmgr file, and then paste it to the System Reserved partition.
-
-8.  Restart the computer.
+7. Restart the computer.
 
 ### Method 5: Restore System Hive
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -178,12 +178,12 @@ bootrec /rebuildbcd
 
 After you run the command, you receive the following output:
 
-    ```dos
-    Scanning all disks for Windows installations. Please wait, since this may take a while ...
-    Successfully scanned Windows installations. Total identified Windows installations: 1
-    {D}:\Windows
-    Add installation to boot list? Yes/No/All: Y
-    ```
+```dos
+Scanning all disks for Windows installations. Please wait, since this may take a while ...
+Successfully scanned Windows installations. Total identified Windows installations: 1
+{D}:\Windows
+Add installation to boot list? Yes/No/All: Y
+```
 
 5. Try restarting the system.
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -176,7 +176,7 @@ bootrec /rebuildbcd
 
 After you run the command, you receive the following output:
 
-    Scanning all disks for Windows installations. Please wait, since this may take a while...
+    Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 1
     {D}:\Windows
     Add installation to boot list? Yes/No/All: Y

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -151,15 +151,18 @@ If you receive BCD-related errors, follow these steps:
     ```
 
 4. You might receive one of the following outputs:
-
-    - Scanning all disks for Windows installations. Please wait, since this may take a while ...
+    ```dos
+    Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 0
     The operation completed successfully.
+    ```
 
-    - Scanning all disks for Windows installations. Please wait, since this may take a while ...
+    ```dos
+    Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 1
     D:\Windows  
     Add installation to boot list? Yes/No/All:
+    ```
 
 If the output shows **windows installation: 0**, run the following commands:
 
@@ -175,10 +178,12 @@ bootrec /rebuildbcd
 
 After you run the command, you receive the following output:
 
+    ```dos
     Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 1
     {D}:\Windows
     Add installation to boot list? Yes/No/All: Y
+    ```
 
 5. Try restarting the system.
 
@@ -268,16 +273,16 @@ For detailed instructions, see [How to perform a clean boot in Windows](https://
 If the computer starts in Disable Driver Signature mode, start the computer in Disable Driver Signature Enforcement mode, and then follow the steps that are documented in the following article to determine which drivers or files require driver signature enforcement:
 [Troubleshooting boot problem caused by missing driver signature (x64)](https://blogs.technet.microsoft.com/askcore/2012/04/15/troubleshooting-boot-issues-due-to-missing-driver-signature-x64/)
 
->[!NOTE]
->If the computer is a domain controller, try Directory Services Restore mode (DSRM).
+> [!NOTE]
+> If the computer is a domain controller, try Directory Services Restore mode (DSRM).
 >
->This method is an important step if you encounter Stop error "0xC00002E1" or "0xC00002E2"
+> This method is an important step if you encounter Stop error "0xC00002E1" or "0xC00002E2"
 
 
 **Examples**
 
->[!WARNING]
->Serious problems might occur if you modify the registry incorrectly by using Registry Editor or by using another method. These problems might require that you reinstall the operating system. Microsoft cannot guarantee that these
+> [!WARNING]
+> Serious problems might occur if you modify the registry incorrectly by using Registry Editor or by using another method. These problems might require that you reinstall the operating system. Microsoft cannot guarantee that these
 problems can be solved. Modify the registry at your own risk.
 
 *Error code INACCESSIBLE_BOOT_DEVICE (STOP 0x7B)*
@@ -308,11 +313,11 @@ For additional troubleshooting steps, see the following articles:
 
 To fix problems that occur after you install Windows updates, check for pending updates by using these steps:
 
-1. Open a Command Prompt winodw in WinRE.
+1. Open a Command Prompt window in WinRE.
 
 2. Run the command:
     ```dos
-    dism /image:C:\ /get-packages
+    DISM /image:C:\ /get-packages
     ```
 
 3. If there are any pending updates, uninstall them by running the following commands:
@@ -320,7 +325,7 @@ To fix problems that occur after you install Windows updates, check for pending 
     DISM /image:C:\ /remove-package /packagename: name of the package
     ```
     ```dos
-    Dism /Image:C:\ /Cleanup-Image /RevertPendingActions
+    DISM /Image:C:\ /Cleanup-Image /RevertPendingActions
     ```
 
 Try to start the computer.

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -101,7 +101,7 @@ To do this, follow these steps.
 > [!NOTE]
 > For additional methods to start WinRE, see [Windows Recovery Environment (Windows RE)](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
 
-1. Start the system to the installation media for the installed version of Windows.  
+1. Start the system to the installation media for the installed version of Windows. For more information, see [Create installation media for Windows](https://support.microsoft.com/help/15088).
 
 2. On the **Install Windows** screen, select **Next** > **Repair your computer**.
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -102,7 +102,6 @@ To do this, follow these steps.
 > For additional methods to start WinRE, see [Windows Recovery Environment (Windows RE)](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
 
 1. Start the system to the installation media for the installed version of Windows.  
-    **Note** For more information, see [Create installation media for Windows](https://support.microsoft.com/help/15088).
 
 2. On the **Install Windows** screen, select **Next** > **Repair your computer**.
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -184,7 +184,7 @@ After you run the command, you receive the following output:
 
 ### Method 4: Replace Bootmgr
 
-If methods 1 and 2 do not fix the problem, replace the Bootmgr file from drive C to the System Reserved partition. To do this, follow these steps:
+If methods 1, 2 and 3 do not fix the problem, replace the Bootmgr file from drive C to the System Reserved partition. To do this, follow these steps:
 
 1. At a command prompt, change the directory to the System Reserved partition.
 

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -99,7 +99,7 @@ The Startup Repair tool automatically fixes many common problems. The tool also 
 To do this, follow these steps.
 
 > [!NOTE]
-> For additional methods to start WinRE, see [Entry points into WinRE](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
+> For additional methods to start WinRE, see [Windows Recovery Environment (Windows RE)](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre).
 
 1. Start the system to the installation media for the installed version of Windows.  
     **Note** For more information, see [Create installation media for Windows](https://support.microsoft.com/help/15088).

--- a/windows/client-management/advanced-troubleshooting-boot-problems.md
+++ b/windows/client-management/advanced-troubleshooting-boot-problems.md
@@ -157,7 +157,7 @@ If you receive BCD-related errors, follow these steps:
     Successfully scanned Windows installations. Total identified Windows installations: 0
     The operation completed successfully.
 
-    - Scanning all disks for Windows installations. Please wait, since this may take a while...
+    - Scanning all disks for Windows installations. Please wait, since this may take a while ...
     Successfully scanned Windows installations. Total identified Windows installations: 1
     D:\Windows  
     Add installation to boot list? Yes/No/All:


### PR DESCRIPTION
**Description:**

This pull request is based on a user report in issue ticket #4631, suggesting that some of the content needs review, in particular [**Method 4: Replace Bootmgr**](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/client-management/advanced-troubleshooting-boot-problems.md#method-4-replace-bootmgr) (Github document link).

**Proposed changes:**

- Set correct MarkDown spacing for [!NOTE] blocks
- Add newline breaks to output text for readability
- Reorder attrib command parameters to logical order
- Add missing space between the command attrib and its parameters
- Remove a redundant double backslash in a rename (`ren`) command
- Remove redundant line "Start a text editor, such as Notepad."

**Issue ticket closure or reference:**

Closes #4631

**Additional notes and ToDo:**

This PR content needs additional feedback and possibly verification regarding the use of Double Backslash in the troubleshooting examples.
I also request feedback whether any of my suggested formatting improvements break any existing recommended standard in this document.

@nenonix & @JohanFreelancer9 : Please do a copy review and suggest any changes you know will be needed.

@mypil : Please follow up this PR and locate the current author or replacement final reviewer to validate the changes.