### PR TITLE
fix(ACT): format important/note alerts

### DIFF
--- a/windows/deployment/planning/compatibility-administrator-users-guide.md
+++ b/windows/deployment/planning/compatibility-administrator-users-guide.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -38,8 +39,8 @@ The following flowchart shows the steps for using the Compatibility Administrato
 
 ![act compatibility admin flowchart](images/dep-win8-l-act-compatadminflowchart.jpg)
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create and work with custom databases for 32-bit applications, and the 64-bit version to create and work with custom databases for 64-bit applications.
+> [!IMPORTANT]  
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create and work with custom databases for 32-bit applications, and the 64-bit version to create and work with custom databases for 64-bit applications.
 
  
 

--- a/windows/deployment/planning/compatibility-fix-database-management-strategies-and-deployment.md
+++ b/windows/deployment/planning/compatibility-fix-database-management-strategies-and-deployment.md
@@ -102,8 +102,8 @@ If you decide to use the centralized compatibility-fix database deployment strat
 
 5.  The team that manages the centralized database opens Custom DB1 and uses the Compatibility Administrator to include the new compatibility fixes that were included in Custom DB2.
 
-    **Note**  
-    Custom DB1 contains a unique GUID that makes updating the database easier. For example, if you install a new version of the custom compatibility-fix database that uses the same GUID as the previous version, the computer will automatically uninstall the old version.
+    > [!NOTE]  
+    > Custom DB1 contains a unique GUID that makes updating the database easier. For example, if you install a new version of the custom compatibility-fix database that uses the same GUID as the previous version, the computer will automatically uninstall the old version.
 
 
 
@@ -123,23 +123,17 @@ In order to meet the two requirements above, we recommend that you use one of th
 
     You can package your .sdb file and a custom deployment script into an .msi file, and then deploy the .msi file into your organization.
 
-    **Important**  
-    You must ensure that you mark your custom script so that it does not impersonate the calling user. For example, if you use Microsoft® Visual Basic® Scripting Edition (VBScript), the custom action type would be:
+    > [!IMPORTANT]
+    > You must ensure that you mark your custom script so that it does not impersonate the calling user. For example, if you use Microsoft® Visual Basic® Scripting Edition (VBScript), the custom action type would be:
+    >`msidbCustomActionTypeVBScript + msidbCustomActionTypeInScript + msidbCustomActionTypeNoImpersonate = 0x0006 + 0x0400 + 0x0800 = 0x0C06 = 3078 decimal)`
 
-
-
-~~~
-```
-msidbCustomActionTypeVBScript + msidbCustomActionTypeInScript + msidbCustomActionTypeNoImpersonate = 0x0006 + 0x0400 + 0x0800 = 0x0C06 = 3078 decimal)
-```
-~~~
 
 -   **Using a network share and a custom script**
 
 You can store your .sdb file on your network share and then call to a script that resides on your specified computers.
 
-**Important**  
-You must ensure that you call the script at a time when it will receive elevated rights. For example, you should call the script by using computer startup scripts instead of a user logon script. You must also ensure that the installation of the custom compatibility-fix database occurs with Administrator rights.
+> [!IMPORTANT]  
+> You must ensure that you call the script at a time when it will receive elevated rights. For example, you should call the script by using computer startup scripts instead of a user logon script. You must also ensure that the installation of the custom compatibility-fix database occurs with Administrator rights.
 
 
 

--- a/windows/deployment/planning/compatibility-fixes-for-windows-8-windows-7-and-windows-vista.md
+++ b/windows/deployment/planning/compatibility-fixes-for-windows-8-windows-7-and-windows-vista.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -28,8 +29,8 @@ ms.topic: article
 
 You can fix some compatibility issues that are due to the changes made between Windows operating system versions. These issues can include User Account Control (UAC) restrictions.
 
-**Important**  
-The Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator. You must use the 32-bit version for 32-bit applications and the 64-bit version to work for 64-bit applications. You will receive an error message if you try to use the wrong version.
+> [!IMPORTANT]
+> The Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator. You must use the 32-bit version for 32-bit applications and the 64-bit version to work for 64-bit applications. You will receive an error message if you try to use the wrong version.
 
 If you start the Compatibility Administrator as an Administrator (with elevated privileges), all repaired applications can run successfully; however, virtualization and redirection might not occur as expected. To verify that a compatibility fix addresses an issue, you must test the repaired application by running it under the destination user account.
 

--- a/windows/deployment/planning/creating-a-custom-compatibility-fix-in-compatibility-administrator.md
+++ b/windows/deployment/planning/creating-a-custom-compatibility-fix-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -28,8 +29,8 @@ ms.topic: article
 
 The Compatibility Administrator tool uses the term *fix* to describe the combination of compatibility information added to a customized database for a specific application. This combination can include single application fixes, groups of fixes that work together as a compatibility mode, and blocking and non-blocking AppHelp messages.
 
-**Important**  
-Fixes apply to a single application only; therefore, you must create multiple fixes if you need to fix the same issue in multiple applications.
+> [!IMPORTANT]  
+> Fixes apply to a single application only; therefore, you must create multiple fixes if you need to fix the same issue in multiple applications.
 
  
 
@@ -43,8 +44,8 @@ A compatibility fix, previously known as a shim, is a small piece of code that i
 
 The Compatibility Administrator tool has preloaded fixes for many common applications, including known compatibility fixes, compatibility modes, and AppHelp messages. Before you create a new compatibility fix, you can search for an existing application and then copy and paste the known fixes into your customized database.
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
+> [!IMPORTANT]  
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
 
  
 

--- a/windows/deployment/planning/creating-a-custom-compatibility-mode-in-compatibility-administrator.md
+++ b/windows/deployment/planning/creating-a-custom-compatibility-mode-in-compatibility-administrator.md
@@ -39,8 +39,8 @@ A compatibility mode is a group of compatibility fixes. A compatibility fix, pre
 
 The Compatibility Administrator tool has preloaded fixes for many common applications, including known compatibility fixes, compatibility modes, and AppHelp messages. Before you create a new compatibility mode, you can search for an existing application and then copy and paste the known fixes into your custom database.
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
+> [!IMPORTANT]
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
 
 
 
@@ -55,8 +55,8 @@ Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version o
 
 If you are unable to find a preloaded compatibility mode for your application, you can create a new one for use by your custom database.
 
-**Important**  
-A compatibility mode includes a set of compatibility fixes and must be deployed as a group. Therefore, you should include only fixes that you intend to deploy together to the database.
+> [!IMPORTANT]  
+> A compatibility mode includes a set of compatibility fixes and must be deployed as a group. Therefore, you should include only fixes that you intend to deploy together to the database.
 
 
 

--- a/windows/deployment/planning/creating-an-apphelp-message-in-compatibility-administrator.md
+++ b/windows/deployment/planning/creating-an-apphelp-message-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -40,8 +41,8 @@ A non-blocking AppHelp message does not prevent the application from starting, b
 
 The Compatibility Administrator tool has preloaded fixes for many common applications, including known compatibility fixes, compatibility modes, and AppHelp messages. Before you create a new AppHelp message, you can search for an existing application and then copy and paste the known fixes into your custom database.
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
+> [!IMPORTANT]
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to create custom databases for 32-bit applications and the 64-bit version to create custom databases for 64-bit applications.
 
  
 

--- a/windows/deployment/planning/deployment-considerations-for-windows-to-go.md
+++ b/windows/deployment/planning/deployment-considerations-for-windows-to-go.md
@@ -10,7 +10,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: mobility
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.topic: article
 ---
 
@@ -26,8 +27,8 @@ ms.topic: article
 
 From the start, Windows To Go was designed to minimize differences between the user experience of working on a laptop and Windows To Go booted from a USB drive. Given that Windows To Go was designed as an enterprise solution, extra consideration was given to the deployment workflows that enterprises already have in place. Additionally, there has been a focus on minimizing the number of differences in deployment between Windows To Go workspaces and laptop PCs.
 
-**Note**  
-Windows To Go does not support operating system upgrades. Windows To Go is designed as a feature that is managed centrally. IT departments that plan to transition from one operating system version to a later version will need to incorporate re-imaging their existing Windows To Go drives as part of their upgrade deployment process.
+> [!NOTE]
+> Windows To Go does not support operating system upgrades. Windows To Go is designed as a feature that is managed centrally. IT departments that plan to transition from one operating system version to a later version will need to incorporate re-imaging their existing Windows To Go drives as part of their upgrade deployment process.
 
  
 
@@ -250,8 +251,8 @@ The use of the Store on Windows To Go workspaces that are running Windows 8 can
 
     This policy setting specifies whether the PC can use the hibernation sleep state (S4) when started from a Windows To Go workspace. By default, hibernation is disabled when using Windows To Go workspace, so enabling this setting explicitly turns this ability back on. When a computer enters hibernation, the contents of memory are written to disk. When the disk is resumed, it is important that the hardware attached to the system, as well as the disk itself, are unchanged. This is inherently incompatible with roaming between PC hosts. Hibernation should only be used when the Windows To Go workspace is not being used to roam between host PCs.
 
-    **Important**  
-    For the host-PC to resume correctly when hibernation is enabled the Windows To Go workspace must continue to use the same USB port.
+    > [!IMPORTANT]  
+    > For the host-PC to resume correctly when hibernation is enabled the Windows To Go workspace must continue to use the same USB port.
 
      
 
@@ -265,8 +266,8 @@ The use of the Store on Windows To Go workspaces that are running Windows 8 can
 
     This policy setting controls whether the host computer will boot to Windows To Go if a USB device containing a Windows To Go workspace is connected, and controls whether users can make changes using the **Windows To Go Startup Options** settings dialog. If you enable this policy setting, booting to Windows To Go when a USB device is connected will be enabled and users will not be able to make changes using the **Windows To Go Startup Options** settings dialog. If you disable this policy setting, booting to Windows To Go when a USB device is connected will not be enabled unless a user configures the option manually in the firmware. If you do not configure this policy setting, users who are members of the local Administrators group can enable or disable booting from USB using the **Windows To Go Startup Options** settings dialog.
 
-    **Important**  
-    Enabling this policy setting will cause PCs running Windows to attempt to boot from any USB device that is inserted into the PC before it is started.
+    > [!IMPORTANT]  
+    > Enabling this policy setting will cause PCs running Windows to attempt to boot from any USB device that is inserted into the PC before it is started.
 
      
 
@@ -275,8 +276,8 @@ The use of the Store on Windows To Go workspaces that are running Windows 8 can
 
 The biggest hurdle for a user wanting to use Windows To Go is configuring their computer to boot from USB. This is traditionally done by entering the firmware and configuring the appropriate boot order options. To ease the process of making the firmware modifications required for Windows To Go, Windows includes a feature named **Windows To Go Startup Options** that allows a user to configure their computer to boot from USB from within Windows—without ever entering their firmware, as long as their firmware supports booting from USB.
 
-**Note**  
-Enabling a system to always boot from USB first has implications that you should consider. For example, a USB device that includes malware could be booted inadvertently to compromise the system, or multiple USB drives could be plugged in to cause a boot conflict. For this reason, the Windows To Go startup options are disabled by default. In addition, administrator privileges are required to configure Windows To Go startup options.
+> [!NOTE]
+> Enabling a system to always boot from USB first has implications that you should consider. For example, a USB device that includes malware could be booted inadvertently to compromise the system, or multiple USB drives could be plugged in to cause a boot conflict. For this reason, the Windows To Go startup options are disabled by default. In addition, administrator privileges are required to configure Windows To Go startup options.
 
  
 

--- a/windows/deployment/planning/enabling-and-disabling-compatibility-fixes-in-compatibility-administrator.md
+++ b/windows/deployment/planning/enabling-and-disabling-compatibility-fixes-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -33,8 +34,8 @@ You can disable and enable individual compatibility fixes in your customized dat
 
 Customized compatibility databases can become quite complex as you add your fixes for the multiple applications found in your organization. Over time, you may find you need to disable a particular fix in your customized database. For example, if a software vendor releases a fix for an issue addressed in one of your compatibility fixes, you must validate that the vendor's fix is correct and that it resolves your issue. To do this, you must temporarily disable the compatibility fix and then test your application.
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to work with custom databases for 32-bit applications and the 64-bit version to work with custom databases for 64-bit applications.
+> [!IMPORTANT]  
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to work with custom databases for 32-bit applications and the 64-bit version to work with custom databases for 64-bit applications.
 
  
 

--- a/windows/deployment/planning/installing-and-uninstalling-custom-compatibility-databases-in-compatibility-administrator.md
+++ b/windows/deployment/planning/installing-and-uninstalling-custom-compatibility-databases-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -30,8 +31,8 @@ The Compatibility Administrator tool enables the creation and the use of custom-
 
 By default, the Windows® operating system installs a System Application Fix database for use with the Compatibility Administrator. This database can be updated through Windows Update, and is stored in the %WINDIR% \\AppPatch directory. Your custom databases are automatically stored in the %WINDIR% \\AppPatch\\Custom directory and are installed by using the Sdbinst.exe tool provided with the Compatibility Administrator.
 
-**Important**  
-Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to work with custom databases for 32-bit applications and the 64-bit version to work with custom databases for 64-bit applications.
+> [!IMPORTANT]
+> Application Compatibility Toolkit (ACT) installs a 32-bit and a 64-bit version of the Compatibility Administrator tool. You must use the 32-bit version to work with custom databases for 32-bit applications and the 64-bit version to work with custom databases for 64-bit applications.
 
 In addition, you must deploy your databases to your organization’s computers before the included fixes will have any effect on the application issue. For more information about deploying your database, see [Using the Sdbinst.exe Command-Line Tool](using-the-sdbinstexe-command-line-tool.md).
 

--- a/windows/deployment/planning/prepare-your-organization-for-windows-to-go.md
+++ b/windows/deployment/planning/prepare-your-organization-for-windows-to-go.md
@@ -10,7 +10,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: mobility
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.topic: article
 ---
 
@@ -58,8 +59,8 @@ The following scenarios are examples of situations in which Windows To Go worksp
 
 -   **Travel lightly.** In this situation you have employees who are moving from site to site, but who always will have access to a compatible host computer on site. Using Windows To Go workspaces allows them to travel without the need to pack their PC.
 
-**Note**  
-If the employee wants to work offline for the majority of the time, but still maintain the ability to use the drive on the enterprise network, they should be informed of how often the Windows To Go workspace needs to be connected to the enterprise network. Doing so will ensure that the drive retains its access privileges and the workspace’s computer object is not potentially deleted from Active Directory Domain Services (AD DS).
+> [!NOTE]
+> If the employee wants to work offline for the majority of the time, but still maintain the ability to use the drive on the enterprise network, they should be informed of how often the Windows To Go workspace needs to be connected to the enterprise network. Doing so will ensure that the drive retains its access privileges and the workspace’s computer object is not potentially deleted from Active Directory Domain Services (AD DS).
 
  
 
@@ -77,8 +78,8 @@ Microsoft software, such as Microsoft Office, distributed to a Windows To Go wor
 
 You should investigate other software manufacturer’s licensing requirements to ensure they are compatible with roaming usage before deploying them to a Windows To Go workspace.
 
-**Note**  
-Using Multiple Activation Key (MAK) activation is not a supported activation method for Windows To Go as each different PC-host would require separate activation. MAK activation should not be used for activating Windows, Office, or any other application on a Windows To Go drive.
+> [!NOTE]
+> Using Multiple Activation Key (MAK) activation is not a supported activation method for Windows To Go as each different PC-host would require separate activation. MAK activation should not be used for activating Windows, Office, or any other application on a Windows To Go drive.
 
  
 

--- a/windows/deployment/planning/searching-for-fixed-applications-in-compatibility-administrator.md
+++ b/windows/deployment/planning/searching-for-fixed-applications-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -32,9 +33,8 @@ The **Query Compatibility Databases** tool provides additional search options. F
 
 ## Searching for Previously Applied Compatibility Fixes
 
-
-**Important**  
-You must perform your search with the correct version of the Compatibility Administrator tool. If you are searching for a 32-bit custom database, you must use the 32-bit version of Compatibility Administrator. If you are searching for a 64-bit custom database, you must use the 64-bit version of Compatibility Administrator.
+> [!IMPORTANT]
+> You must perform your search with the correct version of the Compatibility Administrator tool. If you are searching for a 32-bit custom database, you must use the 32-bit version of Compatibility Administrator. If you are searching for a 64-bit custom database, you must use the 64-bit version of Compatibility Administrator.
 
  
 

--- a/windows/deployment/planning/searching-for-installed-compatibility-fixes-with-the-query-tool-in-compatibility-administrator.md
+++ b/windows/deployment/planning/searching-for-installed-compatibility-fixes-with-the-query-tool-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -30,8 +31,8 @@ You can access the Query tool from within Compatibility Administrator. The Query
 
 For information about the Search feature, see [Searching for Fixed Applications in Compatibility Administrator](searching-for-fixed-applications-in-compatibility-administrator.md). However, the Query tool provides more detailed search criteria, including tabs that enable you to search the program properties, the compatibility fix properties, and the fix description. You can perform a search by using SQL SELECT and WHERE clauses, in addition to searching specific types of databases.
 
-**Important**  
-You must perform your search with the correct version of the Compatibility Administrator tool. To use the Query tool to search for a 32-bit custom database, you must use the 32-bit version of Compatibility Administrator. To use the Query tool to search for a 64-bit custom database, you must use the 64-bit version of Compatibility Administrator.
+> [!IMPORTANT]
+> You must perform your search with the correct version of the Compatibility Administrator tool. To use the Query tool to search for a 32-bit custom database, you must use the 32-bit version of Compatibility Administrator. To use the Query tool to search for a 64-bit custom database, you must use the 64-bit version of Compatibility Administrator.
 
  
 
@@ -62,8 +63,8 @@ You can use the **Program Properties** tab of the Query tool to search for any c
 
     -   **Application Helps**
 
-    **Important**  
-    If you do not select any of the check boxes, the search will look for all types of compatibility fixes. Do not select multiple check boxes because only applications that match all of the requirements will appear.
+    > [!IMPORTANT]  
+    > If you do not select any of the check boxes, the search will look for all types of compatibility fixes. Do not select multiple check boxes because only applications that match all of the requirements will appear.
 
      
 
@@ -86,15 +87,15 @@ You can use the **Fix Properties** tab of the Query tool to search for any appli
 
 4.  Type the name of the compatibility fix or compatibility mode into the **Search for programs fixed using** field.
 
-    **Note**  
-    You can use the percent (%) symbol as a wildcard in your fix-properties query, as a substitute for any string of zero or more characters.
+    > [!NOTE]
+    > You can use the percent (%) symbol as a wildcard in your fix-properties query, as a substitute for any string of zero or more characters.
 
      
 
 5.  Select the check box for either **Search in Compatibility Fixes** or **Search in Compatibility Modes**.
 
-    **Important**  
-    Your text must match the type of compatibility fix or mode for which you are performing the query. For example, entering the name of a compatibility fix and selecting the compatibility mode check box will not return any results. Additionally, if you select both check boxes, the query will search for the fix by compatibility mode and compatibility fix. Only applications that match both requirements appear.
+    > [!IMPORTANT]
+    > Your text must match the type of compatibility fix or mode for which you are performing the query. For example, entering the name of a compatibility fix and selecting the compatibility mode check box will not return any results. Additionally, if you select both check boxes, the query will search for the fix by compatibility mode and compatibility fix. Only applications that match both requirements appear.
 
      
 
@@ -117,8 +118,8 @@ You can use the **Fix Description** tab of the Query tool to add parameters that
 
 4.  Type your search keywords into the box **Words to look for**. Use commas to separate multiple keywords.
 
-    **Important**  
-    You cannot use wildcards as part of the Fix Description search query because the default behavior is to search for any entry that meets your search criteria.
+    > [!IMPORTANT]
+    > You cannot use wildcards as part of the Fix Description search query because the default behavior is to search for any entry that meets your search criteria.
 
      
 

--- a/windows/deployment/planning/testing-your-application-mitigation-packages.md
+++ b/windows/deployment/planning/testing-your-application-mitigation-packages.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -71,8 +72,8 @@ At this point, you probably cannot resolve any unresolved application compatibil
 
 -   Apply specific compatibility modes, or run the program as an Administrator, by using the Compatibility Administrator tool.
 
-    **Note**  
-    For more information about using Compatibility Administrator to apply compatibility fixes and compatibility modes, see [Using the Compatibility Administrator Tool](using-the-compatibility-administrator-tool.md).
+    > [!NOTE]
+    > For more information about using Compatibility Administrator to apply compatibility fixes and compatibility modes, see [Using the Compatibility Administrator Tool](using-the-compatibility-administrator-tool.md).
 
      
 

--- a/windows/deployment/planning/understanding-and-using-compatibility-fixes.md
+++ b/windows/deployment/planning/understanding-and-using-compatibility-fixes.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -41,8 +42,8 @@ Specifically, the process modifies the address of the affected Windows function 
 
 ![act app redirect with compatibility fix](images/dep-win8-l-act-appredirectwithcompatfix.jpg)
 
-**Note**  
-For statically linked DLLs, the code redirection occurs as the application loads. You can also fix dynamically linked DLLs by hooking into the GetProcAddress API.
+> [!NOTE]
+> For statically linked DLLs, the code redirection occurs as the application loads. You can also fix dynamically linked DLLs by hooking into the GetProcAddress API.
 
  
 
@@ -57,8 +58,8 @@ There are important considerations to keep in mind when determining your applica
 
 -   The compatibility fixes run as user-mode code inside of a user-mode application process. This means that you cannot use a compatibility fix to fix kernel-mode code issues. For example, you cannot use a compatibility fix to resolve device-driver issues.
 
-    **Note**  
-    Some antivirus, firewall, and anti-spyware code runs in kernel mode.
+    > [!NOTE] 
+    > Some antivirus, firewall, and anti-spyware code runs in kernel mode.
 
      
 

--- a/windows/deployment/planning/viewing-the-events-screen-in-compatibility-administrator.md
+++ b/windows/deployment/planning/viewing-the-events-screen-in-compatibility-administrator.md
@@ -9,7 +9,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.pagetype: appcompat
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.date: 04/19/2017
 ms.topic: article
 ---
@@ -28,8 +29,8 @@ ms.topic: article
 
 The **Events** screen enables you to record and to view your activities in the Compatibility Administrator tool, provided that the screen is open while you perform the activities.
 
-**Important**  
-The **Events** screen only records your activities when the screen is open. If you perform an action before opening the **Events** screen, the action will not appear in the list.
+> [!IMPORTANT]  
+> The **Events** screen only records your activities when the screen is open. If you perform an action before opening the **Events** screen, the action will not appear in the list.
 
  
 

--- a/windows/deployment/planning/windows-10-1903-removed-features.md
+++ b/windows/deployment/planning/windows-10-1903-removed-features.md
@@ -5,7 +5,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.localizationpriority: medium
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 manager: laurawi
 ms.author: greglin
 ms.topic: article
@@ -16,7 +17,8 @@ ms.topic: article
 
 Each version of Windows 10 adds new features and functionality; occasionally we also remove features and functionality, often because we've added a better option. Below are the details about the features and functionalities that we removed in Windows 10, version 1903. **The list below is subject to change and might not include every affected feature or functionality.** 
 
-**Note**: Join the [Windows Insider program](https://insider.windows.com) to get early access to new Windows 10 builds and test these changes yourself.
+> [!NOTE]
+> Join the [Windows Insider program](https://insider.windows.com) to get early access to new Windows 10 builds and test these changes yourself.
 
 ## Features we removed or will remove soon
 

--- a/windows/deployment/planning/windows-10-infrastructure-requirements.md
+++ b/windows/deployment/planning/windows-10-infrastructure-requirements.md
@@ -10,7 +10,8 @@ ms.prod: w10
 ms.mktglfcycl: plan
 ms.localizationpriority: medium
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.topic: article
 ---
 
@@ -48,7 +49,8 @@ For System Center Configuration Manager, Windows 10 support is offered with var
 | System Center Configuration Manager 2012 R2 | Yes, with SP1 and CU1  | Yes, with SP1, CU1, and the ADK for Windows 10 |
 
 
->Note: Configuration Manager 2012 supports Windows 10 version 1507 (build 10.0.10240) and 1511 (build 10.0.10586) for the lifecycle of these builds. Future releases of Windows 10 CB/CBB are not supported With Configuration Manager 2012, and will require System Center Configuration Manager current branch for supported management. 
+> [!NOTE]
+> Configuration Manager 2012 supports Windows 10 version 1507 (build 10.0.10240) and 1511 (build 10.0.10586) for the lifecycle of these builds. Future releases of Windows 10 CB/CBB are not supported With Configuration Manager 2012, and will require System Center Configuration Manager current branch for supported management. 
  
 
 For more details about System Center Configuration Manager support for Windows 10, see [Deploy Windows 10 with System Center 2012 R2 Configuration Manager](../deploy-windows-sccm/deploy-windows-10-with-system-center-2012-r2-configuration-manager.md).

--- a/windows/deployment/planning/windows-to-go-frequently-asked-questions.md
+++ b/windows/deployment/planning/windows-to-go-frequently-asked-questions.md
@@ -10,7 +10,8 @@ ms.prod: w10
 ms.mktglfcycl: deploy
 ms.pagetype: mobility
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.topic: article
 ---
 
@@ -180,8 +181,8 @@ Press **Windows logo key+W** and then search for **Windows To Go startup options
 
 In the **Windows To Go Startup Options** dialog box select **Yes** and then click **Save Changes** to configure the computer to boot from USB.
 
-**Note**  
-Your IT department can use Group Policy to configure Windows To Go Startup Options in your organization.
+> [!NOTE]
+> Your IT department can use Group Policy to configure Windows To Go Startup Options in your organization.
 
  
 
@@ -400,8 +401,8 @@ You can reset the BitLocker system measurements to incorporate the new boot orde
 
 The host computer will now be able to be booted from a USB drive without triggering recovery mode.
 
-**Note**  
-The default BitLocker protection profile in Windows 8 or later does not monitor the boot order.
+> [!NOTE]
+> The default BitLocker protection profile in Windows 8 or later does not monitor the boot order.
 
  
 
@@ -412,8 +413,8 @@ Reformatting the drive erases the data on the drive, but doesn’t reconfigure t
 
 1.  Open a command prompt with full administrator permissions.
 
-    **Note**  
-    If your user account is a member of the Administrators group, but is not the Administrator account itself, then, by default, the programs that you run only have standard user permissions unless you explicitly choose to elevate them.
+    > [!NOTE]
+    > If your user account is a member of the Administrators group, but is not the Administrator account itself, then, by default, the programs that you run only have standard user permissions unless you explicitly choose to elevate them.
 
      
 

--- a/windows/deployment/planning/windows-to-go-overview.md
+++ b/windows/deployment/planning/windows-to-go-overview.md
@@ -10,7 +10,8 @@ ms.prod: w10
 ms.mktglfcycl: deploy
 ms.pagetype: mobility, edu
 ms.sitesec: library
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.topic: article
 ---
 
@@ -33,8 +34,8 @@ PCs that meet the Windows 7 or later [certification requirements](https://go.mi
 -   [Prepare for Windows To Go](#wtg-prep-intro)
 -   [Hardware considerations for Windows To Go](#wtg-hardware)
 
-**Note**  
-Windows To Go is not supported on Windows RT.
+> [!NOTE]
+> Windows To Go is not supported on Windows RT.
 
  
 
@@ -69,8 +70,8 @@ Enterprises install Windows on a large group of computers either by using config
 
 These same tools can be used to provision Windows To Go drive, just as you would if you were planning for provisioning a new class of mobile PCs. You can use the [Windows Assessment and Deployment Kit](https://go.microsoft.com/fwlink/p/?LinkId=526803) to review deployment tools available.
 
-**Important**  
-Make sure you use the versions of the deployment tools provided for the version of Windows you are deploying. There have been many enhancements made to support Windows To Go. Using versions of the deployment tools released for earlier versions of Windows to provision a Windows To Go drive is not supported.
+> [!IMPORTANT]
+> Make sure you use the versions of the deployment tools provided for the version of Windows you are deploying. There have been many enhancements made to support Windows To Go. Using versions of the deployment tools released for earlier versions of Windows to provision a Windows To Go drive is not supported.
 
  
 
@@ -122,8 +123,8 @@ Using a USB drive that has not been certified is not supported
 
 -   Spyrus Secure Portable Workplace ([http://www.spyruswtg.com/](https://go.microsoft.com/fwlink/p/?LinkId=618720))
 
-    **Important**  
-    You must use the Spyrus Deployment Suite for Windows To Go to provision the Spyrus Secure Portable Workplace. For more information about the Spyrus Deployment Suite for Windows To Go please refer to [http://www.spyruswtg.com/](https://go.microsoft.com/fwlink/p/?LinkId=618720).
+    > [!IMPORTANT]  
+    > You must use the Spyrus Deployment Suite for Windows To Go to provision the Spyrus Secure Portable Workplace. For more information about the Spyrus Deployment Suite for Windows To Go please refer to [http://www.spyruswtg.com/](https://go.microsoft.com/fwlink/p/?LinkId=618720).
 
      
 


### PR DESCRIPTION
This commit introduces formatting of all alerts within the
`windows/deployment/planning` directory - [Application Compatibility Toolkit (ACT)](https://docs.microsoft.com/en-us/windows/deployment/planning/act-technical-reference)

This is a follow up of PR #4680

=== 
**Screenshots**
From:
![Searching for Fixed Applications in Compatibility Administrator (Windows 10) _ Microsoft Docs](https://user-images.githubusercontent.com/261265/63688168-3aea2980-c80f-11e9-8e66-abe2c888cf78.png)
To:
![Application Compatibility Toolkit (ACT) Technical Reference (Windows 10) _ Microsoft Docs](https://user-images.githubusercontent.com/261265/63688175-40477400-c80f-11e9-8280-8662ffa8d9f4.png)


> **NOTE:**
> I have not yet figured out why when I make a minor change on a file, GIT diffs the whole file as changed. It has to do with something around CLRF but not sure how to fix that.