### PR TITLE
Microsoft Defender ATP: amend broken link

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-advanced-threat-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-advanced-threat-protection.md
@@ -19,9 +19,9 @@ ms.topic: conceptual
 
 # Microsoft Defender Advanced Threat Protection
 
->Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/WindowsForBusiness/windows-atp?ocid=docs-wdatp-main-abovefoldlink)
+> Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/WindowsForBusiness/windows-atp?ocid=docs-wdatp-main-abovefoldlink)
 >
->For more info about Windows 10 Enterprise Edition features and functionality, see [Windows 10 Enterprise edition](https://www.microsoft.com/WindowsForBusiness/buy).
+> For more info about Windows 10 Enterprise Edition features and functionality, see [Windows 10 Enterprise edition](https://www.microsoft.com/WindowsForBusiness/buy).
 
 Microsoft Defender Advanced Threat Protection is a platform designed to help enterprise networks prevent, detect, investigate, and respond to advanced threats.
 
@@ -66,9 +66,9 @@ Microsoft Defender ATP uses the following combination of technology built into W
 <br>
 
 
->[!TIP]
->- Learn about the latest enhancements in Microsoft Defender ATP: [What's new in Microsoft Defender ATP](https://cloudblogs.microsoft.com/microsoftsecure/2018/11/15/whats-new-in-windows-defender-atp/).
->- Microsoft Defender ATP demonstrated industry-leading optics and detection capabilities in the recent MITRE evaluation. Read: [Insights from the MITRE ATT&CK-based evaluation](https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/insights-from-the-mitre-attack-based-evaluation-of-windows-defender-atp/).
+> [!TIP]
+> - Learn about the latest enhancements in Microsoft Defender ATP: [What's new in Microsoft Defender ATP](https://cloudblogs.microsoft.com/microsoftsecure/2018/11/15/whats-new-in-windows-defender-atp/).
+> - Microsoft Defender ATP demonstrated industry-leading optics and detection capabilities in the recent MITRE evaluation. Read: [Insights from the MITRE ATT&CK-based evaluation](https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/insights-from-the-mitre-attack-based-evaluation-of-windows-defender-atp/).
 
 <a name="tvm"></a>
 
@@ -99,7 +99,7 @@ In conjunction with being able to quickly respond to advanced attacks, Microsoft
 <a name="ss"></a>
 
 **[Secure score](overview-secure-score.md)**<br>
->[!NOTE]
+> [!NOTE]
 >  Secure score is now part of [Threat & Vulnerability Management](next-gen-threat-and-vuln-mgt.md) as [Configuration score](configuration-score.md). The secure score page will be available for a few weeks. View the [Secure score](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/overview-secure-score) page.
 
 Microsoft Defender ATP includes a secure score to help you dynamically assess the security state of your enterprise network, identify unprotected systems, and take recommended actions to improve the overall security of your organization.
@@ -127,7 +127,7 @@ To help you maximize the effectiveness of the security platform, you can configu
 Topic | Description
 :---|:---
 [Overview](overview.md) | Understand the concepts behind the capabilities in Microsoft Defender ATP so you take full advantage of the complete threat protection platform. 
-[Get started](get-started.md) | Learn about the requirements of the platform and the initial steps you need to take to get started with Microsoft Defender ATP.
+[Minimum requirements](minimum-requirements.md) | Learn about the requirements of the platform and the initial steps you need to take to get started with Microsoft Defender ATP.
 [Configure and manage capabilities](onboard.md)| Configure and manage the individual capabilities in Microsoft Defender ATP. 
 [Troubleshoot Microsoft Defender ATP](troubleshoot-mdatp.md) | Learn how to address issues that you might encounter while using the platform.
 


### PR DESCRIPTION
**Description:**
The link "Get started" at the end of the page "Microsoft Defender Advanced Threat Protection" points to a non-existing page.
It may have been renamed and the name "Get started" appropriated as one of the expandable sections in the left hand side index/TOC section.

**Proposed changes:**
The suggested change is to replace the broken link `get-started.md` with `minimum-requirements.md` found at the same directory level.

Broken link:
- https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/microsoft-defender-atp/get-started.md

Replacement link:
- https://github.com/MicrosoftDocs/windows-itpro-docs/blob/master/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md

I have also included a few MarkDown blockquote spaces where a single space was missing.

**issue ticket closure or reference:**
Closes #4832

Thanks to @xNiklasJern for discovering the broken link.