### PR TITLE
BitLocker and AD DS: back up recovery information

### DIFF
--- a/windows/security/information-protection/bitlocker/bitlocker-and-adds-faq.md
+++ b/windows/security/information-protection/bitlocker/bitlocker-and-adds-faq.md
@@ -37,7 +37,15 @@ If BitLocker is enabled on a drive before Group Policy has been applied to enfor
 
 For more info, see [BitLocker Group Policy settings](bitlocker-group-policy-settings.md).
 
-The BitLocker Windows Management Instrumentation (WMI) interface does allow administrators to write a script to back up or synchronize an online client's existing recovery information; however, BitLocker does not automatically manage this process. The manage-bde command-line tool can also be used to manually back up recovery information to AD DS. For example, to back up all of the recovery information for the C: drive to AD DS, you would use the following command from an elevated command prompt: **manage-bde -protectors -adbackup C:**.
+The BitLocker Windows Management Instrumentation (WMI) interface does allow administrators to write a script to back up or synchronize an online client's existing recovery information; however, BitLocker does not automatically manage this process. The manage-bde command-line tool can also be used to manually back up recovery information to AD DS. For example, to back up all of the recovery information for the `$env:SystemDrive` to AD DS, you would use the following command script from an elevated command prompt:
+
+```PowerShell
+$BitLocker = Get-BitLockerVolume -MountPoint $env:SystemDrive
+$RecoveryProtector = $BitLocker.KeyProtector | Where-Object { $_.KeyProtectorType -eq 'RecoveryPassword' }
+
+Backup-BitLockerKeyProtector -MountPoint $env:SystemDrive -KeyProtectorId $RecoveryProtector.KeyProtectorID
+BackupToAAD-BitLockerKeyProtector -MountPoint $env:SystemDrive -KeyProtectorId $RecoveryProtector.KeyProtectorID
+```
 
 > [!IMPORTANT]
 > Joining a computer to the domain should be the first step for new computers within an organization. After computers are joined to a domain, storing the BitLocker recovery key to AD DS is automatic (when enabled in Group Policy).


### PR DESCRIPTION
**Description:**

Based on user feedback in issue ticket #5159 (**Specifying the parameter '-ID' is required to back up recovery information**), the existing command example on this page  `manage-bde -protectors -adbackup C:` is incorrect and needs to be replaced with a working backup command.

Thanks to @rafalfitt for raising this issue and reporting the error.

**Changes proposed:**

- replace existing command sample with an extended PowerShell script
- change focus from drive C: to $env:SystemDrive in case C: is incorrect

**Additional notes and caveats:**

I do not have access to a test scenario to verify this content myself, so I rely heavily on user feedback and confirmation from MS Docs team members with regards to the suggested changes.
(This PR and my discussion in the referenced issue ticket can possibly be seen as me mostly providing a Github user support service.)

**issue ticket closure or reference:**

Closes #5159