### PR TITLE
MacOS manual onboarding: instruct to use absolute path to python

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/microsoft-defender-atp-mac-install-manually.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/microsoft-defender-atp-mac-install-manually.md
@@ -151,7 +151,7 @@ realTimeProtectionEnabled               : true
 2. Install the configuration file on a client machine:
 
     ```bash
-    python WindowsDefenderATPOnboarding.py
+    /usr/bin/python WindowsDefenderATPOnboarding.py
     Generating /Library/Application Support/Microsoft/Defender/com.microsoft.wdav.atp.plist ... (You may be required to enter sudos password)
     ```
 


### PR DESCRIPTION
validated on 10.14 and 10.15 vanilla and after install of Python 3.x