### PR TITLE
WHfB GPO: Enable Windows Hello for Business

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-key-whfb-settings-policy.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-key-whfb-settings-policy.md
@@ -91,7 +91,7 @@ Sign-in a domain controller or management workstations with _Domain Admin_ equiv
 3. Right-click **Group Policy object** and select **New**.
 4. Type *Enable Windows Hello for Business* in the name box and click **OK**.
 5. In the content pane, right-click the **Enable Windows Hello for Business** Group Policy object and click **Edit**.
-6. In the navigation pane, expand **Policies** under **User Configuration**.
+6. In the navigation pane, expand **Policies** under **Computer Configuration**.
 7. Expand **Administrative Templates > Windows Component**, and select **Windows Hello for Business**.
 8. In the content pane, double-click **Use Windows Hello for Business**. Click **Enable** and click **OK**. Close the **Group Policy Management Editor**.
 


### PR DESCRIPTION
**Description:**

The Group Policy Object "Enable Windows Hello for Business" does not
exist as a GPO under User Configuration, but in Computer Configuration.

Thanks to @swiftPeter for reporting this issue in ticket #5251 .

**Proposed change:**

- Replace "User Configuration" with "Computer Configuration" in line 94.

**issue ticket closure or reference:**

Closes #5251