### PR TITLE
Update white-glove.md

### DIFF
--- a/windows/deployment/windows-autopilot/white-glove.md
+++ b/windows/deployment/windows-autopilot/white-glove.md
@@ -96,6 +96,9 @@ If the pre-provisioning process completes successfully:
  ![white-glove-result](images/white-glove-result.png)
 - Click **Reseal** to shut the device down.  At that point, the device can be shipped to the end user.
 
+>[!NOTE]
+>Technician Flow inherits behavior from [Self-Deploying Mode](self-deploying.md). Per the Self-Deploying Mode documentation, it leverages the Enrollment Status Page to hold the device in a provisioning state and prevent the user from proceeding to the desktop after enrollment but before software and configuration is done applying. As such, if Enrollment Status Page is disabled, the reseal button may appear before software and configuration is done applying letting you proceed to the user flow before technician flow provisioning is complete. The green screen validates that enrollment was successful, not that the technician flow is necessarily complete.
+
 If the pre-provisioning process fails:
 - A red status screen will be displayed with information about the device, including the same details presented previously (e.g. Autopilot profile, organization name, assigned user, QR code), as well as the elapsed time for the pre-provisioning steps.
 - Diagnostic logs can be gathered from the device, and then it can be reset to start the process over again.


### PR DESCRIPTION
From testing, this seems to be the tech flow behavior regarding software deployment - additionally, the behavior we've seen is that the green screen appears once enrollment is done, not once everything is applied - this means the screen can go green but the reseal button won't appear until configuration and install is complete. 

Without ESP, the device enrolls, the screen goes green, the reseal button appears, but launching a command prompt and exploring the disk validates software didn't install. With ESP, the screen goes green within the same period, but there's a 20 minute delay after that before the reseal button appears - in this scenario, at reseal, the software is installed as expected.

Mostly just trying to get this behavior documented if it's correct, but if it's incorrect, some clarification on the software install behavior during tech flow would be good, because the expectation that software will install during the technician flow seems to not be consistent and this is the only reason I could find from the documentation that explains the behavior we're seeing.