### PR TITLE
Client Management/MDM: 1903 GPO ADMX templates

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -232,6 +232,6 @@ To collect Event Viewer logs:
 
 ### Useful Links
 
-- [Windows 10 Administrative Templates for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495)
+- [Windows 10 Administrative Templates for Windows 10 May 2019 Update 1903](https://www.microsoft.com/download/details.aspx?id=58495)
 - [Windows 10 Administrative Templates for Windows 10 October 2018 Update 1809](https://www.microsoft.com/download/details.aspx?id=57576)
 - [Windows 10 Administrative Templates for Windows 10 April 2018 Update 1803](https://www.microsoft.com/download/details.aspx?id=56880)

--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -153,16 +153,18 @@ Requirements:
 - Enterprise AD must be integrated with Azure AD.
 - Ensure that PCs belong to same computer group.
 
->[!IMPORTANT]
->If you do not see the policy, it may be because you don’t have the ADMX installed for Windows 10, version 1803 or version 1809. To fix the issue, follow these steps:        
+> [!IMPORTANT]
+> If you do not see the policy, it may be because you don’t have the ADMX installed for Windows 10, version 1803 or version 1809. To fix the issue, follow these steps:        
 >   1. Download:  
 >   1803 -->[Administrative Templates (.admx) for Windows 10 April 2018 Update (1803)](https://www.microsoft.com/download/details.aspx?id=56880) or  
->   1809 --> [Administrative Templates for Windows 10 October 2018 Update (1809)](https://www.microsoft.com/download/details.aspx?id=57576).
+>   1809 --> [Administrative Templates for Windows 10 October 2018 Update (1809)](https://www.microsoft.com/download/details.aspx?id=57576) or
+>   1903 --> [Administrative Templates for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495)
 >   2. Install the package on the Primary Domain Controller (PDC).
 >   3. Navigate, depending on the version to the folder:
->   1803 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 April 2018 Update (1803) v2**, or  
->   1809 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 October 2018 Update (1809) v2**
->   4. Copy policy definitions folder to **C:\Windows\SYSVOL\domain\Policies**.
+>   1803 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 April 2018 Update (1803) v2**, or
+>   1809 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 October 2018 Update (1809) v2** or
+>   1903 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2019 Update (1903) v3**
+>   4. Copy policy definitions folder to **C:\Windows\SYSVOL\domain\Policies** .
 >   5. Restart the Primary Domain Controller for the policy to be available.
 >   This procedure will work for any future version as well.
 
@@ -172,10 +174,8 @@ Requirements:
 4. Filter using Security Groups.
 5. Enforce a GPO link.
 
-> [!NOTE]
-> Version 1903 (March 2019) is actually on the Insider program and doesn't yet contain a downloadable version of Templates (version 1903).
-
 ## Troubleshoot auto-enrollment of devices
+
 Investigate the log file if you have issues even after performing all the mandatory verification steps. The first log file to investigate is the event log on the target Windows 10 device. 
 
 To collect Event Viewer logs:
@@ -232,5 +232,6 @@ To collect Event Viewer logs:
 
 ### Useful Links
 
+- [Windows 10 Administrative Templates for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495)
 - [Windows 10 Administrative Templates for Windows 10 October 2018 Update 1809](https://www.microsoft.com/download/details.aspx?id=57576)
 - [Windows 10 Administrative Templates for Windows 10 April 2018 Update 1803](https://www.microsoft.com/download/details.aspx?id=56880)


### PR DESCRIPTION
**Description:**

Administrative Templates (.admx) for Windows 10 May 2019 Update (1903) v3.0 has been available since 2019-08-28
and this page needs updating to reflect this change, as mentioned in issue ticket #5078.

**Proposed changes:**

- Remove the note saying that Windows 10 version 1903 is still on the
  Insider program and doesn't contain any downloadable templates yet.
- Add version number 1903 and its link to the list (under 1803 & 1809)
- Add folder information for the installed 1903 templates location
- Minor MarkDown space standardization adjustments
- Add missing blank line after one of the headings

**issue ticket closure or reference:**

Closes #5078