### PR TITLE
Windows/Configuration: broken header+missing space

### DIFF
--- a/windows/configuration/customize-windows-10-start-screens-by-using-provisioning-packages-and-icd.md
+++ b/windows/configuration/customize-windows-10-start-screens-by-using-provisioning-packages-and-icd.md
@@ -23,12 +23,12 @@ ms.date: 11/15/2017
 - Windows 10
 
 
->**Looking for consumer information?** [Customize the Start menu](https://go.microsoft.com/fwlink/p/?LinkId=623630)
+> **Looking for consumer information?** [Customize the Start menu](https://go.microsoft.com/fwlink/p/?LinkId=623630)
 
 In Windows 10 Pro, Windows 10 Enterprise, and Windows 10 Education, version 1703, you can use a provisioning package that you create with Windows Configuration Designer to deploy a customized Start and taskbar layout to users. No reimaging is required, and the Start and taskbar layout can be updated simply by overwriting the .xml file that contains the layout. The provisioning package can be applied to a running device. This enables you to customize Start and taskbar layouts for different departments or organizations, with minimal management overhead.
 
->[!IMPORTANT]
->If you use a provisioning package to configure the taskbar, your configuration will be reapplied each time the explorer.exe process restarts. If your configuration pins an app and the user unpins that app, the user's change will be overwritten the next time the configuration is applied. To apply a taskbar configuration and allow users to make changes that will persist, apply your configuration by using Group Policy.
+> [!IMPORTANT]
+> If you use a provisioning package to configure the taskbar, your configuration will be reapplied each time the explorer.exe process restarts. If your configuration pins an app and the user unpins that app, the user's change will be overwritten the next time the configuration is applied. To apply a taskbar configuration and allow users to make changes that will persist, apply your configuration by using Group Policy.
 
 **Before you begin**: [Customize and export Start layout](customize-and-export-start-layout.md) for desktop editions.
 
@@ -39,14 +39,15 @@ Three features enable Start and taskbar layout control:
 
 -   The **Export-StartLayout** cmdlet in Windows PowerShell exports a description of the current Start layout in .xml file format. 
 
-    >[!NOTE]
-    >To import the layout of Start to a mounted Windows image, use the [Import-StartLayout](https://docs.microsoft.com/powershell/module/startlayout/import-startlayout) cmdlet.
+    > [!NOTE]
+    > To import the layout of Start to a mounted Windows image, use the [Import-StartLayout](https://docs.microsoft.com/powershell/module/startlayout/import-startlayout) cmdlet.
 
 -    [You can modify the Start .xml file](configure-windows-10-taskbar.md) to include  `<CustomTaskbarLayoutCollection>` or create an .xml file just for the taskbar configuration.
 
 -   In Windows Configuration Designer, you use the **Policies/Start/StartLayout** setting to provide the contents of the .xml file that defines the Start and taskbar layout.
 
-<span id="escape" />
+<span id="escape"/>
+
 ## Prepare the Start layout XML file
 
 The **Export-StartLayout** cmdlet produces an XML file. Because Windows Configuration Designer produces a customizations.xml file that contains the configuration settings, adding the Start layout section to the customizations.xml file directly would result in an XML file embedded in an XML file. Before you add the Start layout section to the customizations.xml file, you must replace the markup characters in your layout.xml with escape characters. 
@@ -61,8 +62,8 @@ The **Export-StartLayout** cmdlet produces an XML file. Because Windows Configur
 
 Use the Windows Configuration Designer tool to create a provisioning package. [Learn how to install Windows Configuration Designer.](provisioning-packages/provisioning-install-icd.md)
 
->[!IMPORTANT]
->When you build a provisioning package, you may include sensitive information in the project files and in the provisioning package (.ppkg) file. Although you have the option to encrypt the .ppkg file, project files are not encrypted. You should store the project files in a secure location and delete the project files when they are no longer needed.
+> [!IMPORTANT]
+> When you build a provisioning package, you may include sensitive information in the project files and in the provisioning package (.ppkg) file. Although you have the option to encrypt the .ppkg file, project files are not encrypted. You should store the project files in a secure location and delete the project files when they are no longer needed.
 
 1.  Open Windows Configuration Designer (by default, %systemdrive%\\Program Files (x86)\\Windows Kits\\10\\Assessment and Deployment Kit\\Imaging and Configuration Designer\\x86\\ICD.exe).
 
@@ -76,8 +77,8 @@ Use the Windows Configuration Designer tool to create a provisioning package. [L
 
 6. Expand **Runtime settings** &gt; **Policies** &gt; **Start**, and click **StartLayout**.
 
-   >[!TIP]
-   >If **Start** is not listed, check the type of settings you selected in step 4. You must create the project using settings for **All Windows desktop editions**.
+   > [!TIP]
+   > If **Start** is not listed, check the type of settings you selected in step 4. You must create the project using settings for **All Windows desktop editions**.
 
 7. Enter **layout.xml**. This value creates a placeholder in the customizations.xml file that you will replace with the contents of the layout.xml file in a later step.
 


### PR DESCRIPTION
**Description:**

Seeing that there is a broken header on this page, I found the error to be caused by a preceding HTML tag on the line directly above the header.
While browsing the page source, I also noticed the common mistake of not having 1 space character between the MarkDown indent character ( `>` ) and its following text in sections such as `[!NOTE]`, `[!TIP]` and `[!IMPORTANT]`, as well as its following text (and a stray link text at the top of the page, also missing this recommended space).

**Proposed changes:**
- Repair a broken MarkDown (MD) header by adding a blank line between it
  and its preceding HTML tag, which up until now has disabled the header

- Set correct MarkDown spacing for Note/Tip/important block indents
  (1 space between the indent marker and its text content)

**issue ticket closure or reference:**

There is no open issue asking for this specific change yet. I simply noticed the broken header while browsing this page, linked from the issue #4659 (**Escape chars still needed?**), although it is currently not within the scope of this PR to solve the issue reported by the user in that ticket. Even so, if asked, I will happily add any recommended changes to this PR if it helps resolving an open issue ticket.