### PR TITLE
Reboot CSP/ISO 8601: reboot reset date+time format

### DIFF
--- a/windows/client-management/mdm/reboot-csp.md
+++ b/windows/client-management/mdm/reboot-csp.md
@@ -38,8 +38,10 @@ The following diagram shows the Reboot configuration service provider management
 <p style="margin-left: 20px">The supported operation is Get.</p>
 
 <a href="" id="schedule-single"></a>**Schedule/Single**  
-<p style="margin-left: 20px">This node will execute a reboot at a scheduled date and time. Setting a null (empty) date will delete the existing schedule. The date and time value is ISO8601, and both the date and time are required.  </br>
+<p style="margin-left: 20px">This node will execute a reboot at a scheduled date and time. The date and time value is **ISO 8601**, and both the date and time are required.  </br>
 Example to configure: 2018-10-25T18:00:00</p>
+
+Setting a null (empty) date will delete the existing schedule. In accordance with the ISO 8601 format, the date and time representation needs to be 0000-00-00T00:00:00.
 
 <p style="margin-left: 20px">The supported operations are Get, Add, Replace, and Delete.</p>
 
@@ -53,13 +55,3 @@ Example to configure: 2018-10-25T18:00:00</p>
 
 
 [Configuration service provider reference](configuration-service-provider-reference.md)
-
- 
-
- 
-
-
-
-
-
-


### PR DESCRIPTION
**Description:**

There have been repeated cases of misunderstanding the time format needed to reset the reboot date & time schedule, lately in ticket #4810.

This is an attempt to shift the focus over to the fact that the Reboot CSP strictly follows the ISO 8601 standard, also when resetting the date and time for a reboot schedule.
- https://www.iso.org/iso-8601-date-and-time-format.html
- https://en.wikipedia.org/wiki/ISO_8601

**Changes proposed:**

- Add an extra sentence to inform the reader that the empty (null) value to reset an existing reboot schedule needs to contain zeros (0000-00-00T00:00:00).

- Move the sentence "Setting a null (empty) date will delete [...]" to a line below the example to configure, as well as the addendum, to focus on this fact that a format representation is required.

- Add the missing spacing in "ISO 8601" to keep its ISO name standard.

- Remove redundant white space (10 lines) at the end of the document.

**issue ticket closure or reference:**

Closes #4810