### PR TITLE
surface-hub-recovery-tool.md: Enable image link

### DIFF
--- a/devices/surface-hub/surface-hub-recovery-tool.md
+++ b/devices/surface-hub/surface-hub-recovery-tool.md
@@ -20,8 +20,8 @@ The [Microsoft Surface Hub Recovery Tool](https://www.microsoft.com/download/det
 
 To re-image the Surface Hub SSD using the Recovery Tool, you'll need to remove the SSD from the Surface Hub, connect the drive to the USB-to-SATA cable, and then connect the cable to the desktop PC on which the Recovery Tool is installed. For more information on how to remove the existing drive from your Surface Hub, see [Surface Hub SSD replacement](surface-hub-ssd-replacement.md).
 
->[!IMPORTANT]
->Do not let the device go to sleep or interrupt the download of the image file.
+> [!IMPORTANT]
+> Do not let the device go to sleep or interrupt the download of the image file.
 
 If the tool is unsuccessful in reimaging your drive, please contact [Surface Hub Support](https://support.microsoft.com/help/4037644/surface-contact-surface-warranty-and-software-support).
 
@@ -77,10 +77,7 @@ Install Surface Hub Recovery Tool on the host PC.
 
 5. When the download is complete, the tool instructs you to connect an SSD drive. If the tool is unable to locate the attached drive, there is a good chance that the cable being used is not reporting the name of the SSD to Windows.  The imaging tool must find the name of the drive as "LITEON L CH-128V2S USB Device" before it can continue.  For more information on how to remove the existing drive from your Surface Hub, see [Surface Hub SSD replacement](surface-hub-ssd-replacement.md).
 
-
-~~~
-![Connect SSD](images/shrt-drive.png)
-~~~
+    ![Connect SSD](images/shrt-drive.png)
 
 6. When the drive is recognized, click **Start** to begin the re-imaging process. On the warning that all data on the drive will be erased, click **OK**.
 


### PR DESCRIPTION
**Description:**

The image in step 5 was encapsulated in a code block fence, for reasons
unknown. Thanks to @danieldhudson for noticing this glitch in the doc.

**Proposed changes:**

- Remove the code block fence to make the image link actually work and show the image as intended.
- Add 1 blank MD spacing (on 2 lines) in the `[!IMPORTANT]` note (MD formatting).

**issue ticket closure or reference:**

Closes #4967