### PR TITLE
wrong link is replaced by correct link#5436

### DIFF
--- a/windows/client-management/mdm/wmi-providers-supported-in-windows.md
+++ b/windows/client-management/mdm/wmi-providers-supported-in-windows.md
@@ -305,7 +305,7 @@ For links to these classes, see [**MDM Bridge WMI Provider**](https://msdn.micro
 [Configuration service provider reference](configuration-service-provider-reference.md)
 
 ## Related Links
-[CIM Videocontroller](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
+[CIM Video Controller](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
  
 
  

--- a/windows/client-management/mdm/wmi-providers-supported-in-windows.md
+++ b/windows/client-management/mdm/wmi-providers-supported-in-windows.md
@@ -305,13 +305,4 @@ For links to these classes, see [**MDM Bridge WMI Provider**](https://msdn.micro
 [Configuration service provider reference](configuration-service-provider-reference.md)
 
 ## Related Links
-[CIM Video Controller](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
- 
-
- 
-
-10/10/2016
-
-
-
-
+[CIM Video Controller](https://docs.microsoft.com/windows/win32/cimwin32prov/cim-videocontroller)

--- a/windows/client-management/mdm/wmi-providers-supported-in-windows.md
+++ b/windows/client-management/mdm/wmi-providers-supported-in-windows.md
@@ -296,15 +296,16 @@ For links to these classes, see [**MDM Bridge WMI Provider**](https://msdn.micro
 [**Win32\_UninterruptiblePowerSupply**](https://msdn.microsoft.com/library/windows/hardware/aa394503) |
 [**Win32\_USBController**](https://msdn.microsoft.com/library/windows/hardware/aa394504)    |
 [**Win32\_UTCTime**](https://msdn.microsoft.com/library/windows/hardware/aa394510)          | ![cross mark](images/checkmark.png)
-[**Win32\_VideoController**](https://msdn.microsoft.com/library/windows/hardware/aa394505) |
+[**Win32\_VideoController**](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-videocontroller) |
 **Win32\_WindowsUpdateAgentVersion**                                                        |
  
 
 ## Related topics
 
-
 [Configuration service provider reference](configuration-service-provider-reference.md)
 
+## Related Links
+[CIM Videocontroller] (https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
  
 
  

--- a/windows/client-management/mdm/wmi-providers-supported-in-windows.md
+++ b/windows/client-management/mdm/wmi-providers-supported-in-windows.md
@@ -305,7 +305,7 @@ For links to these classes, see [**MDM Bridge WMI Provider**](https://msdn.micro
 [Configuration service provider reference](configuration-service-provider-reference.md)
 
 ## Related Links
-[CIM Videocontroller] (https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
+[CIM Videocontroller](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/cim-videocontroller)
  
 
  


### PR DESCRIPTION
as per user issue # 5436, I have replaced the wrong link to new link
wrong link
https://msdn.microsoft.com/library/windows/hardware/aa394505

new link
https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-videocontroller

also, i added the related link for reference