### PR TITLE
Need to update the policy path details under the section "Use Group Policy to manage the update location"

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
@@ -109,7 +109,7 @@ The procedures in this article first describe how to set the order, and then how
 
 > [!NOTE]
 > For Windows 10, versions 1703 up to and including 1809, the policy path is **Windows Components > Windows Defender Antivirus > Signature Updates**
-      For Windows 10, version 1903, the policy path is Windows Components > Windows Defender Antivirus > Security Intelligence Updates
+> For Windows 10, version 1903, the policy path is **Windows Components > Windows Defender Antivirus > Security Intelligence Updates**
 
 **Use Configuration Manager to manage the update location:**
 

--- a/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
@@ -107,6 +107,8 @@ The procedures in this article first describe how to set the order, and then how
 
    6. Click **OK**. This will set the order of file shares when that source is referenced in the **Define the order of sources...** group policy setting.
 
+Note: For Windows 10, version 1703 till 1809, the policy path is Windows Components > Windows Defender Antivirus > Signature Updates
+      For Windows 10, version 1903, the policy path is Windows Components > Windows Defender Antivirus > Security Intelligence Updates
 
 **Use Configuration Manager to manage the update location:**
 

--- a/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/manage-protection-updates-windows-defender-antivirus.md
@@ -107,7 +107,8 @@ The procedures in this article first describe how to set the order, and then how
 
    6. Click **OK**. This will set the order of file shares when that source is referenced in the **Define the order of sources...** group policy setting.
 
-Note: For Windows 10, version 1703 till 1809, the policy path is Windows Components > Windows Defender Antivirus > Signature Updates
+> [!NOTE]
+> For Windows 10, versions 1703 up to and including 1809, the policy path is **Windows Components > Windows Defender Antivirus > Signature Updates**
       For Windows 10, version 1903, the policy path is Windows Components > Windows Defender Antivirus > Security Intelligence Updates
 
 **Use Configuration Manager to manage the update location:**


### PR DESCRIPTION
Under the section "Use Group Policy to manage the update location", 

The policy path details mentioned in the article is valid only till Windows 10, version 1607. It has changed starting Windows 10, version 1703 and remains the same till Windows 10, version 1809 and then again changed in Windows 10, version 1903.