### PR TITLE
Advanced hunting: Kusto query operators versus MT

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-query-language.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/advanced-hunting-query-language.md
@@ -97,16 +97,16 @@ Now that you've run your first query and have a general idea of its components, 
 
 | Operator | Description and usage |
 |--|--|
-| **where** | Filter a table to the subset of rows that satisfy a predicate. |
-| **summarize** | Produce a table that aggregates the content of the input table. |
-| **join** | Merge the rows of two tables to form a new table by matching values of the specified column(s) from each table. |
-| **count** | Return the number of records in the input record set. |
-| **top** | Return the first N records sorted by the specified columns. |
-| **limit** | Return up to the specified number of rows. |
-| **project** | Select the columns to include, rename or drop, and insert new computed columns. |
-| **extend** | Create calculated columns and append them to the result set. |
-| **makeset** |  Return a dynamic (JSON) array of the set of distinct values that Expr takes in the group. |
-| **find** | Find rows that match a predicate across a set of tables. |
+| **`where`** | Filter a table to the subset of rows that satisfy a predicate. |
+| **`summarize`** | Produce a table that aggregates the content of the input table. |
+| **`join`** | Merge the rows of two tables to form a new table by matching values of the specified column(s) from each table. |
+| **`count`** | Return the number of records in the input record set. |
+| **`top`** | Return the first N records sorted by the specified columns. |
+| **`limit`** | Return up to the specified number of rows. |
+| **`project`** | Select the columns to include, rename or drop, and insert new computed columns. |
+| **`extend`** | Create calculated columns and append them to the result set. |
+| **`makeset`** |  Return a dynamic (JSON) array of the set of distinct values that Expr takes in the group. |
+| **`find`** | Find rows that match a predicate across a set of tables. |
 
 To see a live example of these operators, run them from the **Get started** section of the Advanced hunting page.
 


### PR DESCRIPTION
**Description:**

As discussed in issue ticket #5463 (KQL table command list translated to German), at least half of the operator names in the table list of common
Kusto query language operators are being translated to German by Machine Translation, making them incorrect and unusable in localized pages.

Also, as pointed out the MS Docs localization specialist team member Tina McNaboe (@TinaMcN), this is also happens in localization to other languages than German, so a generic solution to block these terms from translation would be quite productive to save time by avoiding more human translated pages for each affected localization language.

**Proposed change:**
- Add MD code tags (back ticks) around the operators in the table.

**issue ticket closure or reference:**

Ref. #5463 (it will take a week to confirm that the problem is solved)