### PR TITLE
Windows/Deployment: White Glove typo

### DIFF
--- a/windows/deployment/windows-autopilot/white-glove.md
+++ b/windows/deployment/windows-autopilot/white-glove.md
@@ -71,7 +71,7 @@ Windows Autopilot for white glove deployment supports two distinct scenarios:
 - User-driven deployments with Hybrid Azure AD Join.  The device will be joined to an on-premises Active Directory domain, and separately registered with Azure AD.
 Each of these scenarios consists of two parts, a technician flow and a user flow.  At a high level, these parts are the same for Azure AD Join and Hybrid Azure AD join; differences are primarily seen by the end user in the authentication steps.
 
-### Technican flow
+### Technician flow
 
 After the customer or IT Admin has targeted all the apps and settings they want for their devices through Intune, the white glove technician can begin the white glove process.  The technician could be a member of the IT staff, a services partner, or an OEM – each organization can decide who should perform these activities. Regardless of the scenario, the process to be performed by the technician is the same:
 - Boot the device (running Windows 10 Pro, Enterprise, or Education SKUs, version 1903 or later).


### PR DESCRIPTION
**Description:**

From issue ticket #4806, Technician is misspelled as "Technican" in a subsection heading.

**Proposed change:**

- correct the typo, "Technican" -> Technician

**issue ticket closure or reference:**

Closes #4806