### PR TITLE
wrong link is replaced by new link

### DIFF
--- a/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
+++ b/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
@@ -49,7 +49,7 @@ The following items are required or recommended for creating the DaRT recovery i
 </tr>
 <tr class="odd">
 <td align="left"><p>Windows Debugging Tools for your platform</p></td>
-<td align="left"><p>Required when you run the <strong>Crash Analyzer</strong> to determine the cause of a computer failure. We recommend that you specify the path of the Windows Debugging Tools at the time that you create the DaRT recovery image. You can download the Windows Debugging Tools here: <a href="https://docs.microsoft.com/en-in/windows-hardware/drivers/debugger/" data-raw-source="[Download and Install Debugging Tools for Windows](https://docs.microsoft.com/en-in/windows-hardware/drivers/debugger/)">Download and Install Debugging Tools for Windows</a>.</p></td>
+<td align="left"><p>Required when you run the <strong>Crash Analyzer</strong> to determine the cause of a computer failure. We recommend that you specify the path of the Windows Debugging Tools at the time that you create the DaRT recovery image. You can download the Windows Debugging Tools here: <a href="https://docs.microsoft.com/windows-hardware/drivers/debugger/" data-raw-source="[Download and Install Debugging Tools for Windows](https://docs.microsoft.com/windows-hardware/drivers/debugger/)">Download and Install Debugging Tools for Windows</a>.</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Optional: Windows symbols files for use with <strong>Crash Analyzer</strong></p></td>

--- a/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
+++ b/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
@@ -61,14 +61,12 @@ The following items are required or recommended for creating the DaRT recovery i
  
 
 ## Related topics
-Note :: Debugging tools in not available for seperate download,Instead you must download Windows Driver Kit (WDK)
 
 [Planning to Deploy DaRT 10](planning-to-deploy-dart-10.md)
 
  
 
  
-
 
 
 

--- a/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
+++ b/mdop/dart-v10/planning-to-create-the-dart-10-recovery-image.md
@@ -49,7 +49,7 @@ The following items are required or recommended for creating the DaRT recovery i
 </tr>
 <tr class="odd">
 <td align="left"><p>Windows Debugging Tools for your platform</p></td>
-<td align="left"><p>Required when you run the <strong>Crash Analyzer</strong> to determine the cause of a computer failure. We recommend that you specify the path of the Windows Debugging Tools at the time that you create the DaRT recovery image. You can download the Windows Debugging Tools here: <a href="https://go.microsoft.com/fwlink/?LinkId=99934" data-raw-source="[Download and Install Debugging Tools for Windows](https://go.microsoft.com/fwlink/?LinkId=99934)">Download and Install Debugging Tools for Windows</a>.</p></td>
+<td align="left"><p>Required when you run the <strong>Crash Analyzer</strong> to determine the cause of a computer failure. We recommend that you specify the path of the Windows Debugging Tools at the time that you create the DaRT recovery image. You can download the Windows Debugging Tools here: <a href="https://docs.microsoft.com/en-in/windows-hardware/drivers/debugger/" data-raw-source="[Download and Install Debugging Tools for Windows](https://docs.microsoft.com/en-in/windows-hardware/drivers/debugger/)">Download and Install Debugging Tools for Windows</a>.</p></td>
 </tr>
 <tr class="even">
 <td align="left"><p>Optional: Windows symbols files for use with <strong>Crash Analyzer</strong></p></td>
@@ -61,7 +61,7 @@ The following items are required or recommended for creating the DaRT recovery i
  
 
 ## Related topics
-
+Note :: Debugging tools in not available for seperate download,Instead you must download Windows Driver Kit (WDK)
 
 [Planning to Deploy DaRT 10](planning-to-deploy-dart-10.md)
 


### PR DESCRIPTION
as per user report issue #5552.
i replaced the old link by new link

old link
https://go.microsoft.com/fwlink/?LinkId=99934

replaced link
https://docs.microsoft.com/en-in/windows-hardware/drivers/debugger/

added important note under Related topics