### PR TITLE
WHfB/certutil: Add command args comma separators

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-whfb-settings-pki.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-whfb-settings-pki.md
@@ -77,8 +77,8 @@ Sign-in a certificate authority or management workstations with _Enterprise Admi
 
 The certificate template is configured to supersede all the certificate templates provided in the certificate templates superseded templates list.  However, the certificate template and the superseding of certificate templates is not active until you publish the certificate template to one or more certificate authorities.
 
->[!NOTE]
->The Domain Controller Certificate must be present in the NTAuth store. By default, Microsoft Enterprise CAs are added to the NTAuth store. If you are using a 3rd party CA, this may not be done by default. If the Domain Controller Certificate is not present in the NTAuth store, user authentication will fail. 
+> [!NOTE]
+> The Domain Controller Certificate must be present in the NTAuth store. By default, Microsoft Enterprise CAs are added to the NTAuth store. If you are using a 3rd party CA, this may not be done by default. If the Domain Controller Certificate is not present in the NTAuth store, user authentication will fail. 
 
 ### Enrollment Agent certificate template
 
@@ -150,10 +150,10 @@ Sign-in a certificate authority or management workstations with _Domain Admin eq
 
 Sign-in to an **AD FS Windows Server 2016** computer with _Enterprise Admin_ equivalent credentials.
 1. Open an elevated command prompt.
-2. Run `certutil -dsTemplate WHFBAuthentication msPKI-Private-Key-Flag +CTPRIVATEKEY_FLAG_HELLO_LOGON_KEY`
+2. Run `certutil -dsTemplate WHFBAuthentication,msPKI-Private-Key-Flag,+CTPRIVATEKEY_FLAG_HELLO_LOGON_KEY`
 
->[!NOTE]
->If you gave your Windows Hello for Business Authentication certificate template a different name, then replace **WHFBAuthentication** in the above command with the name of your certificate template. It's important that you use the template name rather than the template display name. You can view the template name on the **General** tab of the certificate template using the Certificate Template management console (certtmpl.msc).  Or, you can view the template name using the **Get-CATemplate** ADCS Administration Windows PowerShell cmdlet on our Windows Server 2012 or later certificate authority.
+> [!NOTE]
+> If you gave your Windows Hello for Business Authentication certificate template a different name, then replace **WHFBAuthentication** in the above command with the name of your certificate template. It's important that you use the template name rather than the template display name. You can view the template name on the **General** tab of the certificate template using the Certificate Template management console (certtmpl.msc).  Or, you can view the template name using the **Get-CATemplate** ADCS Administration Windows PowerShell cmdlet on our Windows Server 2012 or later certificate authority.
 
 ## Publish Templates
 


### PR DESCRIPTION
**Description:**

As reported & discussed in issue ticket #5089 (**Certutil command wrong**), the certutil command modifiers need to be in a comma separated list,
otherwise you will get the error message "too many arguments".

This behavior has been verified by [TechNet moderator Steven_Lee0510](https://social.technet.microsoft.com/profile/steven_lee0510/):

- https://social.technet.microsoft.com/Forums/windowsserver/en-US/847c13d5-a32e-4799-bb83-2f8ead98a069/certutil-too-many-arguments?forum=winserversecurity

Thanks to @Digiroka for reporting and pointing out this issue.

**Proposed changes:**
- replace the modifier/argument spaces with commas
- add missing MD compatibility spacing in 2 MarkDown notes

**issue ticket closure or reference:**

Closes #5089