### PR TITLE
MDATP Get started 404: link Overview page instead

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/evaluate-atp.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/evaluate-atp.md
@@ -45,4 +45,4 @@ Next gen protections help detect and block the latest threats.
 
 ## See Also
 
-[Get started with Microsoft Defender Advanced Threat Protection](get-started.md)
+[Microsoft Defender Advanced Threat Protection overview](microsoft-defender-advanced-threat-protection.md)


### PR DESCRIPTION
**Description:**

As reported by a new community user, the "Get started" link is broken and causes a 404 error when trying to open that page.
As discussed in issue ticket #5053, it will be useful to make the link point to the MDATP Overview page instead.
Thanks to @bstockbrugger for finding and reporting the broken link.

**Proposed change:**

- Rewrite the link name from "Get started with Microsoft Defender Advanced Threat Protection"
to "Microsoft Defender Advanced Threat Protection overview"
(the name of the link can be changed depending on feedback from MS Docs team members).
- Link the main page "Microsoft Defender Advanced Threat Protection" instead of the non-existing "Get started" page that causes a 404 error.

**issue ticket closure or reference:**

Resolves #5053