### PR TITLE
Update waas-delivery-optimization.md

### DIFF
--- a/windows/deployment/update/waas-delivery-optimization.md
+++ b/windows/deployment/update/waas-delivery-optimization.md
@@ -65,7 +65,7 @@ The following table lists the minimum Windows 10 version that supports Delivery 
 
 By default in Windows 10 Enterprise and Education editions, Delivery Optimization allows peer-to-peer sharing on the organization's own network only (specifically, all of the devices must be behind the same NAT), but you can configure it differently in Group Policy and mobile device management (MDM) solutions such as Microsoft Intune.
 
-For more details, see "Download mode" in [Delivery optimization reference](waas-delivery-optimization-reference.md#download-mode).
+For more details, see "Download mode" in [Delivery optimization reference](waas-delivery-optimization-reference.md).
 
 
 ## Set up Delivery Optimization


### PR DESCRIPTION
The link it taking users to the middle of the page (Download Mode) and then they miss the top part of the page with the rest of the reference...
It should link to the top of the reference page.