### PR TITLE
MSC/MSDATP: Advanced hunting 404 URL correction

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/exploit-protection.md
@@ -49,7 +49,7 @@ Many of the features in the [Enhanced Mitigation Experience Toolkit (EMET)](http
 
 Microsoft Defender ATP provides detailed reporting into events and blocks as part of its alert investigation scenarios.
 
-You can query Microsoft Defender ATP data by using [Advanced hunting](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-windows-defender-advanced-threat-protection). If you're using [audit mode](audit-windows-defender.md), you can use Advanced hunting to see how exploit protection settings could affect your environment.
+You can query Microsoft Defender ATP data by using [Advanced hunting](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-overview). If you're using [audit mode](audit-windows-defender.md), you can use Advanced hunting to see how exploit protection settings could affect your environment.
 
 Here is an example query:
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #5484, the link URL pointing to Advanced
hunting is broken on this page due to changes in the page filename
structure. This URL correction amends that issue.

Thanks to Peter Forster (@myfope) for reporting the issue.

**Proposed change:**
- adjust the filename part of the URL to point to the correct page

**issue ticket closure or reference:**

Closes #5484