### PR TITLE
Windows/What's New: amend broken link in See Also

### DIFF
--- a/windows/whats-new/whats-new-windows-10-version-1903.md
+++ b/windows/whats-new/whats-new-windows-10-version-1903.md
@@ -144,7 +144,7 @@ Several new features are coming in the next version of Edge. See the [news from 
 
 ## See Also
 
-[What's New in Windows Server, version 1903](https://docs.microsoft.com/windows-server/get-started/whats-new-in-windows-server-1903): New and updated features in Windows Server.<br>
+[What's New in Windows Server, version 1903](https://docs.microsoft.com/windows-server/get-started-19/whats-new-in-windows-server-1903): New and updated features in Windows Server.<br>
 [Windows 10 Features](https://www.microsoft.com/windows/features): Review general information about Windows 10 features.<br>
 [What's New in Windows 10](https://docs.microsoft.com/windows/whats-new/): See what’s new in other versions of Windows 10.<br>
 [What's new in Windows 10](https://docs.microsoft.com/windows-hardware/get-started/what-s-new-in-windows): See what’s new in Windows 10 hardware.<br>


### PR DESCRIPTION
**Description:**
The first link under "See Also", "What's New in Windows Server, version 1903" ,
is broken because it points to the wrong directory for the file `whats-new-in-windows-server-1903`
which resides in the new directory `/get-started-19/` instead of the old directory `/get-started/`.

This directory difference is only present in the docs.microsoft.com pages, not on Github.
The links are therefore pointing directly to the docs.microsoft.com pages instead of being
relative to the Github directory structure.

**Proposed change:**
Amend the broken link  https://docs.microsoft.com/windows-server/get-started/whats-new-in-windows-server-1903
with the operative link https://docs.microsoft.com/windows-server/get-started-19/whats-new-in-windows-server-1903

**issue ticket closure or reference:**
Closes #4784