### PR TITLE
Correcting admin role language

### DIFF
--- a/devices/surface-hub/first-run-program-surface-hub.md
+++ b/devices/surface-hub/first-run-program-surface-hub.md
@@ -337,10 +337,10 @@ This is what happens when you choose an option.
 
 -   **Use Microsoft Azure Active Directory**
 
-    Clicking this option allows you to join the device to Azure AD. Once you click **Next**, the device will restart to apply some settings, and then you’ll be taken to the [Use Microsoft Azure Active Directory](#use-microsoft-azure) page and asked to enter credentials that can allow you to join Azure AD. Members of the Azure Global Admins security group from the joined organization will be able to use the Settings app. The specific people that will be allowed depends on your Azure AD subscription and how you’ve configured the settings for your Azure AD organization.
+    Clicking this option allows you to join the device to Azure AD. Once you click **Next**, the device will restart to apply some settings, and then you’ll be taken to the [Use Microsoft Azure Active Directory](#use-microsoft-azure) page and asked to enter credentials that can allow you to join Azure AD. Members of the Azure Global Admins role from the joined organization will be able to use the Settings app. The specific people that will be allowed depends on your Azure AD subscription and how you’ve configured the settings for your Azure AD organization.
     
     >[!IMPORTANT]
-    >Administrators added to the Azure Global Admins group after you join the device to Azure AD will be unable to use the Settings app.
+    >Administrators added to the Azure Device Administrators role after you join the device to Azure AD will be unable to use the Settings app.
     >
     >If you join Surface Hub to Azure AD during first-run setup, single sign-on (SSO) for Office apps will not work properly. Users will have to sign in to each Office app individually.
 

--- a/devices/surface-hub/first-run-program-surface-hub.md
+++ b/devices/surface-hub/first-run-program-surface-hub.md
@@ -340,7 +340,7 @@ This is what happens when you choose an option.
     Clicking this option allows you to join the device to Azure AD. Once you click **Next**, the device will restart to apply some settings, and then you’ll be taken to the [Use Microsoft Azure Active Directory](#use-microsoft-azure) page and asked to enter credentials that can allow you to join Azure AD. Members of the Azure Global Admins role from the joined organization will be able to use the Settings app. The specific people that will be allowed depends on your Azure AD subscription and how you’ve configured the settings for your Azure AD organization.
     
     > [!IMPORTANT]
-    >Administrators added to the Azure Device Administrators role after you join the device to Azure AD will be unable to use the Settings app.
+    > Administrators added to the Azure Device Administrators role after you join the device to Azure AD will be unable to use the Settings app.
     >
     >If you join Surface Hub to Azure AD during first-run setup, single sign-on (SSO) for Office apps will not work properly. Users will have to sign in to each Office app individually.
 

--- a/devices/surface-hub/first-run-program-surface-hub.md
+++ b/devices/surface-hub/first-run-program-surface-hub.md
@@ -339,7 +339,7 @@ This is what happens when you choose an option.
 
     Clicking this option allows you to join the device to Azure AD. Once you click **Next**, the device will restart to apply some settings, and then you’ll be taken to the [Use Microsoft Azure Active Directory](#use-microsoft-azure) page and asked to enter credentials that can allow you to join Azure AD. Members of the Azure Global Admins role from the joined organization will be able to use the Settings app. The specific people that will be allowed depends on your Azure AD subscription and how you’ve configured the settings for your Azure AD organization.
     
-    >[!IMPORTANT]
+    > [!IMPORTANT]
     >Administrators added to the Azure Device Administrators role after you join the device to Azure AD will be unable to use the Settings app.
     >
     >If you join Surface Hub to Azure AD during first-run setup, single sign-on (SSO) for Office apps will not work properly. Users will have to sign in to each Office app individually.

--- a/devices/surface-hub/first-run-program-surface-hub.md
+++ b/devices/surface-hub/first-run-program-surface-hub.md
@@ -342,7 +342,7 @@ This is what happens when you choose an option.
     > [!IMPORTANT]
     > Administrators added to the Azure Device Administrators role after you join the device to Azure AD will be unable to use the Settings app.
     >
-    >If you join Surface Hub to Azure AD during first-run setup, single sign-on (SSO) for Office apps will not work properly. Users will have to sign in to each Office app individually.
+    > If you join Surface Hub to Azure AD during first-run setup, single sign-on (SSO) for Office apps will not work properly. Users will have to sign in to each Office app individually.
 
 -   **Use Active Directory Domain Services**
 


### PR DESCRIPTION
Global admin is a role not a security group in Azure. The additional note referred to global admin role, but actually means the Device Administrator role (global admin role works fine regardless of role changes after OOBE).