### PR TITLE
I have added error code 0x801C03F2 - Please review

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
+++ b/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
@@ -187,6 +187,12 @@ If the error occurs again, check the error code against the following table to s
 <td align="left">The AIK certificate is no longer valid</td>
 <td align="left">Sign out and then sign in again.</td>
 </tr>
+</tr>
+<tr class="odd">
+<td align="left">0x801C03F2</td>
+<td align="left">Windows Hello key registration failed.</td>
+<td align="left">ERROR_BAD_DIRECTORY_REQUEST. Another object with the same value for property proxyAddresses already exists.</td>
+</tr>
 <tr class="odd">
 <td align="left">​0x801C044D</td>
 <td align="left">Unable to obtain user token</td>
@@ -197,6 +203,7 @@ If the error occurs again, check the error code against the following table to s
 <td align="left">Failed to receive user creds input</td>
 <td align="left">Sign out and then sign in again.</td>
 </tr>
+
 </tbody>
 </table>
  


### PR DESCRIPTION
I have added this error code and this would come when the user object proxy address in conflict. User wont be able to provision for PIN or Bio-metric. This may occur any user on any directory as duplicate proxy address is common error. Please review and approve
Event ids: 7510,7045
Windows Hello key registration failed.Error: 0x801C03F2
Windows Hello processing failed with 0x801C03F2.

device reg admin logs event id 301:
Error code: directory_error 
Server error message: Another object with the same value for property proxyAddresses already exists. 
Recommended client response: ERROR_BAD_DIRECTORY_REQUEST 
Server response: {"error":{"code":"directory_error","message":"Another object with the same value for property proxyAddresses already exists.","response":"ERROR_BAD_DIRECTORY_REQUEST","target":"ProvisionKey","clientrequestid":"fa703d18-824b-4904-9dc7-8267a82f257c","time":"08-07-2019 15:32:47Z","innererror":{"trace":null,"context":null}}}