### PR TITLE
Update policy-csp-update.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-update.md
+++ b/windows/client-management/mdm/policy-csp-update.md
@@ -1072,7 +1072,7 @@ The following list shows the supported values:
 -  4  {0x4}  - Windows Insider build - Slow (added in Windows 10, version 1709)
 -  8  {0x8}  - Release Windows Insider build (added in Windows 10, version 1709)
 -  16 {0x10} - (default) Semi-annual Channel (Targeted). Device gets all applicable feature updates from Semi-annual Channel (Targeted). 
--  32 {0x20} - Semi-annual Channel. Device gets feature updates from Semi-annual Channel. (*Only applicable to releases prior to 1903)
+-  32 {0x20} - Semi-annual Channel. Device gets feature updates from Semi-annual Channel. (*Only applicable to releases prior to 1903, for all releases 1903 and after the Semi-annual Channel and Semi-annual Channel (Targeted) into a single Semi-annual Channel with a value of 16)
 
 <!--/SupportedValues-->
 <!--/Policy-->


### PR DESCRIPTION
We have MDMs who need to be aware that the value of 32 has been deprecated as a supported value for branch readiness level on Win. 10 version 1903 and beyond. Please update ASAP.