### PR TITLE
configure-attack-surface-reduction.md: 4 typos

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/configure-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-attack-surface-reduction.md
@@ -33,10 +33,10 @@ The topics in this section describe how to configure attack surface reduction. E
 
 Topic | Description
 -|-
-[Enable hardware-based isolation for Microsoft Edge](../windows-defender-application-guard/install-wd-app-guard.md) | How to preprare for and install Application Guard, including hardware and softeware requirements
-[Enable application control](../windows-defender-application-control/windows-defender-application-control.md)|How to control applications run by users and potect kernel mode processes
+[Enable hardware-based isolation for Microsoft Edge](../windows-defender-application-guard/install-wd-app-guard.md) | How to prepare for and install Application Guard, including hardware and software requirements
+[Enable application control](../windows-defender-application-control/windows-defender-application-control.md)|How to control applications run by users and protect kernel mode processes
 [Exploit protection](./enable-exploit-protection.md)|How to automatically apply exploit mitigation techniques on both operating system processes and on individual apps
-[Network protection](./enable-network-protection.md)|How to prevent users from using any apps to acces dangerous domains
+[Network protection](./enable-network-protection.md)|How to prevent users from using any apps to access dangerous domains
 [Controlled folder access](./enable-controlled-folders.md)|How to protect valuable data from malicious apps
 [Attack surface reduction](./enable-attack-surface-reduction.md)|How to prevent actions and apps that are typically used for by exploit-seeking malware
 [Network firewall](../windows-firewall/windows-firewall-with-advanced-security-deployment-guide.md)|How to protect devices and data across a network

--- a/windows/security/threat-protection/microsoft-defender-atp/configure-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-attack-surface-reduction.md
@@ -38,5 +38,5 @@ Topic | Description
 [Exploit protection](./enable-exploit-protection.md)|How to automatically apply exploit mitigation techniques on both operating system processes and on individual apps
 [Network protection](./enable-network-protection.md)|How to prevent users from using any apps to access dangerous domains
 [Controlled folder access](./enable-controlled-folders.md)|How to protect valuable data from malicious apps
-[Attack surface reduction](./enable-attack-surface-reduction.md)|How to prevent actions and apps that are typically used for by exploit-seeking malware
+[Attack surface reduction](./enable-attack-surface-reduction.md)|How to prevent actions and apps that are typically used by exploit-seeking malware
 [Network firewall](../windows-firewall/windows-firewall-with-advanced-security-deployment-guide.md)|How to protect devices and data across a network


### PR DESCRIPTION
**Description:**
As reported in issue ticket #5298 (Spelling Mistakes), 4 typos are quite obvious in this page and need to be corrected.

Thanks to @helloitsliam for reporting this issue.

**Changes proposed:**

- preprare -> prepare
- softeware -> software
- potect -> protect
- acces -> access

Suggestions for further improvements of this document are welcome.

**issue ticket closure or reference:**

Closes #5298