### PR TITLE
Advanced hunting query language: Kusto query typos

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-query-language.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-query-language.md
@@ -23,7 +23,7 @@ ms.date: 10/08/2019
 **Applies to:**
 - [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
 
->Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-advancedhunting-abovefoldlink)
+> Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-advancedhunting-abovefoldlink)
 
 Advanced hunting is based on the [Kusto query language](https://docs.microsoft.com/azure/kusto/query/). You can use Kusto syntax and operators to construct queries that locate information in the [schema](advanced-hunting-schema-reference.md) specifically structured for Advanced hunting. To understand these concepts better, run your first query.
 
@@ -31,7 +31,7 @@ Advanced hunting is based on the [Kusto query language](https://docs.microsoft.c
 
 In Microsoft Defender Security Center, go to **Advanced hunting** to run your first query. Use the following example:
 
-```
+```kusto
 // Finds PowerShell execution events that could involve a download.
 ProcessCreationEvents  
 | where EventTime > ago(7d)
@@ -42,7 +42,7 @@ ProcessCreationEvents
         or ProcessCommandLine has "Invoke-Shellcode"
         or ProcessCommandLine contains "http:"
 | project EventTime, ComputerName, InitiatingProcessFileName, FileName, ProcessCommandLine
-| top 100 by EventTime'
+| top 100 by EventTime
 ```
 
 This is how it will look like in Advanced hunting.
@@ -52,7 +52,7 @@ This is how it will look like in Advanced hunting.
 ### Describe the query and specify the table to search
 The query starts with a short comment describing what it is for. This helps if you later decide to save your query and share it with others in your organization.
 
-```
+```kusto
 // Finds PowerShell execution events that could involve a download.
 ProcessCreationEvents
 ```
@@ -62,19 +62,19 @@ The query itself will typically start with a table name followed by a series of 
 ### Set the time range
 The first piped element is a time filter scoped within the previous seven days. Keeping the time range as narrow as possible ensures that queries perform well, return manageable results, and don't time out.
 
-```
+```kusto
 | where EventTime > ago(7d)
 ```
 ### Search for specific executable files
 The time range is immediately followed by a search for files representing the PowerShell application.
 
-```
+```kusto
 | where FileName in ("powershell.exe", "POWERSHELL.EXE", "powershell_ise.exe", "POWERSHELL_ISE.EXE")
 ```
 ### Search for specific command lines
 Afterwards, the query looks for command lines that are typically used with PowerShell to download files.
 
-```
+```kusto
 | where ProcessCommandLine has "Net.WebClient"
         or ProcessCommandLine has "DownloadFile"
         or ProcessCommandLine has "Invoke-WebRequest"
@@ -84,9 +84,9 @@ Afterwards, the query looks for command lines that are typically used with Power
 ### Select result columns and length 
 Now that your query clearly identifies the data you want to locate, you can add elements that define what the results look like. `project` returns specific columns and `top` limits the number of results, making the results well-formatted and reasonably large and easy to process.
 
-```
+```kusto
 | project EventTime, ComputerName, InitiatingProcessFileName, FileName, ProcessCommandLine
-| top 100 by EventTime'
+| top 100 by EventTime
 ```
 
 Click **Run query** to see the results. You can expand the screen view so you can focus on your hunting query and the results.
@@ -128,8 +128,8 @@ The **Get started** section provides a few simple queries using commonly used op
 
 ![Image of Advanced hunting window](images/atp-advanced-hunting.png)
 
->[!NOTE]
->Apart from the basic query samples, you can also access [shared queries](advanced-hunting-shared-queries.md) for specific threat hunting scenarios. Explore the shared queries on the left side of the page or the GitHub query repository.
+> [!NOTE]
+> Apart from the basic query samples, you can also access [shared queries](advanced-hunting-shared-queries.md) for specific threat hunting scenarios. Explore the shared queries on the left side of the page or the GitHub query repository.
 
 ## Access comprehensive query language reference
 
@@ -140,4 +140,4 @@ For detailed information about the query language, see [Kusto query language doc
 - [Understand the schema](advanced-hunting-schema-reference.md)
 - [Apply query best practices](advanced-hunting-best-practices.md)
 
->Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-advancedhunting-belowfoldlink)
+> Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-advancedhunting-belowfoldlink)


### PR DESCRIPTION
**Description:**

According to the report in issue ticket #5457 (**Error in example code Try your first query**), the sample query fails because of the quote apostrophe at the end of the last line in the query. As can be seen in the complementary image, the single quote or apostrophe is unexpected in that position. This can also be verified by using query language editors, marking the quote as an unexpected error in the text.

Thanks to @GeneCupstid for reporting the typo in this training sample.

**Changes proposed:**

- remove 2 occurrences of the unwanted quote/apostrophe
- add "kusto" as recommended MD syntax highlighting tag, as recommended in [Contribute/Contribute/how-to-write-use-markdown.md](https://github.com/MicrosoftDocs/Contribute/blob/master/Contribute/how-to-write-use-markdown.md#code-snippets)
- add MarkDown compatibility spacing to the MD Note quote markers

**issue ticket closure or reference:**

Closes #5457