### PR TITLE
Update on-premises-deployment-surface-hub-device-accounts.md

### DIFF
--- a/devices/surface-hub/on-premises-deployment-surface-hub-device-accounts.md
+++ b/devices/surface-hub/on-premises-deployment-surface-hub-device-accounts.md
@@ -49,6 +49,7 @@ If you have a single-forest on-premises deployment with Microsoft Exchange 2013 
    ```PowerShell
    New-Mailbox -UserPrincipalName HUB01@contoso.com -Alias HUB01 -Name "Hub-01" -Room -EnableRoomMailboxAccount $true -RoomMailboxPassword (ConvertTo-SecureString -String <password> -AsPlainText -Force)
    ```
+[!IMPORTANT] ActiveSync Virtual Directory Basic Authentication is required to be enabled as the Surface Hub is unable to authenticate using other authentication methods.
 
 3. After setting up the mailbox, you will need to either create a new Exchange ActiveSync policy, or use a compatible existing policy.
 


### PR DESCRIPTION
[!IMPORTANT] ActiveSync Virtual Directory Basic Authentication is required to be enabled as the Surface Hub is unable to authenticate using other authentication methods.

[PS] C:\windows\system32>Get-ActiveSyncVirtualDirectory  | fl name,BasicAuthEnabled


Name             : Microsoft-Server-ActiveSync (Default Web Site)
BasicAuthEnabled : True