### PR TITLE
Configure DC Certificates: Subject Name tab text

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-cert-trust-validate-pki.md
+++ b/windows/security/identity-protection/hello-for-business/hello-cert-trust-validate-pki.md
@@ -69,7 +69,7 @@ Sign-in to a certificate authority or management workstations with _Domain Admin
 4. On the **Compatibility** tab, clear the **Show resulting changes** check box.  Select **Windows Server 2008 R2** from the **Certification Authority** list. Select **Windows 7.Server 2008 R2** from the **Certification Recipient** list.
 5. On the **General** tab, type **Domain Controller Authentication (Kerberos)** in Template display name.  Adjust the validity and renewal period to meet your enterprise’s needs.   
     **Note**If you use different template names, you’ll need to remember and substitute these names in different portions of the lab.
-6. On the **Subject** tab, select the **Build from this Active Directory information** button if it is not already selected.  Select **None** from the **Subject name format** list.  Select **DNS name** from the **Include this information in alternate subject** list. Clear all other items.
+6. On the **Subject Name** tab, select the **Build from this Active Directory information** button if it is not already selected.  Select **None** from the **Subject name format** list.  Select **DNS name** from the **Include this information in alternate subject** list. Clear all other items.
 7. On the **Cryptography** tab, select **Key Storage Provider** from the **Provider Category** list.  Select **RSA** from the **Algorithm name** list.  Type **2048** in the **Minimum key size** text box.  Select **SHA256** from the **Request hash** list.  Click **OK**. 
 8. Close the console.
 
@@ -104,7 +104,7 @@ Sign-in to a certificate authority or management workstations with _Domain Admin
 5. On the **General** tab, type **Internal Web Server** in **Template display name**.  Adjust the validity and renewal period to meet your enterprise’s needs.   
     **Note:** If you use different template names, you’ll need to remember and substitute these names in different portions of the lab.
 6. On the **Request Handling** tab, select **Allow private key to be exported**.
-7. On the **Subject** tab, select the **Supply in the request** button if it is not already selected.
+7. On the **Subject Name** tab, select the **Supply in the request** button if it is not already selected.
 8. On the **Security** tab, Click **Add**. Type **Domain Computers** in the **Enter the object names to select** box.  Click **OK**. Select the **Allow** check box next to the **Enroll** permission.
 9. On the **Cryptography** tab, select **Key Storage Provider** from the **Provider Category** list.  Select **RSA** from the **Algorithm name** list.  Type **2048** in the **Minimum key size** text box.  Select **SHA256** from the **Request hash** list.  Click **OK**. 
 10. Close the console.


### PR DESCRIPTION
**Description:**

As reported and shown in issue ticket #5600 (Update text). one of the tabs in Properties of New Template is referred to as Subject, whereas the actual tab name is "Subject Name" in the doc page. Thanks to Rami (@drunkrhin0) for reporting this discrepancy.

**Proposed change:**
- add the word  **Name** to the "On the **Subject** tab" text (2x)

**issue ticket closure or reference:**

Closes #5600