### PR TITLE
fixed broken link to SyncML RePro Protocol

### DIFF
--- a/windows/client-management/mdm/oma-dm-protocol-support.md
+++ b/windows/client-management/mdm/oma-dm-protocol-support.md
@@ -349,7 +349,7 @@ The following LocURL shows a per device CSP node configuration: **./device/vendo
 <a href="" id="syncml-response-codes"></a>
 ## SyncML response status codes
 
-When using SyncML in OMA DM, there are standard response status codes that are returned. The following table lists the common SyncML response status codes you are likely to see. For more information about SyncML response status codes, see section 10 of the [SyncML Representation Protocol](https://go.microsoft.com/fwlink/p/?LinkId=526905) specification.
+When using SyncML in OMA DM, there are standard response status codes that are returned. The following table lists the common SyncML response status codes you are likely to see. For more information about SyncML response status codes, see section 10 of the [SyncML Representation Protocol](http://openmobilealliance.org/release/Common/V1_2_2-20090724-A/OMA-TS-SyncML-RepPro-V1_2_2-20090724-A.pdf) specification.
 
 | Status code | Description                                                                                                                                                                                                                       |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
the SyncML Representation Protocol link to openmobilealliance.org was broken. I fixed it with the working link to the document as I can't update the MS link redirector.