### PR TITLE
Update security-compliance-toolkit-10.md

### DIFF
--- a/windows/security/threat-protection/security-compliance-toolkit-10.md
+++ b/windows/security/threat-protection/security-compliance-toolkit-10.md
@@ -31,9 +31,7 @@ The Security Compliance Toolkit consists of:
     -   Windows 10 Version 1809 (October 2018 Update)
     -   Windows 10 Version 1803 (April 2018 Update)
     -   Windows 10 Version 1709 (Fall Creators Update)
-    -   Windows 10 Version 1703 (Creators Update)
     -   Windows 10 Version 1607 (Anniversary Update)
-    -   Windows 10 Version 1511 (November Update)
     -   Windows 10 Version 1507
 
 -   Windows Server security baselines
@@ -42,7 +40,7 @@ The Security Compliance Toolkit consists of:
     -   Windows Server 2012 R2
 
 -   Microsoft Office security baseline
-    -   Office 2016 
+    -   Office365 ProPlus (Sept 2019)
 
 -   Tools
     -   Policy Analyzer tool


### PR DESCRIPTION
Removed unsupported baseline and downloads for Windows 10 1511 and Windows 10 1703.  Removed Office 2016 baseline and replaced with Office365 ProPlus (Sept 2019)