### PR TITLE
fixes #4760, broken table

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/network-security-configure-encryption-types-allowed-for-kerberos.md
+++ b/windows/security/threat-protection/security-policy-settings/network-security-configure-encryption-types-allowed-for-kerberos.md
@@ -35,14 +35,13 @@ The following table lists and explains the allowed encryption types.
  
 | Encryption type | Description and version support |
 | - | - |
-| DES_CBC_CRC | Data Encryption Standard with Cipher Block Chaining using the Cyclic Redundancy Check function<br/>Supported in Windows 2000 Server, Windows XP, Windows Server 2003, Windows Vista, and Windows Server 2008. The Windows 7, Windows 10 and Windows Server 2008 R2 operating systems do not support DES| by default.
+| DES_CBC_CRC | Data Encryption Standard with Cipher Block Chaining using the Cyclic Redundancy Check function<br/>Supported in Windows 2000 Server, Windows XP, Windows Server 2003, Windows Vista, and Windows Server 2008. The Windows 7, Windows 10 and Windows Server 2008 R2 operating systems do not support DES by default. |
 | DES_CBC_MD5| Data Encryption Standard with Cipher Block Chaining using the Message-Digest algorithm 5 checksum function<br/>Supported in Windows 2000 Server, Windows XP, Windows Server 2003, Windows Vista, and Windows Server 2008. The Windows 7, Windows 10 and Windows Server 2008 R2 operating systems do not support DES by default. |
 | RC4_HMAC_MD5| Rivest Cipher 4 with Hashed Message Authentication Code using the Message-Digest algorithm 5 checksum function<br/>Supported in Windows 2000 Server, Windows XP, Windows Server 2003, Windows Vista, Windows Server 2008, Windows 7, Windows 10 and Windows Server 2008 R2.|
 | AES128_HMAC_SHA1| Advanced Encryption Standard in 128 bit cipher block with Hashed Message Authentication Code using the Secure Hash Algorithm (1).<br/>Not supported in Windows 2000 Server, Windows XP, or Windows Server 2003. Supported in Windows Vista, Windows Server 2008, Windows 7, Windows 10 and Windows Server 2008 R2. |
 | AES256_HMAC_SHA1| Advanced Encryption Standard in 256 bit cipher block with Hashed Message Authentication Code using the Secure Hash Algorithm (1).<br/>Not supported in Windows 2000 Server, Windows XP, or Windows Server 2003. Supported in Windows Vista, Windows Server 2008, Windows 7, Windows 10 and Windows Server 2008 R2. |
 | Future encryption types| Reserved by Microsoft for additional encryption types that might be implemented.|
- 
- 
+
 ### Possible values
 
 


### PR DESCRIPTION
The formatting was broken because a pipe character was in the wrong place. There was also an extra row due to double spacing below the table.