### PR TITLE
Corrected AUMID for the Kiosk Browser

### DIFF
--- a/windows/configuration/setup-digital-signage.md
+++ b/windows/configuration/setup-digital-signage.md
@@ -58,7 +58,7 @@ This procedure explains how to configure digital signage using Kiosk Browser on 
     - Enter a user name and password, and toggle **Auto sign-in** to **Yes**.
     - Under **Configure the kiosk mode app**, enter the user name for the account that you're creating.
     - For **App type**, select **Universal Windows App**.
-    - In **Enter the AUMID for the app**, enter `Microsoft.KioskBrowser_8wekyb3d8bbwe`.
+    - In **Enter the AUMID for the app**, enter `Microsoft.KioskBrowser_8wekyb3d8bbwe!App`.
 11. In the bottom left corner of Windows Configuration Designer, select **Switch to advanced editor**. 
 12. Go to **Runtime settings** > **Policies** > **KioskBrowser**. Let's assume that the URL for your digital signage content is contoso.com/menu.
     - In **BlockedUrlExceptions**, enter `https://www.contoso.com/menu`.


### PR DESCRIPTION
The AUMID shown in this guide is incorrect. Per the instructions found at https://docs.microsoft.com/en-us/windows/configuration/find-the-application-user-model-id-of-an-installed-app, the AUMID should be the "packagefamilyname"+"!"+"package.applications.application.id". In the case of the Kiosk Bowser, the AUMID is "Microsoft.KioskBrowser_8wekyb3d8bbwe!App". Failure to include the "!App" will result in an error when the kiosk account tries to load the app.