### PR TITLE
MBAM 2.5 Service releases: add May 2019 to list

### DIFF
--- a/mdop/mbam-v25/mbam-25-supported-configurations.md
+++ b/mdop/mbam-v25/mbam-25-supported-configurations.md
@@ -598,6 +598,7 @@ The MBAM client is not supported on virtual machines and is also not supported o
 - [September 2017](https://support.microsoft.com/en-ie/help/4041137/september-2017-servicing-release-for-microsoft-desktop-optimization)
 - [March 2018](https://support.microsoft.com/help/4074878/march-2018-servicing-release-for-microsoft-desktop-optimization-pack)
 - [July 2018](https://support.microsoft.com/help/4340040/july-2018-servicing-release-for-microsoft-desktop-optimization-pack)
+- [May 2019](https://support.microsoft.com/help/4505175/may-2019-servicing-release-for-microsoft-desktop-optimization-pack)
 
 ## Related topics
 


### PR DESCRIPTION
**Description:**

This is yet another page where the May 2019 Service release is missing from the list of service releases of the Microsoft Desktop Optimization Pack (MDOP).

**Proposed change:**
- add May 2019 Service release at the end of the list.

Thanks to @philschwan for noticing and reporting this detail.

**issue ticket closure or reference:**

Closes #4944