### PR TITLE
Deploy WDAC/Intune: update intro description

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune.md
+++ b/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune.md
@@ -27,7 +27,7 @@ ms.date: 05/17/2018
 -   Windows 10
 -   Windows Server 2016
 
-You can use Microsoft Intune to configure Windows Defender Application Control (WDAC). You can configure the Endpoint protection profile for WDAC or a custom profile with an OMA-URI. You can configure Windows 10 client computers to only run Windows components and Microsoft Store apps, or let them also run reputable apps defined by the Intelligent Security Graph.   
+You can use Microsoft Intune to configure Windows Defender Application Control (WDAC). You can either configure an Endpoint Protection profile for WDAC, or create a custom profile with an OMA-URI setting. Using an Endpoint Protection profile, you can configure Windows 10 client computers to only run Windows components and Microsoft Store apps, or let them also run reputable apps defined by the Intelligent Security Graph.   
 
 1. Open the Microsoft Intune portal and click **Device configuration** > **Profiles** > **Create profile**.
 


### PR DESCRIPTION
**Description:**
As discussed in issue ticket #4482 (Custom WDAC policy in Intune), it would be useful to add a detail on implementing a custom WDAC policy in Intune. Without this detail, the implication is that you can ONLY
use the Endpoint Protection template to configure WDAC in Intune.

Thank you to @Air-Git for following up on this topic and the content.

**Proposed change:**

- add details missed in the previous PR #5659 (Content Update)

**issue ticket closure or reference:**
Ref. #4482 (already closed)

**Additional notes:**
Feel free to suggest modifications or improvements as you deem necessary.