### PR TITLE
Use Boot folder for case sensitive TFTP servers

### DIFF
--- a/windows/deployment/configure-a-pxe-server-to-load-windows-pe.md
+++ b/windows/deployment/configure-a-pxe-server-to-load-windows-pe.md
@@ -7,10 +7,12 @@ ms.mktglfcycl: deploy
 ms.localizationpriority: medium
 ms.sitesec: library
 ms.pagetype: deploy
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.reviewer: 
 manager: laurawi
-audience: itproauthor: greg-lindsay
+audience: itpro
+author: greg-lindsay
 ms.author: greglin
 ms.topic: article
 ---
@@ -72,27 +74,27 @@ All four of the roles specified above can be hosted on the same computer or each
     ```
     net use y: \\PXE-1\TFTPRoot
     y:
-    md boot
+    md Boot
     ```
 6. Copy the PXE boot files from the mounted directory to the \boot folder. For example:
 
     ```
-    copy c:\winpe_amd64\mount\windows\boot\pxe\*.* y:\boot
+    copy c:\winpe_amd64\mount\windows\boot\pxe\*.* y:\Boot
     ```
 7.  Copy the boot.sdi file to the PXE/TFTP server.
 
     ```
-    copy C:\winpe_amd64\media\boot\boot.sdi y:\boot
+    copy C:\winpe_amd64\media\boot\boot.sdi y:\Boot
     ```
 8.  Copy the bootable Windows PE image (boot.wim) to the \boot folder.
 
     ```
-    copy C:\winpe_amd64\media\sources\boot.wim y:\boot
+    copy C:\winpe_amd64\media\sources\boot.wim y:\Boot
     ```
 9. (Optional) Copy true type fonts to the \boot folder
 
     ```
-    copy C:\winpe_amd64\media\Boot\Fonts y:\boot\Fonts
+    copy C:\winpe_amd64\media\Boot\Fonts y:\Boot\Fonts
     ```
 
 ## Step 2: Configure boot settings and copy the BCD file
@@ -107,7 +109,7 @@ All four of the roles specified above can be hosted on the same computer or each
     ```
     bcdedit /store c:\BCD /create {ramdiskoptions} /d "Ramdisk options"
     bcdedit /store c:\BCD /set {ramdiskoptions} ramdisksdidevice boot
-    bcdedit /store c:\BCD /set {ramdiskoptions} ramdisksdipath \boot\boot.sdi
+    bcdedit /store c:\BCD /set {ramdiskoptions} ramdisksdipath \Boot\boot.sdi
     bcdedit /store c:\BCD /create /d "winpe boot image" /application osloader
     ```
     The last command will return a GUID, for example:
@@ -119,9 +121,9 @@ All four of the roles specified above can be hosted on the same computer or each
 3.  Create a new boot application entry for the Windows PE image:
 
     ```
-    bcdedit /store c:\BCD /set {GUID1} device ramdisk=[boot]\boot\boot.wim,{ramdiskoptions} 
+    bcdedit /store c:\BCD /set {GUID1} device ramdisk=[boot]\Boot\boot.wim,{ramdiskoptions} 
     bcdedit /store c:\BCD /set {GUID1} path \windows\system32\winload.exe 
-    bcdedit /store c:\BCD /set {GUID1} osdevice ramdisk=[boot]\boot\boot.wim,{ramdiskoptions} 
+    bcdedit /store c:\BCD /set {GUID1} osdevice ramdisk=[boot]\Boot\boot.wim,{ramdiskoptions} 
     bcdedit /store c:\BCD /set {GUID1} systemroot \windows
     bcdedit /store c:\BCD /set {GUID1} detecthal Yes
     bcdedit /store c:\BCD /set {GUID1} winpe Yes
@@ -136,7 +138,7 @@ All four of the roles specified above can be hosted on the same computer or each
 5.  Copy the BCD file to your TFTP server:
 
     ```
-    copy c:\BCD \\PXE-1\TFTPRoot\boot\BCD
+    copy c:\BCD \\PXE-1\TFTPRoot\Boot\BCD
     ```
 
 Your PXE/TFTP server is now configured. You can view the BCD settings that have been configured using the command bcdedit /store &lt;BCD file location&gt; /enum all. See the following example. Note: Your GUID will be different than the one shown below.
@@ -153,9 +155,9 @@ timeout                 30
 Windows Boot Loader
 -------------------
 identifier              {a4f89c62-2142-11e6-80b6-00155da04110}
-device                  ramdisk=[boot]\boot\boot.wim,{ramdiskoptions}
+device                  ramdisk=[boot]\Boot\boot.wim,{ramdiskoptions}
 description             winpe boot image
-osdevice                ramdisk=[boot]\boot\boot.wim,{ramdiskoptions}
+osdevice                ramdisk=[boot]\Boot\boot.wim,{ramdiskoptions}
 systemroot              \Windows
 detecthal               Yes
 winpe                   Yes
@@ -165,7 +167,7 @@ Setup Ramdisk Options
 identifier              {ramdiskoptions}
 description             ramdisk options
 ramdisksdidevice        boot
-ramdisksdipath          \boot\boot.sdi
+ramdisksdipath          \Boot\boot.sdi
 ```
 
 >[!TIP]


### PR DESCRIPTION
I just noticed that the bootloader looks after a BCD file as follow : '\Boot\BCD'. Thus, if you are using a case sensitive TFTP server, you need to place the BCD file in a Boot folder instead of a 'boot' folder.
If you do this, you need to change all the paths specified in the BCD file, still because of the case sensitive server (otherwise, it won't find the sdi/wim files).