### PR TITLE
MDATP/Raw Data Streaming: turn Preview features On

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/raw-data-export-storage.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/raw-data-export-storage.md
@@ -28,7 +28,8 @@ Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://w
 ## Before you begin:
 
 1. Create a [Storage account](https://docs.microsoft.com/azure/storage/common/storage-account-overview) in your tenant.
-2. Log in to your [Azure tenant](https://ms.portal.azure.com/), go to **Subscriptions > Your subscription > Resource Providers > Register to **Microsoft.insights****.
+2. Log in to your [Azure tenant](https://ms.portal.azure.com/), go to **Subscriptions > Your subscription > Resource Providers > Register to Microsoft.insights**.
+3. Go to **Settings > Advanced Features > Preview features** and turn Preview features **On**.
 
 ## Enable raw data streaming:
 


### PR DESCRIPTION
**Description:**

As noted in issue ticket #5166 (Has Data Export been retired?), streaming Advanced Hunting events to your Storage account is only available if you turn on the **Preview features** switch in
**Settings -> Advanced Features**.

Thanks to Daniel Snelling (@dancs85) for reporting this issue.

**Proposed change:**

- Add a required procedural step to turn on **Preview features**

**Additional notes:**

The format and placement of this information is very much subject to change before merging into the existing document page, depending on factual feedback from the document author or manager.

**issue ticket closure or reference:**

Closes #5166