### PR TITLE
Auditing: add MD code block to table keywords

### DIFF
--- a/windows/security/threat-protection/auditing/event-4624.md
+++ b/windows/security/threat-protection/auditing/event-4624.md
@@ -33,55 +33,55 @@ This event generates when a logon session is created (on destination machine). I
 <br clear="all">
 
 ***Event XML:***
-```
-- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
-- <System>
- <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-A5BA-3E3B0328C30D}" /> 
- <EventID>4624</EventID> 
- <Version>2</Version> 
- <Level>0</Level> 
- <Task>12544</Task> 
- <Opcode>0</Opcode> 
- <Keywords>0x8020000000000000</Keywords> 
- <TimeCreated SystemTime="2015-11-12T00:24:35.079785200Z" /> 
- <EventRecordID>211</EventRecordID> 
- <Correlation ActivityID="{00D66690-1CDF-0000-AC66-D600DF1CD101}" /> 
- <Execution ProcessID="716" ThreadID="760" /> 
- <Channel>Security</Channel> 
- <Computer>WIN-GG82ULGC9GO</Computer> 
- <Security /> 
- </System>
-- <EventData>
- <Data Name="SubjectUserSid">S-1-5-18</Data> 
- <Data Name="SubjectUserName">WIN-GG82ULGC9GO$</Data> 
- <Data Name="SubjectDomainName">WORKGROUP</Data> 
- <Data Name="SubjectLogonId">0x3e7</Data> 
- <Data Name="TargetUserSid">S-1-5-21-1377283216-344919071-3415362939-500</Data> 
- <Data Name="TargetUserName">Administrator</Data> 
- <Data Name="TargetDomainName">WIN-GG82ULGC9GO</Data> 
- <Data Name="TargetLogonId">0x8dcdc</Data> 
- <Data Name="LogonType">2</Data> 
- <Data Name="LogonProcessName">User32</Data> 
- <Data Name="AuthenticationPackageName">Negotiate</Data> 
- <Data Name="WorkstationName">WIN-GG82ULGC9GO</Data> 
- <Data Name="LogonGuid">{00000000-0000-0000-0000-000000000000}</Data> 
- <Data Name="TransmittedServices">-</Data> 
- <Data Name="LmPackageName">-</Data> 
- <Data Name="KeyLength">0</Data> 
- <Data Name="ProcessId">0x44c</Data> 
- <Data Name="ProcessName">C:\\Windows\\System32\\svchost.exe</Data> 
- <Data Name="IpAddress">127.0.0.1</Data> 
- <Data Name="IpPort">0</Data> 
- <Data Name="ImpersonationLevel">%%1833</Data> 
- <Data Name="RestrictedAdminMode">-</Data> 
- <Data Name="TargetOutboundUserName">-</Data> 
- <Data Name="TargetOutboundDomainName">-</Data> 
- <Data Name="VirtualAccount">%%1843</Data> 
- <Data Name="TargetLinkedLogonId">0x0</Data> 
- <Data Name="ElevatedToken">%%1842</Data> 
- </EventData>
- </Event>
-
+```xml
+<?xml version="1.0"?>
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-A5BA-3E3B0328C30D}"/>
+    <EventID>4624</EventID>
+    <Version>2</Version>
+    <Level>0</Level>
+    <Task>12544</Task>
+    <Opcode>0</Opcode>
+    <Keywords>0x8020000000000000</Keywords>
+    <TimeCreated SystemTime="2015-11-12T00:24:35.079785200Z"/>
+    <EventRecordID>211</EventRecordID>
+    <Correlation ActivityID="{00D66690-1CDF-0000-AC66-D600DF1CD101}"/>
+    <Execution ProcessID="716" ThreadID="760"/>
+    <Channel>Security</Channel>
+    <Computer>WIN-GG82ULGC9GO</Computer>
+    <Security/>
+  </System>
+  <EventData>
+    <Data Name="SubjectUserSid">S-1-5-18</Data>
+    <Data Name="SubjectUserName">WIN-GG82ULGC9GO$</Data>
+    <Data Name="SubjectDomainName">WORKGROUP</Data>
+    <Data Name="SubjectLogonId">0x3e7</Data>
+    <Data Name="TargetUserSid">S-1-5-21-1377283216-344919071-3415362939-500</Data>
+    <Data Name="TargetUserName">Administrator</Data>
+    <Data Name="TargetDomainName">WIN-GG82ULGC9GO</Data>
+    <Data Name="TargetLogonId">0x8dcdc</Data>
+    <Data Name="LogonType">2</Data>
+    <Data Name="LogonProcessName">User32</Data>
+    <Data Name="AuthenticationPackageName">Negotiate</Data>
+    <Data Name="WorkstationName">WIN-GG82ULGC9GO</Data>
+    <Data Name="LogonGuid">{00000000-0000-0000-0000-000000000000}</Data>
+    <Data Name="TransmittedServices">-</Data>
+    <Data Name="LmPackageName">-</Data>
+    <Data Name="KeyLength">0</Data>
+    <Data Name="ProcessId">0x44c</Data>
+    <Data Name="ProcessName">C:\\Windows\\System32\\svchost.exe</Data>
+    <Data Name="IpAddress">127.0.0.1</Data>
+    <Data Name="IpPort">0</Data>
+    <Data Name="ImpersonationLevel">%%1833</Data>
+    <Data Name="RestrictedAdminMode">-</Data>
+    <Data Name="TargetOutboundUserName">-</Data>
+    <Data Name="TargetOutboundDomainName">-</Data>
+    <Data Name="VirtualAccount">%%1843</Data>
+    <Data Name="TargetLinkedLogonId">0x0</Data>
+    <Data Name="ElevatedToken">%%1842</Data>
+  </EventData>
+</Event>
 ```
 
 ***Required Server Roles:*** None.
@@ -144,17 +144,17 @@ This event generates when a logon session is created (on destination machine). I
 
 ## Logon types and descriptions
 
-| Logon Type | Logon Title       | Description                                                                                                                                                                                                                                                                                                                |
-|------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2          | Interactive       | A user logged on to this computer.                                                                                                                                                                                                                                                                                         |
-| 3          | Network           | A user or computer logged on to this computer from the network.                                                                                                                                                                                                                                                            |
-| 4          | Batch             | Batch logon type is used by batch servers, where processes may be executing on behalf of a user without their direct intervention.                                                                                                                                                                                         |
-| 5          | Service           | A service was started by the Service Control Manager.                                                                                                                                                                                                                                                                      |
-| 7          | Unlock            | This workstation was unlocked.                                                                                                                                                                                                                                                                                             |
-| 8          | NetworkCleartext  | A user logged on to this computer from the network. The user's password was passed to the authentication package in its unhashed form. The built-in authentication packages all hash credentials before sending them across the network. The credentials do not traverse the network in plaintext (also called cleartext). |
-| 9          | NewCredentials    | A caller cloned its current token and specified new credentials for outbound connections. The new logon session has the same local identity, but uses different credentials for other network connections.                                                                                                                 |
-| 10         | RemoteInteractive | A user logged on to this computer remotely using Terminal Services or Remote Desktop.                                                                                                                                                                                                                                      |
-| 11         | CachedInteractive | A user logged on to this computer with network credentials that were stored locally on the computer. The domain controller was not contacted to verify the credentials.                                                                                                                                                    |
+| Logon Type | Logon Title         | Description                                                                                                                                                                                                                                                                                                                |
+|:----------:|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  `2`       | `Interactive`       | A user logged on to this computer.                                                                                                                                                                                                                                                                                         |
+|  `3`       | `Network`           | A user or computer logged on to this computer from the network.                                                                                                                                                                                                                                                            |
+|  `4`       | `Batch`             | Batch logon type is used by batch servers, where processes may be executing on behalf of a user without their direct intervention.                                                                                                                                                                                         |
+|  `5`       | `Service`           | A service was started by the Service Control Manager.                                                                                                                                                                                                                                                                      |
+|  `7`       | `Unlock`            | This workstation was unlocked.                                                                                                                                                                                                                                                                                             |
+|  `8`       | `NetworkCleartext`  | A user logged on to this computer from the network. The user's password was passed to the authentication package in its unhashed form. The built-in authentication packages all hash credentials before sending them across the network. The credentials do not traverse the network in plaintext (also called cleartext). |
+|  `9`       | `NewCredentials`    | A caller cloned its current token and specified new credentials for outbound connections. The new logon session has the same local identity, but uses different credentials for other network connections.                                                                                                                 |
+| `10`       | `RemoteInteractive` | A user logged on to this computer remotely using Terminal Services or Remote Desktop.                                                                                                                                                                                                                                      |
+| `11`       | `CachedInteractive` | A user logged on to this computer with network credentials that were stored locally on the computer. The domain controller was not contacted to verify the credentials.                                                                                                                                                    |
 
 -   **Restricted Admin Mode** \[Version 2\] \[Type = UnicodeString\]**:** Only populated for **RemoteInteractive** logon type sessions. This is a Yes/No flag indicating if the credentials provided were passed using Restricted Admin mode. Restricted Admin mode was added in Win8.1/2012R2 but this flag was added to the event in Win10.
 


### PR DESCRIPTION
**Description:**

This PR aims to block keywords and values from being translated to another language, keeping the values and keywords intact, in response to the windows-itpro-docs issue ticket #4995.

**Proposed changes:**

- Surround Logon Type values and Logon Title keywords with MD code block markers (back ticks) to keep them from being translated by MT.
- Add XML indentation to the XML for the layout to be shown properly.
- Center the numerical values in column 1 (Logon Type).

Thanks to @takondo for pointing out the uselessness in translating these parts of the table when the document is machine translated.

**issue ticket reference or closure:**
Ref. issue ticket #4995

(The ticket can be closed when this commit is successfully migrated and shown to be effective against machine translation.)