### PR TITLE
Release notes link changes to HoloLens section

### DIFF
--- a/devices/hololens/index.md
+++ b/devices/hololens/index.md
@@ -55,4 +55,4 @@ appliesto:
 ## Related resources
 
 * [Documentation for Holographic app development](https://developer.microsoft.com/windows/mixed-reality/development)
-* [HoloLens release notes](https://developer.microsoft.com/windows/mixed-reality/release_notes)
+* [HoloLens release notes](https://docs.microsoft.com/hololens/hololens-release-notes)


### PR DESCRIPTION
Link for HoloLens release notes was pointing to Mixed Reality docs instead of HoloLens. Redirected.
@scooley