### PR TITLE
Microsoft Defender ATP: amend copy-paste error

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/enable-controlled-folders.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-controlled-folders.md
@@ -55,7 +55,7 @@ For more information about disabling local list merging, see [Prevent or allow u
 > If controlled folder access is configured with Group Policy, PowerShell, or MDM CSPs, the state will change in the Windows Security app after a restart of the device.
 > If the feature is set to **Audit mode** with any of those tools, the Windows Security app will show the state as **Off**.
 
->If you are protecting user profile data, we recommend that the user profile should be on the default Windows installation drive.
+> If you are protecting user profile data, we recommend that the user profile should be on the default Windows installation drive.
 
 ## Intune
 
@@ -63,7 +63,7 @@ For more information about disabling local list merging, see [Prevent or allow u
 1. Click **Device configuration** > **Profiles** > **Create profile**.
 1. Name the profile, choose **Windows 10 and later** and **Endpoint protection**.
    ![Create endpoint protection profile](../images/create-endpoint-protection-profile.png)
-1. Click **Configure** > **Windows Defender Exploit Guard** > **Network filtering** > **Enable**.
+1. Click **Configure** > **Windows Defender Exploit Guard** > **Controlled folder access** > **Enable**.
 1. Type the path to each application that has access to protected folders and the path to any additional folder that needs protection and click **Add**.
 
    ![Enable controlled folder access in Intune](../images/enable-cfa-intune.png)


### PR DESCRIPTION
**Description:**
When using Microsoft Intune as part of the Defender ATP setup, it will become necessary to configure some controlled folder access.
This bug looks like it could have been transferred from one of the other pages during editing, but I could not locate it easily enough.

Anyway, the correct part of this step is to refer to
-- Controlled folder access -- (name of the dialog box)
exactly as the page name points to.

**Proposed changes:**
- Replace the step **Network filtering** with **Controlled folder access**
- MarkDown codestyle correction on the last line of the previous section

👍 Thanks to jcampos79 for discovering this text-based bug.

**issue ticket closure or reference:**

Closes #4854