### PR TITLE
MDATP/ASR rules: Restore broken link

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/attack-surface-reduction.md
@@ -36,9 +36,9 @@ Attack surface reduction rules target behaviors that malware and malicious apps 
 * Obfuscated or otherwise suspicious scripts
 * Behaviors that apps don't usually initiate during normal day-to-day work
 
-You can use [audit mode](audit-windows-defender.md) to evaluate how attack surface reduction rules would impact your organization if they were enabled. It's best to run all rules in audit mode first so you can understand their impact on your line-of-business applications. Many line-of-business applications are written with limited security concerns, and they may perform tasks similar to malware. By monitoring audit data and [adding exclusions](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-attack-surface-reduction#exclude-files-and-folders-from-asr-rules) for necessary applications, you can deploy attack surface reduction rules without impacting productivity.
+You can use [audit mode](audit-windows-defender.md) to evaluate how attack surface reduction rules would impact your organization if they were enabled. It's best to run all rules in audit mode first so you can understand their impact on your line-of-business applications. Many line-of-business applications are written with limited security concerns, and they may perform tasks similar to malware. By monitoring audit data and [adding exclusions](enable-attack-surface-reduction.md#exclude-files-and-folders-from-asr-rules) for necessary applications, you can deploy attack surface reduction rules without impacting productivity.
 
-Triggered rules display a notification on the device. You can [customize the notification](customize-attack-surface-reduction.md#customize-the-notification) with your company details and contact information. The notification also displays in the Microsoft Defender Security Center and in the Microsoft 365 securty center.
+Triggered rules display a notification on the device. You can [customize the notification](customize-attack-surface-reduction.md#customize-the-notification) with your company details and contact information. The notification also displays in the Microsoft Defender Security Center and in the Microsoft 365 security center.
 
 For information about configuring attack surface reduction rules, see [Enable attack surface reduction rules](enable-attack-surface-reduction.md).
 


### PR DESCRIPTION
**Description:**

As described in issue ticket #5105, the link to "adding exclusions" for
Attack Surface Reduction Rules is broken and causes a HTTP 404 error.

Thanks to @redog for reporting the broken link & 404 error.

The cause of this link breaking is more or less documented on the
Github source page for "Reduce attack surfaces with attack surface
reduction rules" with the latest commit ae43d72
(moved attack surface topics to mdatp dir) from August 21, 2019.

**Proposed changes:**
- insert the correct new page link, pointing to the Github page
- correct an old typo, securty -> security

**issue ticket closure or reference:**

Closes #5105