### PR TITLE
Information DOES NOT apply to Windows 10

### DIFF
--- a/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10.md
+++ b/windows/security/information-protection/bitlocker/bitlocker-device-encryption-overview-windows-10.md
@@ -22,7 +22,6 @@ ms.reviewer:
 -   Windows 10
 
 This topic explains how BitLocker Device Encryption can help protect data on devices running Windows 10. 
-For an architectural overview about how BitLocker Device Encryption  works with Secure Boot, see [Secure boot and BitLocker Device Encryption overview](https://docs.microsoft.com/windows-hardware/drivers/bringup/secure-boot-and-device-encryption-overview). 
 For a general overview and list of topics about BitLocker, see [BitLocker](bitlocker-overview.md).
 
 When users travel, their organization’s confidential data goes with them. Wherever confidential data is stored, it must be protected against unauthorized access. Windows has a long history of providing at-rest data-protection solutions that guard against nefarious attackers, beginning with the Encrypting File System in the Windows 2000 operating system. More recently, BitLocker has provided encryption for full drives and portable drives. Windows consistently improves data protection by improving existing options and by providing new strategies.


### PR DESCRIPTION
The first section of this article applies to windows 10. The linked article where you should find further information DOES NOT apply to windows 10 (https://github.com/MicrosoftDocs/windows-driver-docs/pull/1764 and https://github.com/MicrosoftDocs/windows-driver-docs/issues/1753). So the statement, "see Secure boot and BitLocker Device Encryption overview", is incorrect in this context.


Since the sentence does not make sense without a linked page I deleted the whole sentence. I would propose either to delete the whole sentence like in my pull request or to link another appropriate page.