### PR TITLE
WDAC/Recommended block rules: Add notes and link

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -1514,7 +1514,7 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
 <br />
 
 > [!Note]
-> To create a policy that works on both version 1803 and 1809, you can create two diff policies, or merge them into one broader policy.
+> To create a policy that works on both Windows 10, version 1803 and version 1809, you can create two different policies, or merge them into one broader policy.
 
 ## Further reading (How-To)
 

--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -18,6 +18,7 @@ ms.author: dansimp
 **Applies to**
 -   Windows 10
 -   Windows Server 2016
+-   Windows Server 2019
 
 Members of the security community<sup>\*</sup> continuously collaborate with Microsoft to help protect customers. With the help of their valuable reports, Microsoft has identified a list of valid applications that an attacker could also potentially use to bypass Windows Defender Application Control. 
 
@@ -69,8 +70,8 @@ Unless your use scenarios explicitly require them, Microsoft recommends that you
 
 <br />
 
->[!Note]
->This application list will be updated with the latest vendor information as application vulnerabilities are resolved and new issues are discovered. 
+> [!Note]
+> This application list will be updated with the latest vendor information as application vulnerabilities are resolved and new issues are discovered. 
 
 Certain software applications may allow additional code to run by design. 
 These types of applications should be blocked by your Windows Defender Application Control policy. 
@@ -1511,3 +1512,10 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   </SiPolicy>
 ```
 <br />
+
+> [!Note]
+> To create a policy that works on both version 1803 and 1809, you can create two diff policies, or merge them into one broader policy.
+
+## Further reading (How-To)
+
+- [Merge Windows Defender Application Control policies](merge-windows-defender-application-control-policies.md)

--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -1516,6 +1516,6 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
 > [!Note]
 > To create a policy that works on both Windows 10, version 1803 and version 1809, you can create two different policies, or merge them into one broader policy.
 
-## Further reading (How-To)
+## More information
 
 - [Merge Windows Defender Application Control policies](merge-windows-defender-application-control-policies.md)


### PR DESCRIPTION
**Description:**

As agreed on in issue ticket #3642 (**Ambiguity**), this PR adds a note about creating two diff policies or merging them in a broad policy,
as well as adding a link to how to merge WDAC policies. 

As recommended by @Justinha , Windows Server 2019 is also added to the "Applies to" list at the top of this document.

Also, thanks to @Air-Git for requesting this clarification.

**Proposed changes:**
- add note about creating two diff policies or merging them in a broad policy
- add a link to how to merge WDAC policies
- add Windows Server 2019 to the "Applies to" list
- Cosmetic: add single compatibility MarkDown quote spacing to the existing Note.

**issue ticket closure or reference:**

Closes #3642