### PR TITLE
Command for adding users into RDP group doesn't work

### DIFF
--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -44,7 +44,8 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >You can specify individual Azure AD accounts for remote connections by having the user sign in to the remote device at least once and then running the following PowerShell cmdlet:
      >
      >`net localgroup "Remote Desktop Users" /add "AzureAD\the-UPN-attribute-of-your-user"`, where *FirstnameLastname* is the name of the user profile in C:\Users\, which is created based on DisplayName attribute in Azure AD.
-     > This command works only for the user , who already added into the AADJ device any of the local group (administrators)
+     >
+     > This command only works for AADJ device users already added to any of the local groups (administrators).
      > Otherwise this command throws the below error. For example: 
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
      > for synced user -->"There is no such global user or group : baz\user2"

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -45,7 +45,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >
      >`net localgroup "Remote Desktop Users" /add "AzureAD\the-UPN-attribute-of-your-user"`, where *FirstnameLastname* is the name of the user profile in C:\Users\, which is created based on DisplayName attribute in Azure AD.
      > This command works only for the user , who already added into the AADJ device any of the local group (administrators)
-Otherwise this command throws the below error. For example: 
+     > Otherwise this command throws the below error. For example: 
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
      > for synced user -->"There is no such global user or group : baz\user2"
 >

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -48,7 +48,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      > This command only works for AADJ device users already added to any of the local groups (administrators).
      > Otherwise this command throws the below error. For example: </br>
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry" </br>
-     > for synced user -->"There is no such global user or group : baz\user2"
+     > for synced user --> "There is no such global user or group : baz\user2" </br>
      >
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -46,7 +46,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >`net localgroup "Remote Desktop Users" /add "AzureAD\the-UPN-attribute-of-your-user"`, where *FirstnameLastname* is the name of the user profile in C:\Users\, which is created based on DisplayName attribute in Azure AD.
      > This command works only for the user , who already added into the AADJ device any of the local group (administrators)
 Otherwise this command throws the below error. For example: 
- for cloud only user --> "There is no such global user or group : Azuread\Shenry"
+     > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
      > for synced user -->"There is no such global user or group : baz\user2"
 
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -47,7 +47,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >
      > This command only works for AADJ device users already added to any of the local groups (administrators).
      > Otherwise this command throws the below error. For example: 
-     > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
+     > for cloud only user --> "There is no such global user or group : Azuread\Shenry" </br>
      > for synced user -->"There is no such global user or group : baz\user2"
      >
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -44,7 +44,11 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >You can specify individual Azure AD accounts for remote connections by having the user sign in to the remote device at least once and then running the following PowerShell cmdlet:
      >
      >`net localgroup "Remote Desktop Users" /add "AzureAD\the-UPN-attribute-of-your-user"`, where *FirstnameLastname* is the name of the user profile in C:\Users\, which is created based on DisplayName attribute in Azure AD.
-     >
+     > This command works only for the user , who already added into the AADJ device any of the local group (administrators)
+Otherwise this command throws the below error. For example: 
+ for cloud only user --> "There is no such global user or group : Azuread\Shenry"
+for synced user -->"There is no such global user or group : baz\user2"
+
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >
      >In Windows 10, version 1709, you can add other Azure AD users to the **Administrators** group on a device in **Settings** and restrict remote credentials to **Administrators**. If there is a problem connecting remotely, make sure that both devices are joined to Azure AD and that TPM is functioning properly on both devices.

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -46,7 +46,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >`net localgroup "Remote Desktop Users" /add "AzureAD\the-UPN-attribute-of-your-user"`, where *FirstnameLastname* is the name of the user profile in C:\Users\, which is created based on DisplayName attribute in Azure AD.
      >
      > This command only works for AADJ device users already added to any of the local groups (administrators).
-     > Otherwise this command throws the below error. For example: 
+     > Otherwise this command throws the below error. For example: </br>
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry" </br>
      > for synced user -->"There is no such global user or group : baz\user2"
      >

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -48,7 +48,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      > Otherwise this command throws the below error. For example: 
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
      > for synced user -->"There is no such global user or group : baz\user2"
->
+     >
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >
      >In Windows 10, version 1709, you can add other Azure AD users to the **Administrators** group on a device in **Settings** and restrict remote credentials to **Administrators**. If there is a problem connecting remotely, make sure that both devices are joined to Azure AD and that TPM is functioning properly on both devices.

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -48,7 +48,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
 Otherwise this command throws the below error. For example: 
      > for cloud only user --> "There is no such global user or group : Azuread\Shenry"
      > for synced user -->"There is no such global user or group : baz\user2"
-
+>
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >
      >In Windows 10, version 1709, you can add other Azure AD users to the **Administrators** group on a device in **Settings** and restrict remote credentials to **Administrators**. If there is a problem connecting remotely, make sure that both devices are joined to Azure AD and that TPM is functioning properly on both devices.

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -47,8 +47,8 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      >
      > This command only works for AADJ device users already added to any of the local groups (administrators).
      > Otherwise this command throws the below error. For example: </br>
-     > for cloud only user --> "There is no such global user or group : Azuread\Shenry" </br>
-     > for synced user --> "There is no such global user or group : baz\user2" </br>
+     > for cloud only user: "There is no such global user or group : *name*" </br>
+     > for synced user: "There is no such global user or group : *name*" </br>
      >
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -47,7 +47,7 @@ From its release, Windows 10 has supported remote connections to PCs that are jo
      > This command works only for the user , who already added into the AADJ device any of the local group (administrators)
 Otherwise this command throws the below error. For example: 
  for cloud only user --> "There is no such global user or group : Azuread\Shenry"
-for synced user -->"There is no such global user or group : baz\user2"
+     > for synced user -->"There is no such global user or group : baz\user2"
 
      >In Windows 10, version 1709, the user does not have to sign in to the remote device first.
      >


### PR DESCRIPTION
This command works only for the user , who already added into the AADJ device any of the local group (administrators)
Otherwise this command throws the below error. For example: 
 for cloud only user --> "There is no such global user or group : Azuread\Shenry"
for synced user -->"There is no such global user or group : baz\user2"