### PR TITLE
Do not require CTRL+ALT+DEL: remove duplicate text

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/interactive-logon-do-not-require-ctrl-alt-del.md
+++ b/windows/security/threat-protection/security-policy-settings/interactive-logon-do-not-require-ctrl-alt-del.md
@@ -19,7 +19,7 @@ ms.date: 04/19/2017
 # Interactive logon: Do not require CTRL+ALT+DEL
 
 **Applies to**
--   Windows 10
+- Windows 10
 
 Describes the best practices, location, values, and security considerations for the **Interactive logon: Do not require CTRL+ALT+DEL** security policy setting.
 
@@ -27,7 +27,7 @@ Describes the best practices, location, values, and security considerations for 
 
 This security setting determines whether pressing CTRL+ALT+DEL is required before a user can log on.
 
-If this policy setting is enabled on a device, a user is not required to press CTRL+ALT+DEL to log on. Not having to press CTRL+ALT+DEL leaves users susceptible to attacks that attempt to intercept the users' passwords. Requiring CTRL+ALT+DEL before users log on ensures that users are communicating by means of a trusted path when entering their passwords.
+If this policy setting is enabled on a device, a user is not required to press CTRL+ALT+DEL to log on.
 
 If this policy is disabled, any user is required to press CTRL+ALT+DEL before logging on to the Windows operating system (unless they are using a smart card for logon).
 
@@ -37,13 +37,13 @@ A malicious user might install malware that looks like the standard logon dialog
 
 ### Possible values
 
--   Enabled
--   Disabled
--   Not defined
+- Enabled
+- Disabled
+- Not defined
 
 ### Best practices
 
--   It is advisable to set **Disable CTRL+ALT+DEL requirement for logon** to **Not configured**.
+- It is advisable to set **Disable CTRL+ALT+DEL requirement for logon** to **Not configured**.
 
 ### Location
 


### PR DESCRIPTION
**Description:**

As discussed with @jvsam (Jo) in issue ticket #5559 (**Is the guidance around CTRL-ALT-DEL still valid?**),
this improvement suggestion is based on already noted redundant or duplicated sentences in the article.

**Changes proposed:**
- Remove 2 redundant sentences repeated 2 paragraphs below.
- Remove redundant whitespace in a few MarkDown bullet lists.

**issue ticket closure or reference:**

Ref. #5559 (issue not resolved yet)