### PR TITLE
Update supported languages for HoloLens 2

### DIFF
--- a/devices/hololens/hololens2-language-support.md
+++ b/devices/hololens/hololens2-language-support.md
@@ -29,15 +29,15 @@ HoloLens 2 supports the following languages. This support includes voice command
 - German (Germany)
 - Italian (Italy)
 - Japanese (Japan)
-- Spanish (Mexico)
 - Spanish (Spain)
 
-Windows Mixed Reality is also available in the following languages. However, this support does not include speech commands or dictation features.
+HoloLens 2 is also available in the following languages. However, this support does not include speech commands or dictation features.
 
 - Chinese Traditional (Taiwan and Hong Kong)
 - Dutch (Netherlands)
 - Korean (Korea)
-- Changing language or keyboard
+
+# Changing language or keyboard
 
 > [!NOTE]
 > Your speech and dictation language depends on the Windows display language.

--- a/devices/hololens/hololens2-language-support.md
+++ b/devices/hololens/hololens2-language-support.md
@@ -37,7 +37,7 @@ HoloLens 2 is also available in the following languages. However, this support d
 - Dutch (Netherlands)
 - Korean (Korea)
 
-# Changing language or keyboard
+## Changing language or keyboard
 
 > [!NOTE]
 > Your speech and dictation language depends on the Windows display language.


### PR DESCRIPTION
Removing Spanish (Mexico) from the list of supported languages. I also fixed up a formatting error and changed an incorrect use of "Windows Mixed Reality" to "HoloLens 2"