### PR TITLE
System Guard/Requirements: adjust description

### DIFF
--- a/windows/security/threat-protection/windows-defender-system-guard/system-guard-secure-launch-and-smm-protection.md
+++ b/windows/security/threat-protection/windows-defender-system-guard/system-guard-secure-launch-and-smm-protection.md
@@ -67,7 +67,7 @@ To verify that Secure Launch is running, use System Information (MSInfo32). Clic
 >To enable System Guard Secure launch, the platform must meet all the baseline requirements for [Device Guard](https://docs.microsoft.com/windows/security/threat-protection/device-guard/introduction-to-device-guard-virtualization-based-security-and-windows-defender-application-control), [Credential Guard](https://docs.microsoft.com/windows/security/identity-protection/credential-guard/credential-guard-requirements), and [Virtualization Based Security](https://docs.microsoft.com/windows/security/threat-protection/windows-defender-exploit-guard/enable-virtualization-based-protection-of-code-integrity).
 
 ## Requirements Met by System Guard Enabled Machines
-Any machine with System Guard enabled will automatically meet the following low-level hardware requirements:
+Any machine with System Guard enabled has already met the following low-level hardware requirements:
 
 |For Intel&reg; vPro&trade; processors starting with Intel&reg; Coffeelake, Whiskeylake, or later silicon|Description|
 |--------|-----------|


### PR DESCRIPTION
**Description:**
As suggested in issue ticket #5515 (**confusing phrasing about requirements**), the first sentence under the heading "Requirements Met by System Guard Enabled Machines" can be interpreted to mean that the act of enabling System Guard magically causes the correct hardware to exist in the computer. This is an attempt to adjust the sentence to be less ambiguous.

Thanks to @marypcbuk for pointing out this ambiguity.

**Proposed change:**

- Adjust the sentence to state that the hardware requirements are already met if System Guard is enabled.

**issue ticket closure or reference:**

Closes #5515