### PR TITLE
WHfB/Error mitigation: convert table to MarkDown

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
+++ b/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
@@ -41,196 +41,64 @@ When a user encounters an error when creating the work PIN, advise the user to t
 5.  On mobile devices, if you are unable to setup a PIN after multiple attempts, reset your device and start over. For help on how to reset your phone go to [Reset my phone](https://go.microsoft.com/fwlink/p/?LinkId=715697).
 If the error occurs again, check the error code against the following table to see if there is another mitigation for that error. When no mitigation is listed in the table, contact Microsoft Support for assistance.
 
-<table>
+| Hex        | Cause                                                              | Mitigation                                  |
+| :--------- | :----------------------------------------------------------------- | :------------------------------------------ |
+| 0x80090005 | NTE\_BAD\_DATA                                                     | Unjoin the device from Azure AD and rejoin. |
+| 0x8009000F | The container or key already exists.                               | Unjoin the device from Azure AD and rejoin. |
+| 0x80090011 | The container or key was not found.                                | Unjoin the device from Azure AD and rejoin. |
+| 0x80090029 | TPM is not set up.                                                 | Sign on with an administrator account. Click Start, type "tpm.msc", and select tpm.msc Microsoft Common Console Document. In the Actions pane, select Prepare the TPM. |
+| 0x8009002A | NTE\_NO\_MEMORY                                                    | Close programs which are taking up memory and try again. |
+| 0x80090031 | NTE\_AUTHENTICATION\_IGNORED                                       | Reboot the device. If the error occurs again after rebooting, reset the TPM or run Clear-TPM |
+| 0x80090035 | Policy requires TPM and the device does not have TPM.              | Change the Windows Hello for Business policy to not require a TPM. |
+| 0x80090036 | User canceled an interactive dialog.                               | User will be asked to try again. |
+| 0x801C0003 | User is not authorized to enroll.                                  | Check if the user has permission to perform the operation​. |
+| 0x801C000E | Registration quota reached.                                        | Unjoin some other device that is currently joined using the same account or increase the maximum number of devices per user. |
+| 0x801C000F | Operation successful, but the device requires a reboot.            | Reboot the device.               |
+| 0x801C0010 | The AIK certificate is not valid or trusted.                       | Sign out and then sign in again. |
+| 0x801C0011 | The attestation statement of the transport key is invalid.         | Sign out and then sign in again. |
+| 0x801C0012 | Discovery request is not in a valid format.                        | Sign out and then sign in again. |
+| 0x801C0015 | The device is required to be joined to an Active Directory domain. | ​Join the device to an Active Directory domain. |
+| 0x801C0016 | The federation provider configuration is empty                     | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the file is not empty. |
+| 0x801C0017 | ​The federation provider domain is empty                            | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the FPDOMAINNAME element is not empty. |
+| 0x801C0018 | The federation provider client configuration URL is empty          | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the CLIENTCONFIG element contains a valid URL. |
+| 0x801C03E9 | Server response message is invalid                                 | Sign out and then sign in again. |
+| 0x801C03EA | Server failed to authorize user or device.                         | Check if the token is valid and user has permission to register Windows Hello for Business keys. |
+| 0x801C03EB | Server response http status is not valid                           | Sign out and then sign in again. |
+| 0x801C03EC | Unhandled exception from server.                                   | sign out and then sign in again. |
+| 0x801C03ED | Multi-factor authentication is required for a 'ProvisionKey' operation, but was not performed. <br><br> -or- <br><br> Token was not found in the Authorization header. <br><br> -or- <br><br> Failed to read one or more objects. <br><br> -or- <br><br> The request sent to the server was invalid. | Sign out and then sign in again. If that doesn't resolve the issue, unjoin the device from Azure Active Directory (Azure AD) and rejoin.
+| 0x801C03EE | Attestation failed.                                                | Sign out and then sign in again. |
+| 0x801C03EF | The AIK certificate is no longer valid.                            | Sign out and then sign in again. |
+| 0x801C03F2 | Windows Hello key registration failed.                             | ERROR_BAD_DIRECTORY_REQUEST. Another object with the same value for property proxyAddresses already exists. To resolve the issue refer to Duplicate Attributes Prevent Dirsync.
+| 0x801C044D | Authorization token does not contain device ID.                    | Unjoin the device from Azure AD and rejoin. |
+|            | Unable to obtain user token.                                       | Sign out and then sign in again. Check network and credentials. |
+| 0x801C044E | Failed to receive user credentials input.                          | Sign out and then sign in again. |
 
-<thead>
-<tr class="header">
-<th align="left">Hex</th>
-<th align="left">Cause</th>
-<th align="left">Mitigation</th>
-</tr>
-</thead>
-<tbody>
-
-<tr class="even">
-<td align="left">0x801C044D</td>
-<td align="left">Authorization token does not contain device ID</td>
-<td align="left">Unjoin the device from Azure AD and rejoin</td>
-</tr>
-
-<tr class="odd">
-<td align="left">0x80090036</td>
-<td align="left">User canceled an interactive dialog</td>
-<td align="left">User will be asked to try again</td>
-</tr>
-<tr class="even">
-<td align="left">0x80090011</td>
-<td align="left">The container or key was not found</td>
-<td align="left">Unjoin the device from Azure AD and rejoin</td>
-</tr>
-<tr class="odd">
-<td align="left">0x8009000F</td>
-<td align="left">The container or key already exists</td>
-<td align="left">Unjoin the device from Azure AD and rejoin</td>
-</tr>
-<tr class="even">
-<td align="left">0x8009002A</td>
-<td align="left">NTE_NO_MEMORY</td>
-<td align="left">Close programs which are taking up memory and try again.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x80090005</td>
-<td align="left">NTE_BAD_DATA</td>
-<td align="left">Unjoin the device from Azure AD and rejoin</td>
-</tr><tr class="even">
-<td align="left">0x80090029</td>
-<td align="left">TPM is not set up.</td>
-<td align="left">Sign on with an administrator account. Click <strong>Start</strong>, type &quot;tpm.msc&quot;, and select <strong>tpm.msc Microsoft Common Console Document</strong>. In the <strong>Actions</strong> pane, select <strong>Prepare the TPM</strong>. </td>
-</tr>
-<tr class="even">
-<td align="left">0x80090031</td>
-<td align="left">NTE_AUTHENTICATION_IGNORED</td>
-<td align="left">Reboot the device. If the error occurs again after rebooting, <a href="https://go.microsoft.com/fwlink/p/?LinkId=619969" data-raw-source="[reset the TPM]( https://go.microsoft.com/fwlink/p/?LinkId=619969)">reset the TPM</a> or run <a href="https://go.microsoft.com/fwlink/p/?LinkId=629650" data-raw-source="[Clear-TPM](https://go.microsoft.com/fwlink/p/?LinkId=629650)">Clear-TPM</a></td>
-</tr>
-<tr class="odd">
-<td align="left">0x80090035</td>
-<td align="left">Policy requires TPM and the device does not have TPM.</td>
-<td align="left">Change the Windows Hello for Business policy to not require a TPM.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C0003</td>
-<td align="left">User is not authorized to enroll</td>
-<td align="left">Check if the user has permission to perform the operation​.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C000E</td>
-<td align="left">Registration quota reached</td>
-<td align="left"><p>Unjoin some other device that is currently joined using the same account or <a href="https://go.microsoft.com/fwlink/p/?LinkId=626933" data-raw-source="[increase the maximum number of devices per user](https://go.microsoft.com/fwlink/p/?LinkId=626933)">increase the maximum number of devices per user</a>.</p></td>
-</tr>
-<tr class="even">
-<td align="left">0x801C000F</td>
-<td align="left">Operation successful but the device requires a reboot</td>
-<td align="left">Reboot the device.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C0010</td>
-<td align="left">The AIK certificate is not valid or trusted</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C0011</td>
-<td align="left">The attestation statement of the transport key is invalid</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C0012</td>
-<td align="left">Discovery request is not in a valid format</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C0015</td>
-<td align="left">The device is required to be joined to an Active Directory domain</td>
-<td align="left">​Join the device to an Active Directory domain.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C0016</td>
-<td align="left">The federation provider configuration is empty</td>
-<td align="left">Go to <a href="http://clientconfig.microsoftonline-p.net/FPURL.xml" data-raw-source="[http://clientconfig.microsoftonline-p.net/FPURL.xml](http://clientconfig.microsoftonline-p.net/FPURL.xml)">http://clientconfig.microsoftonline-p.net/FPURL.xml</a> and verify that the file is not empty.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C0017</td>
-<td align="left">​The federation provider domain is empty</td>
-<td align="left">Go to <a href="http://clientconfig.microsoftonline-p.net/FPURL.xml" data-raw-source="[http://clientconfig.microsoftonline-p.net/FPURL.xml](http://clientconfig.microsoftonline-p.net/FPURL.xml)">http://clientconfig.microsoftonline-p.net/FPURL.xml</a> and verify that the FPDOMAINNAME element is not empty.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C0018</td>
-<td align="left">The federation provider client configuration URL is empty</td>
-<td align="left">Go to <a href="http://clientconfig.microsoftonline-p.net/FPURL.xml" data-raw-source="[http://clientconfig.microsoftonline-p.net/FPURL.xml](http://clientconfig.microsoftonline-p.net/FPURL.xml)">http://clientconfig.microsoftonline-p.net/FPURL.xml</a> and verify that the CLIENTCONFIG element contains a valid URL.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C03E9</td>
-<td align="left">Server response message is invalid</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C03EA</td>
-<td align="left">Server failed to authorize user or device.</td>
-<td align="left">Check if the token is valid and user has permission to register Windows Hello for Business keys.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C03EB</td>
-<td align="left">Server response http status is not valid</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C03EC</td>
-<td align="left">Unhandled exception from server.</td>
-<td align="left">sign out and then sign in again.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C03ED</td>
-<td align="left"><p>Multi-factor authentication is required for a &#39;ProvisionKey&#39; operation, but was not performed</p>
-<p>-or-</p>
-<p>Token was not found in the Authorization header</p>
-<p>-or-</p>
-<p>Failed to read one or more objects</p>
-<p>-or-</p><p>The request sent to the server was invalid.</p></td>
-<td align="left">Sign out and then sign in again. If that doesn&#39;t resolve the issue, unjoin the device from Azure Active Directory (Azure AD) and rejoin.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C03EE</td>
-<td align="left">Attestation failed</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="even">
-<td align="left">0x801C03EF</td>
-<td align="left">The AIK certificate is no longer valid</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-<tr class="odd"> 
-<td align="left">0x801C03F2</td> 
-<td align="left">Windows Hello key registration failed.</td> 
-<td align="left">ERROR_BAD_DIRECTORY_REQUEST. Another object with the same value for property proxyAddresses already exists. To resolve the issue refer to <a href="https://docs.microsoft.com/office365/troubleshoot/administration/duplicate-attributes-prevent-dirsync" data-raw-source="[Duplicate Attributes Prevent Dirsync]( https://docs.microsoft.com/office365/troubleshoot/administration/duplicate-attributes-prevent-dirsync)">Duplicate Attributes Prevent Dirsync</a>. </td>
-</tr>
-<tr class="even">
-<td align="left">0x801C044D</td>
-<td align="left">Unable to obtain user token</td>
-<td align="left">Sign out and then sign in again. Check network and credentials.</td>
-</tr>
-<tr class="odd">
-<td align="left">0x801C044E</td>
-<td align="left">Failed to receive user creds input</td>
-<td align="left">Sign out and then sign in again.</td>
-</tr>
-</tbody>
-</table>
 
 ## Errors with unknown mitigation
 
 For errors listed in this table, contact Microsoft Support for assistance.
 
-| Hex         | Cause     |
+| Hex         | Cause   |
 |-------------|---------|
-| 0x80072f0c  | Unknown    |
-| 0x80070057 | Invalid parameter or argument is passed |
-| 0x80090027  | Caller provided wrong parameter. If third-party code receives this error they must change their code. |
-| 0x8009002D  | NTE\_INTERNAL\_ERROR   |
-| 0x80090020  | NTE\_FAIL     |
-| 0x801C0001  | ​ADRS server response is not in valid format    |
-| 0x801C0002  | Server failed to authenticate the user   |
-| 0x801C0006  | Unhandled exception from server    |
-| 0x801C000C  | Discovery failed      |
-| 0x801C001B  | ​The device certificate is not found    |
-| 0x801C000B  | Redirection is needed and redirected location is not a well known server   |
+| 0X80072F0C  | Unknown |
+| 0x80070057  | Invalid parameter or argument is passed. |
+| 0x80090020  | NTE\_FAIL |
+| 0x80090027  | Caller provided a wrong parameter. If third-party code receives this error, they must change their code. |
+| 0x8009002D  | NTE\_INTERNAL\_ERROR |
+| 0x801C0001  | ​ADRS server response is not in a valid format. |
+| 0x801C0002  | Server failed to authenticate the user. |
+| 0x801C0006  | Unhandled exception from server. |
+| 0x801C000B  | Redirection is needed and redirected location is not a well known server. |
+| 0x801C000C  | Discovery failed. |
+| 0x801C0013  | Tenant ID is not found in the token. |
+| 0x801C0014  | User SID is not found in the token. |
 | 0x801C0019  | ​The federation provider client configuration is empty    |
-| 0x801C001A  | The DRS endpoint in the federation provider client configuration is empty   |
-| 0x801C0013  | Tenant ID is not found in the token    |
-| 0x801C0014  | User SID is not found in the token       |
-| 0x801C03F1  | There is no UPN in the token       |
-| 0x801C03F0  | ​There is no key registered for the user   |
-| 0x801C03F1  | ​There is no UPN in the token          |
-| ​0x801C044C | There is no core window for the current thread     |
- 
+| 0x801C001A  | The DRS endpoint in the federation provider client configuration is empty. |
+| 0x801C001B  | ​The device certificate is not found. |
+| 0x801C03F0  | ​There is no key registered for the user. |
+| 0x801C03F1  | ​There is no UPN in the token. |
+| ​0x801C044C  | There is no core window for the current thread. |
+
 
 ## Related topics
 

--- a/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
+++ b/windows/security/identity-protection/hello-for-business/hello-errors-during-pin-creation.md
@@ -46,21 +46,21 @@ If the error occurs again, check the error code against the following table to s
 | 0x80090005 | NTE\_BAD\_DATA                                                     | Unjoin the device from Azure AD and rejoin. |
 | 0x8009000F | The container or key already exists.                               | Unjoin the device from Azure AD and rejoin. |
 | 0x80090011 | The container or key was not found.                                | Unjoin the device from Azure AD and rejoin. |
-| 0x80090029 | TPM is not set up.                                                 | Sign on with an administrator account. Click Start, type "tpm.msc", and select tpm.msc Microsoft Common Console Document. In the Actions pane, select Prepare the TPM. |
+| 0x80090029 | TPM is not set up.                                                 | Sign on with an administrator account. Click **Start**, type "tpm.msc", and select **tpm.msc Microsoft Common Console Document**. In the **Actions** pane, select **Prepare the TPM**. |
 | 0x8009002A | NTE\_NO\_MEMORY                                                    | Close programs which are taking up memory and try again. |
-| 0x80090031 | NTE\_AUTHENTICATION\_IGNORED                                       | Reboot the device. If the error occurs again after rebooting, reset the TPM or run Clear-TPM |
+| 0x80090031 | NTE\_AUTHENTICATION\_IGNORED                                       | Reboot the device. If the error occurs again after rebooting, [reset the TPM](https://go.microsoft.com/fwlink/p/?LinkId=619969) or run [Clear-TPM](https://go.microsoft.com/fwlink/p/?LinkId=629650). |
 | 0x80090035 | Policy requires TPM and the device does not have TPM.              | Change the Windows Hello for Business policy to not require a TPM. |
 | 0x80090036 | User canceled an interactive dialog.                               | User will be asked to try again. |
 | 0x801C0003 | User is not authorized to enroll.                                  | Check if the user has permission to perform the operation​. |
-| 0x801C000E | Registration quota reached.                                        | Unjoin some other device that is currently joined using the same account or increase the maximum number of devices per user. |
+| 0x801C000E | Registration quota reached.                                        | Unjoin some other device that is currently joined using the same account or [increase the maximum number of devices per user](https://go.microsoft.com/fwlink/p/?LinkId=626933). |
 | 0x801C000F | Operation successful, but the device requires a reboot.            | Reboot the device.               |
 | 0x801C0010 | The AIK certificate is not valid or trusted.                       | Sign out and then sign in again. |
 | 0x801C0011 | The attestation statement of the transport key is invalid.         | Sign out and then sign in again. |
 | 0x801C0012 | Discovery request is not in a valid format.                        | Sign out and then sign in again. |
 | 0x801C0015 | The device is required to be joined to an Active Directory domain. | ​Join the device to an Active Directory domain. |
-| 0x801C0016 | The federation provider configuration is empty                     | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the file is not empty. |
-| 0x801C0017 | ​The federation provider domain is empty                            | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the FPDOMAINNAME element is not empty. |
-| 0x801C0018 | The federation provider client configuration URL is empty          | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the CLIENTCONFIG element contains a valid URL. |
+| 0x801C0016 | The federation provider configuration is empty                     | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the file is not empty. |
+| 0x801C0017 | ​The federation provider domain is empty                            | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the FPDOMAINNAME element is not empty. |
+| 0x801C0018 | The federation provider client configuration URL is empty          | Go to http://clientconfig.microsoftonline-p.net/FPURL.xml and verify that the CLIENTCONFIG element contains a valid URL. |
 | 0x801C03E9 | Server response message is invalid                                 | Sign out and then sign in again. |
 | 0x801C03EA | Server failed to authorize user or device.                         | Check if the token is valid and user has permission to register Windows Hello for Business keys. |
 | 0x801C03EB | Server response http status is not valid                           | Sign out and then sign in again. |
@@ -68,7 +68,7 @@ If the error occurs again, check the error code against the following table to s
 | 0x801C03ED | Multi-factor authentication is required for a 'ProvisionKey' operation, but was not performed. <br><br> -or- <br><br> Token was not found in the Authorization header. <br><br> -or- <br><br> Failed to read one or more objects. <br><br> -or- <br><br> The request sent to the server was invalid. | Sign out and then sign in again. If that doesn't resolve the issue, unjoin the device from Azure Active Directory (Azure AD) and rejoin.
 | 0x801C03EE | Attestation failed.                                                | Sign out and then sign in again. |
 | 0x801C03EF | The AIK certificate is no longer valid.                            | Sign out and then sign in again. |
-| 0x801C03F2 | Windows Hello key registration failed.                             | ERROR_BAD_DIRECTORY_REQUEST. Another object with the same value for property proxyAddresses already exists. To resolve the issue refer to Duplicate Attributes Prevent Dirsync.
+| 0x801C03F2 | Windows Hello key registration failed.                             | ERROR\_BAD\_DIRECTORY\_REQUEST. Another object with the same value for property proxyAddresses already exists. To resolve the issue refer to [Duplicate Attributes Prevent Dirsync](https://docs.microsoft.com/office365/troubleshoot/administration/duplicate-attributes-prevent-dirsync).
 | 0x801C044D | Authorization token does not contain device ID.                    | Unjoin the device from Azure AD and rejoin. |
 |            | Unable to obtain user token.                                       | Sign out and then sign in again. Check network and credentials. |
 | 0x801C044E | Failed to receive user credentials input.                          | Sign out and then sign in again. |


### PR DESCRIPTION
**Description:**

Based on community feedback in issue ticket #5455, the Error Code 0x801C044D is listed twice in the mitigation section, not adjacent, and with different explanations. The suggestion is to group them together
to make it more obvious that there are 2 separate causes & mitigations.

Thanks to J.R. Jenkins (@jrjenk) for reporting this issue.

In order to simplify editing and information management in the table, I propose to change the table formatting from simple HTML to MarkDown.
I also suggest sorting the lines based on the Error code Hex values.

**Changes proposed:**
- convert the Error mitigations table to MarkDown
- rearrange the row lines and sort by Hex value (1 exception)
- place the 2 errors with the same Hex value adjacent to each other
- add some missing punctuation
- adjust spacing and remove some redundant whitespace

**issue ticket closure or reference:**

Closes #5455