### PR TITLE
Store instructions, rs5, workflow, install method

### DIFF
--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -33,12 +33,18 @@ Open the Microsoft Store from the **Start** menu. Then browse for apps and games
 
 ## Install apps
 
-To download apps, you'll need to be signed in with a Microsoft account. To buy them, you'll need a payment method associated with the Microsoft account you use on your HoloLens. To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.
+To download apps, you'll need to be signed in with a Microsoft account. Some apps are free and can be downloaded right away. Apps that require a purchase require you to be signed into the Store with your Microsoft account and have a valid payment method.
+>[!NOTE]
+>The account you can use on Microsoft Store does not have to be the same as the account you are signed in with. If you are using a Work or School account on your HoloLens then you'll need to sign in with your personal account in the Store App to make a purchase.
 
-1. To open the [**Start** menu](holographic-home.md), perform a [bloom](hololens1-basic-usage.md) gesture or tap your wrist.
-2. Select the Store app and then tap to place this tile into your world.
-3. Once the Store app opens, use the search bar to look for any desired application.
-4. Select **Get** or **Install** on the application's page (a purchase may be required).
+To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.
+
+1. To open the [**Start** menu](holographic-home.md), perform a the [Start gesture](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
+1. Select the Store app. Once the Store app opens:
+  1. Use the search bar to look for any desired application. 
+  1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.
+  1. On the top right of the Store app select the **"..."** button and select **My Library**, to view any perviously purchased apps.
+1. Select **Get** or **Install** on the application's page (a purchase may be required).
 
 ## Uninstall apps
 
@@ -46,7 +52,7 @@ There are two ways to uninstall applications.  You can uninstall applications th
 
 ### Uninstall from the Start menu
 
-On the **Start** menu or in the **All apps** list, gaze at the app. Tap and hold until the menu appears, then select **Uninstall**.
+On the **Start** menu or in the **All apps** list, browse to the app. Air Tap and hold until the menu appears, then select **Uninstall**.
 
 ### Uninstall from the Microsoft Store
 

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -39,7 +39,7 @@ To download apps, you'll need to be signed in with a Microsoft account. Some app
 
 To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.
 
-1. To open the [**Start** menu](holographic-home.md), perform a the [Start gesture](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
+1. To open the [**Start** menu](holographic-home.md), perform a the [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
 1. Select the Store app. Once the Store app opens:
   1. Use the search bar to look for any desired application. 
   1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -35,7 +35,7 @@ Open the Microsoft Store from the **Start** menu. Then browse for apps and games
 
 To download apps, you'll need to be signed in with a Microsoft account. Some apps are free and can be downloaded right away. Apps that require a purchase require you to be signed in to the Store with your Microsoft account and have a valid payment method.
 > [!NOTE]
->The account you can use on Microsoft Store does not have to be the same as the account you are signed in with. If you are using a Work or School account on your HoloLens then you'll need to sign in with your personal account in the Store App to make a purchase.
+> The account you use on Microsoft Store does not have to be the same as the account you are signed in with. If you are using a Work or School account on your HoloLens then you'll need to sign in with your personal account in the Store App to make a purchase.
 
 To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.
 

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -43,7 +43,7 @@ To set up a payment method, go to [account.microsoft.com](https://account.micros
 1. Select the Store app. Once the Store app opens:
   1. Use the search bar to look for any desired applications. 
   1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.
-  1. On the top right of the Store app select the **"..."** button and select **My Library**, to view any perviously purchased apps.
+  1. On the top right of the Store app, select the **"..."** button and then select **My Library** to view any previously purchased apps.
 1. Select **Get** or **Install** on the application's page (a purchase may be required).
 
 ## Uninstall apps

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -34,7 +34,7 @@ Open the Microsoft Store from the **Start** menu. Then browse for apps and games
 ## Install apps
 
 To download apps, you'll need to be signed in with a Microsoft account. Some apps are free and can be downloaded right away. Apps that require a purchase require you to be signed in to the Store with your Microsoft account and have a valid payment method.
->[!NOTE]
+> [!NOTE]
 >The account you can use on Microsoft Store does not have to be the same as the account you are signed in with. If you are using a Work or School account on your HoloLens then you'll need to sign in with your personal account in the Store App to make a purchase.
 
 To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -39,7 +39,7 @@ To download apps, you'll need to be signed in with a Microsoft account. Some app
 
 To set up a payment method, go to [account.microsoft.com](https://account.microsoft.com/) and select **Payment & billing** > **Payment options** > **Add a payment option**.
 
-1. To open the [**Start** menu](holographic-home.md), perform a the [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
+1. To open the [**Start** menu](holographic-home.md), perform a [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
 1. Select the Store app. Once the Store app opens:
   1. Use the search bar to look for any desired applications. 
   1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -41,7 +41,7 @@ To set up a payment method, go to [account.microsoft.com](https://account.micros
 
 1. To open the [**Start** menu](holographic-home.md), perform a the [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
 1. Select the Store app. Once the Store app opens:
-  1. Use the search bar to look for any desired application. 
+  1. Use the search bar to look for any desired applications. 
   1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.
   1. On the top right of the Store app select the **"..."** button and select **My Library**, to view any perviously purchased apps.
 1. Select **Get** or **Install** on the application's page (a purchase may be required).

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -52,7 +52,7 @@ There are two ways to uninstall applications.  You can uninstall applications th
 
 ### Uninstall from the Start menu
 
-On the **Start** menu or in the **All apps** list, browse to the app. Air Tap and hold until the menu appears, then select **Uninstall**.
+On the **Start** menu or in the **All apps** list, browse to the app. Air tap and hold until the menu appears, then select **Uninstall**.
 
 ### Uninstall from the Microsoft Store
 

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -42,7 +42,7 @@ To set up a payment method, go to [account.microsoft.com](https://account.micros
 1. To open the [**Start** menu](holographic-home.md), perform a [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) or [bloom](hololens1-basic-usage.md) gesture on HoloLens 1.
 1. Select the Store app. Once the Store app opens:
   1. Use the search bar to look for any desired applications. 
-  1. Select from one of curated categories to find essential apps or apps made specifically for HoloLens.
+  1. Select essential apps or apps made specifically for HoloLens from one of the curated categories.
   1. On the top right of the Store app, select the **"..."** button and then select **My Library** to view any previously purchased apps.
 1. Select **Get** or **Install** on the application's page (a purchase may be required).
 

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -43,7 +43,7 @@ To set up a payment method, go to [account.microsoft.com](https://account.micros
 1. Select the Store app. Once the Store app opens:
   1. Use the search bar to look for any desired applications. 
   1. Select essential apps or apps made specifically for HoloLens from one of the curated categories.
-  1. On the top right of the Store app, select the **"..."** button and then select **My Library** to view any previously purchased apps.
+  1. On the top right of the Store app, select the **...** button and then select **My Library** to view any previously purchased apps.
 1. Select **Get** or **Install** on the application's page (a purchase may be required).
 
 ## Uninstall apps

--- a/devices/hololens/holographic-store-apps.md
+++ b/devices/hololens/holographic-store-apps.md
@@ -33,7 +33,7 @@ Open the Microsoft Store from the **Start** menu. Then browse for apps and games
 
 ## Install apps
 
-To download apps, you'll need to be signed in with a Microsoft account. Some apps are free and can be downloaded right away. Apps that require a purchase require you to be signed into the Store with your Microsoft account and have a valid payment method.
+To download apps, you'll need to be signed in with a Microsoft account. Some apps are free and can be downloaded right away. Apps that require a purchase require you to be signed in to the Store with your Microsoft account and have a valid payment method.
 >[!NOTE]
 >The account you can use on Microsoft Store does not have to be the same as the account you are signed in with. If you are using a Work or School account on your HoloLens then you'll need to sign in with your personal account in the Store App to make a purchase.
 


### PR DESCRIPTION
Removed old instructions on tap to place apps from pre rs5
Clarified not all apps need to be purchased.
Added note you can use MSA while using another account.
Got rid of a BLOOM reference corrected to Start Gesture 
Added My Library reference
@scooley