### PR TITLE
USMT/XML General Conventions: fix example typo

### DIFF
--- a/windows/deployment/usmt/usmt-general-conventions.md
+++ b/windows/deployment/usmt/usmt-general-conventions.md
@@ -50,7 +50,7 @@ Before you modify the .xml files, become familiar with the following guidelines:
 
 -   **File names with brackets**
 
-    If you are migrating a file that has a bracket character (\[ or \]) in the file name, you must insert a carat (^) character directly before the bracket for the bracket character to be valid. For example, if there is a file named File.txt, you must specify `<pattern type="File">c:\documents\mydocs [file^].txt]</pattern>` instead of `<pattern type="File">c:\documents\mydocs [file].txt]</pattern>`.
+    If you are migrating a file that has a bracket character (\[ or \]) in the file name, you must insert a carat (^) character directly before the bracket for the bracket character to be valid. For example, if there is a file named **file].txt**, you must specify `<pattern type="File">c:\documents\mydocs [file^].txt]</pattern>` instead of `<pattern type="File">c:\documents\mydocs [file].txt]</pattern>`.
 
 -   **Using quotation marks**
 


### PR DESCRIPTION
**Description:**

As suggested in issue ticket #5603 (**USMT XML Ref typo - File.txt => file].txt**), the example filename should contain the aforementioned bracket that this section is all about, as well as preferably use the same case (lowercase) as the directly following XML code.

Thanks to @ChadMcCaffery for reporting this typo.

**Changes proposed:**

- add the missing example bracket character
- convert the filename "File" to lowercase "file"
- add bold text for the filename to be more visible

**issue ticket closure or reference:**

Closes #5603