### PR TITLE
Changing badly formed comments and correcting capitalization in sampl…

### DIFF
--- a/browsers/internet-explorer/ie11-deploy-guide/what-is-enterprise-mode.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/what-is-enterprise-mode.md
@@ -71,19 +71,19 @@ This is a view of the [raw EMIE v2 schema.xml file](https://gist.github.com/kypf
 
 ```xml
 <site-list version="205">
-	<!--- File creation header --->
+	<!-- File creation header -->
 	<created-by>
 		<tool>EnterpriseSiteListManager</tool>
 		<version>10586</version>
 		<date-created>20150728.135021</date-created>
 	</created-by>
-  	<!--- Begin Site List ---> 
+  	<!-- Begin Site List --> 
 	<site url="www.cpandl.com">
 		<compat-mode>IE8Enterprise</compat-mode>
 		<open-in>IE11</open-in>
 	</site>
 	<site url="www.woodgrovebank.com">
-		<compat-mode>default</compat-mode>
+		<compat-mode>Default</compat-mode>
 		<open-in>IE11</open-in>
 	</site>
 	<site url="adatum.com">
@@ -92,8 +92,8 @@ This is a view of the [raw EMIE v2 schema.xml file](https://gist.github.com/kypf
 	</site>
 	<site url="relecloud.com"/>  
 	<!-- default for self-closing XML tag is 
-		<compat-mode>default</compat-mode>
-		<open-in>none</open-in>
+		<compat-mode>Default</compat-mode>
+		<open-in>None</open-in>
 	-->
 	<site url="relecloud.com/products">  
 		<compat-mode>IE8Enterprise"</compat-mode>


### PR DESCRIPTION
…e xml

The sample xml has a couple of problems that are fixed here.
1. Comments use -- not --- to begin and end. 3 hyphens will cause a parse error.
2. The default values for <compat-mode> (Default) and <open-in> (None) are not capitalized, which doesn't fit with other documentation and tools.