### PR TITLE
Update autopilot-support.md

### DIFF
--- a/windows/deployment/windows-autopilot/autopilot-support.md
+++ b/windows/deployment/windows-autopilot/autopilot-support.md
@@ -7,7 +7,8 @@ ms.mktglfcycl: deploy
 ms.localizationpriority: low
 ms.sitesec: library
 ms.pagetype: deploy
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.author: greglin
 ms.date: 10/31/2018
 ms.reviewer: 
@@ -29,9 +30,8 @@ Before contacting the resources listed below for Windows Autopilot-related issue
 |---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OEM or Channel Partner registering devices as a CSP (via MPC) | Use the help resources available in MPC. Whether you are a named partner or a channel partner (distributor, reseller, SI, etc.), if you’re a CSP registering Autopilot devices through MPC (either manually or through the MPC API), your first-line of support should be the help resources within MPC. |
 |         OEM registering devices using OEM Direct API          |                                                                         Contact MSOEMOPS@microsoft.com. Response time depends on priority: <br>Low – 120 hours <br>Normal – 72 hours <br>High – 24 hours <br>Immediate – 4 hours                                                                         |
-|                        OEM with a PFE                         |                                                                                                                                    Reach out to your PFE for support.                                                                                                                                    |
 |      Partners with a Partner Technology Strategist (PTS)      |                                                                             If you have a PTS (whether you’re a CSP or not), you may first try working through your account’s specific Partner Technology Strategist (PTS).                                                                              |
-|                 Partners with an Ecosystem PM                 |                                                                   If you have an Ecosystem PM (whether you’re a CSP or not), you may first try working through your account’s specific Ecosystem PM, especially for technical issues.                                                                    |
+|                 Partners with an Ecosystem PM                 |                                                                   If you have an Ecosystem PM (whether you’re a CSP or not), you may first try working through your account’s specific Ecosystem PM, especially for technical issues. To learn more about Ecosystem PMs and the services they offer, contact epsoinfo@microsoft.com.                                                                   |
 |                     Enterprise customers                      |                                                                                 Contact your Technical Account Manager (TAM), or Account Technology Strategist (ATS), or Customer Service Support (CSS) representative.                                                                                  |
 |                           End-user                            |                                                                                                                                      Contact your IT administrator.                                                                                                                                      |
 |             Microsoft Partner Center (MPC) users              |                                                                                                            Use the [help resources](https://partner.microsoft.com/support) available in MPC.                                                                                                             |


### PR DESCRIPTION
Remove redundant line (PFE was the old term for an Ecosystem PM).  And added new alias for Ecosystem PMs (after discussing all this with the Ecosystem PM managers).