### PR TITLE
HTML StartCSP comment tag: remove duplicate tag

### DIFF
--- a/windows/client-management/mdm/configuration-service-provider-reference.md
+++ b/windows/client-management/mdm/configuration-service-provider-reference.md
@@ -2553,8 +2553,6 @@ Additional lists:
 <!--EndCSP-->
 
 <!--StartCSP-->
-
-<!--StartCSP-->
 [WindowsDefenderApplicationGuard CSP](windowsdefenderapplicationguard-csp.md)
 
 <!--StartSKU-->


### PR DESCRIPTION
**Description:**

Redundant HTML comment tag found in long list of CSP tables.

**Proposed changes:**
- Remove the redundant tag and its blank line (minor removal edit).

Thanks to @tr5tn for discovering this minor redundancy.

**issue ticket closure or reference:**

Closes #4974