### PR TITLE
Edit table of default values

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/allow-log-on-through-remote-desktop-services.md
+++ b/windows/security/threat-protection/security-policy-settings/allow-log-on-through-remote-desktop-services.md
@@ -52,7 +52,8 @@ The following table lists the actual and effective default policy values. Defaul
 | Server type or GPO | Default value |
 | - | - |
 | Default Domain Policy | Not Defined |
-| Default Domain Controller Policy | Administrators |
+| Default Domain Controller Policy | Not Defined |
+| Domain Controller Local Security Policy | Administrators |
 | Stand-Alone Server Default Settings | Administrators<br>Remote Desktop Users | 
 | Domain Controller Effective Default Settings | Administrators | 
 | Member Server Effective Default Settings | Administrators<br>Remote Desktop Users |


### PR DESCRIPTION
Edited table of default settings based on Windows Server 2016 domain defaults.  The right on a domain controller is set in the local security policy and is not defined in the Default Domain Controller policy.