### PR TITLE
Fix rendering of headings

### DIFF
--- a/windows/configuration/kiosk-single-app.md
+++ b/windows/configuration/kiosk-single-app.md
@@ -51,6 +51,7 @@ Method | Description
 
 
 <span id="local"/>
+
 ## Set up a kiosk in local Settings
 
 >App type: UWP
@@ -122,6 +123,7 @@ To remove assigned access, choose **Turn off assigned access and sign out of the
 
 
 <span id="powershell"/>
+
 ## Set up a kiosk using Windows PowerShell
 
  
@@ -182,6 +184,7 @@ Clear-AssignedAccess
 
 
 <span id="wizard" />
+
 ## Set up a kiosk using the kiosk wizard in Windows Configuration Designer
 
 >App type: UWP or Windows desktop application
@@ -234,6 +237,7 @@ When you use the **Provision kiosk devices** wizard in Windows Configuration Des
 
 
 <span id="mdm" />
+
 ## Set up a kiosk or digital sign using Microsoft Intune or other MDM service
 
 >App type: UWP 


### PR DESCRIPTION
Before, `##` headings were rendered as plain text including markup, not as heading.
Seen on the MS docs website and Github, so this seems to be a universal markdown rendering issue.
Apparently, `##` requires a blank line before to be rendered as a heading.