### PR TITLE
Update hello-planning-guide.md + MD improvements

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-planning-guide.md
+++ b/windows/security/identity-protection/hello-for-business/hello-planning-guide.md
@@ -21,10 +21,8 @@ ms.reviewer:
 **Applies to**
 -   Windows 10
 
-> This guide only applies to Windows 10, version 1511 or higher.
-
 Congratulations! You are taking the first step forward in helping move your organizations away from password to a two-factor, convenience authentication for Windows — Windows Hello for Business. This planning guide helps you understand the different topologies, architectures, and components that encompass a Windows Hello for Business infrastructure.
-  
+
 This guide explains the role of each component within Windows Hello for Business and how certain deployment decisions affect other aspects of the infrastructure. Armed with your planning worksheet, you’ll use that information to select the correct deployment guide for your needs.
 
 ## Using this guide
@@ -38,7 +36,7 @@ This guide removes the appearance of complexity by helping you make decisions on
 Read this document and record your decisions on the worksheet. When finished, your worksheet has all the necessary information for your Windows Hello for Business deployment.
 
 There are six major categories you need to consider for a Windows Hello for Business deployment.  Those categories are:
-*	Deployment Options
+*   Deployment Options
 *   Client
 *   Management
 *   Active Directory
@@ -75,13 +73,13 @@ It’s fundamentally important to understand which deployment model to use for a
 #### Trust types
 
 A deployment's trust type defines how each Windows Hello for Business client authenticates to the on-premises Active Directory.  There are two trust types: key trust and certificate trust. 
-  
+
 The key trust type does not require issuing authentication certificates to end users. Users authenticate using a hardware-bound key created during the built-in provisioning experience. This requires an adequate distribution of Windows Server 2016 domain controllers relative to your existing authentication and the number of users included in your Windows Hello for Business deployment. Read the [Planning an adequate number of Windows Server 2016 Domain Controllers for Windows Hello for Business deployments](hello-adequate-domain-controllers.md) to learn more.
 
 The certificate trust type issues authentication certificates to end users.  Users authenticate using a certificate requested using a hardware-bound key created during the built-in provisioning experience.  Unlike key trust, certificate trust does not require Windows Server 2016 domain controllers (but still requires [Windows Server 2016 Active Directory schema](https://docs.microsoft.com/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-prereqs#directories)).  Users can use their certificate to authenticate to any Windows Server 2008 R2, or later, domain controller.
 
->[!NOTE]
->RDP does not support authentication with Windows Hello for business key trust deployments. RDP is only supported with certificate trust deployments at this tim
+> [!NOTE]
+> RDP does not support authentication with Windows Hello for business key trust deployments. RDP is only supported with certificate trust deployments at this tim
 
 #### Device registration
 
@@ -96,12 +94,12 @@ The built-in Windows Hello for Business provisioning experience creates a hardwa
 The goal of Windows Hello for Business is to move organizations away from passwords by providing them a strong credential that provides easy two-factor authentication.  The built-in provisioning experience accepts the user’s weak credentials (username and password) as the first factor authentication; however, the user must provide a second factor of authentication before Windows provisions a strong credential.  
 
 Cloud only and hybrid deployments provide many choices for multi-factor authentication.  On-premises deployments must use a multi-factor authentication that provides an AD FS multi-factor adapter to be used in conjunction with the on-premises Windows Server 2016 AD FS server role. Organizations can use the on-premises Azure Multi-factor Authentication server, or choose from several third parties (Read [Microsoft and third-party additional authentication methods](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configure-additional-authentication-methods-for-ad-fs#microsoft-and-third-party-additional-authentication-methods) for more information).
->[!NOTE]
+> [!NOTE]
 > Azure Multi-Factor Authentication is available through:
->* Microsoft Enterprise Agreement
->* Open Volume License Program
->* Cloud Solution Providers program
->* Bundled with
+> * Microsoft Enterprise Agreement
+> * Open Volume License Program
+> * Cloud Solution Providers program
+> * Bundled with
 >    * Azure Active Directory Premium
 >    * Enterprise Mobility Suite
 >    * Enterprise Cloud Suite
@@ -217,7 +215,7 @@ If box **1a** on your planning worksheet reads **hybrid**, then you have a few o
 * Use AD FS w/3rd Party MFA Adapter
 
 You can directly use the Azure MFA cloud service for the second factor of authentication. Users contacting the service must authenticate to Azure prior to using the service.
-  
+
 If your Azure AD Connect is configured to synchronize identities (usernames only), then your users are redirected to your local on-premises federation server for authentication and then redirected back to the Azure MFA cloud service.  Otherwise, your Azure AD Connect is configured to synchronize credentials (username and passwords), which enables your users to authenticate to Azure Active Directory and use the Azure MFA cloud service.  If you choose to use the Azure MFA cloud service directly, write **Azure MFA** in box **1f** on your planning worksheet.
 
 You can configure your on-premises Windows Server 2016 AD FS role to use the Azure MFA service adapter. In this configuration, users are redirected to the on premises AD FS server (synchronizing identities only). The AD FS server uses the MFA adapter to communicate to the Azure MFA service to perform the second factor of authentication.  If you choose to use AD FS with the Azure MFA cloud service adapter, write **AD FS with Azure MFA cloud adapter** in box **1f** on your planning worksheet.
@@ -236,7 +234,7 @@ Windows Hello for Business provides organizations with many policy settings and 
 
 If box **1a** on your planning worksheet reads **cloud only**, write **N/A** in box **2a** on your planning worksheet.  You have the option to manage non-domain joined devices.  If you choose to manage Azure Active Directory joined devices, write **modern management** in box **2b** on your planning worksheet.  Otherwise, write** N/A** in box **2b**.
 
->[!NOTE]
+> [!NOTE]
 > Azure Active Directory joined devices without modern management automatically enroll in Windows Hello for Business using the default policy settings.  Use modern management to adjust policy settings to match the business needs of your organization.
 
 If box **1a** on your planning worksheet reads **on-prem**, write **GP** in box **2a** on your planning worksheet. Write **N/A** in box **2b** on your worksheet.
@@ -252,8 +250,8 @@ If you use modern management for both domain and non-domain joined devices, writ
 Windows Hello for Business is a feature exclusive to Windows 10.   Some deployments and features are available using earlier versions of Windows 10.  Others need the latest versions.
 
 If box **1a** on your planning worksheet reads **cloud only**, write **N/A** in box **3a** on your planning worksheet.  Optionally, you may write **1511 or later** in box **3b** on your planning worksheet if you plan to manage non-domain joined devices.
->[!NOTE]
->Azure Active Directory joined devices without modern management automatically enroll in Windows Hello for Business using the default policy settings.  Use modern management to adjust policy settings to match the business needs of your organization.
+> [!NOTE]
+> Azure Active Directory joined devices without modern management automatically enroll in Windows Hello for Business using the default policy settings.  Use modern management to adjust policy settings to match the business needs of your organization.
 
 Write **1511 or later** in box **3a** on your planning worksheet if any of the following are true. 
 * Box **2a** on your planning worksheet read **modern management**. 


### PR DESCRIPTION
**Description:**

As agreed upon in issue ticket #4875, the line
"> This guide only applies to Windows 10, version 1511 or higher."
should be removed because it imposes an outdated build.

Thanks to @mapalko for requesting this removal, and to @poortom1004 for pointing out the version redundancy in the first place.

**Proposed changes:**

- Remove the aforementioned line, as agreed upon
- Add recommended single MarkDown quote spaces
- Replace a tab with standardized spacing
- Remove redundant white space in 3 blank lines

**issue ticket closure or reference:**

Closes #4875