### PR TITLE
mpcmdrun.exe : block table column from translation

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/command-line-arguments-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/command-line-arguments-windows-defender-antivirus.md
@@ -42,20 +42,20 @@ MpCmdRun.exe -scan -2
 
 | Command  | Description   |
 |:----|:----|
-| \-? **or** -h   | Displays all available options for this tool |
-| \-Scan [-ScanType [0\|1\|2\|3]] [-File \<path> [-DisableRemediation] [-BootSectorScan]] [-Timeout \<days>] [-Cancel] | Scans for malicious software. Values for **ScanType** are: **0** Default, according to your configuration, **-1** Quick scan, **-2** Full scan, **-3** File and directory custom scan.   |
-| \-Trace [-Grouping #] [-Level #] | Starts diagnostic tracing   |
-| \-GetFiles | Collects support information   |
-| \-GetFilesDiagTrack  | Same as Getfiles but outputs to temporary DiagTrack folder |
-| \-RemoveDefinitions [-All]  | Restores the installed Security intelligence  to a previous backup copy or to the original default set |
-| \-RemoveDefinitions [-DynamicSignatures]   | Removes only the dynamically downloaded Security intelligence |
-| \-RemoveDefinitions [-Engine]   | Restores the previous installed engine   |
-| \-SignatureUpdate [-UNC \| -MMPC]  | Checks for new Security intelligence updates  |
-| \-Restore  [-ListAll \| [[-Name \<name>] [-All] \| [-FilePath \<filePath>]] [-Path \<path>]]               | Restores or lists quarantined item(s)  |
-| \-AddDynamicSignature [-Path]  | Loads dynamic Security intelligence  |
-| \-ListAllDynamicSignatures  | Lists the loaded dynamic Security intelligence  |
-| \-RemoveDynamicSignature [-SignatureSetID]  | Removes dynamic Security intelligence   |
-| \-CheckExclusion -path \<path>   | Checks whether a path is excluded  |
+| `-?` **or** `-h`   | Displays all available options for this tool |
+| `-Scan [-ScanType [0\|1\|2\|3]] [-File <path> [-DisableRemediation] [-BootSectorScan]] [-Timeout <days>] [-Cancel]` | Scans for malicious software. Values for **ScanType** are: **0** Default, according to your configuration, **-1** Quick scan, **-2** Full scan, **-3** File and directory custom scan. |
+| `-Trace [-Grouping #] [-Level #]` | Starts diagnostic tracing |
+| `-GetFiles` | Collects support information |
+| `-GetFilesDiagTrack`  | Same as `-GetFiles`, but outputs to temporary DiagTrack folder |
+| `-RemoveDefinitions [-All]` | Restores the installed Security intelligence  to a previous backup copy or to the original default set |
+| `-RemoveDefinitions [-DynamicSignatures]` | Removes only the dynamically downloaded Security intelligence |
+| `-RemoveDefinitions [-Engine]` | Restores the previous installed engine |
+| `-SignatureUpdate [-UNC \| -MMPC]` | Checks for new Security intelligence updates |
+| `-Restore  [-ListAll \| [[-Name <name>] [-All] \| [-FilePath <filePath>]] [-Path <path>]]` | Restores or lists quarantined item(s) |
+| `-AddDynamicSignature [-Path]` | Loads dynamic Security intelligence |
+| `-ListAllDynamicSignatures` | Lists the loaded dynamic Security intelligence |
+| `-RemoveDynamicSignature [-SignatureSetID]` | Removes dynamic Security intelligence |
+| `-CheckExclusion -path <path>` | Checks whether a path is excluded |
 
 ## Related topics
 


### PR DESCRIPTION
**Description:**

Machine translation of this page (e.g. De-De and Fr-Fr) tends to break the table format by translating some of the escaped pipe characters as cell dividers instead of keeping them as code within the first column.

Thanks to @d-Rickyy-b (Rico) for reporting this issue in the De-De version.

**Proposed changes:**
- Add code block back ticks around the command line arguments
  in the first column to keep them from being translated.
- adjustment of white space (blanks) for consistency.

**issue ticket closure or reference:**

Ref. #4604 (need to wait for migration of this change to translated pages before closing the issue)