### PR TITLE
Windows 2 Go/Kingston IronKey USB: URL updated

### DIFF
--- a/windows/deployment/planning/windows-to-go-overview.md
+++ b/windows/deployment/planning/windows-to-go-overview.md
@@ -92,9 +92,9 @@ As of the date of publication, the following are the USB drives currently certif
 > [!WARNING]
 > Using a USB drive that has not been certified is not supported.
 
-- IronKey Workspace W700 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w700.html](https://go.microsoft.com/fwlink/p/?LinkId=618714))
-- IronKey Workspace W500 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w500.html](https://go.microsoft.com/fwlink/p/?LinkId=618717))
-- IronKey Workspace W300 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w300.html](https://go.microsoft.com/fwlink/p/?LinkId=618718))
+- IronKey Workspace W700 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w700.html](https://www.kingston.com/support/technical/products?model=dtws))
+- IronKey Workspace W500 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w500.html](https://www.kingston.com/support/technical/products?model=dtws))
+- IronKey Workspace W300 ([http://www.ironkey.com/windows-to-go-drives/ironkey-workspace-w300.html](https://www.kingston.com/support/technical/products?model=dtws))
 - Kingston DataTraveler Workspace for Windows To Go ([http://www.kingston.com/wtg/](https://go.microsoft.com/fwlink/p/?LinkId=618719))
 - Spyrus Portable Workplace ([http://www.spyruswtg.com/](https://go.microsoft.com/fwlink/p/?LinkId=618720))
 


### PR DESCRIPTION
**Description:**

Based on the suggestion from @jvsam in issue ticket #5562 (Erreur 404), all the 3 links used for Kingston IronKey USB drives should point to the same Kingston DataTraveler Workspace+B2:M22 support page https://www.kingston.com/support/technical/products?model=dtws

Thanks to @Efflamm for reporting the link as broken (error 404).

**Changes proposed:**

- Replace the 3 different go.microsoft.com/fwlink/ URLs with a common link pointing to the DataTraveler Workspace+B2:M22 support page.

**issue ticket closure or reference:**

Closes #5562