### PR TITLE
Update recommended block list to explain not blocking 1903 files

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -160,9 +160,8 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   <Deny ID="ID_DENY_MS_BUILD" FriendlyName="Microsoft.Build.dll" FileName="Microsoft.Build.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
   <Deny ID="ID_DENY_MS_BUILD_FMWK" FriendlyName="Microsoft.Build.Framework.dll" FileName="Microsoft.Build.Framework.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
 
-  <!-- msxml3.dll pick correct version based on release you are supporting -->
-  <!-- msxml6.dll pick correct version based on release you are supporting -->     
-  <!-- jscript9.dll pick correct version based on release you are supporting -->
+  <!-- pick correct version of msxml3.dll, msxml6.dll, and jscript9.dll based on release you are supporting -->
+  <!-- the versions of these files in the 1903 release have this issue fixed, so they don’t need to be blocked -->
   <!-- RS1 Windows 1607
   <Deny  ID="ID_DENY_MSXML3"        FriendlyName="msxml3.dll"         FileName="msxml3.dll" MinimumFileVersion ="8.110.14393.2550"/>
   <Deny  ID="ID_DENY_MSXML6"        FriendlyName="msxml6.dll"         FileName="msxml6.dll" MinimumFileVersion ="6.30.14393.2550"/>

--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -160,7 +160,7 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   <Deny ID="ID_DENY_MS_BUILD" FriendlyName="Microsoft.Build.dll" FileName="Microsoft.Build.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
   <Deny ID="ID_DENY_MS_BUILD_FMWK" FriendlyName="Microsoft.Build.Framework.dll" FileName="Microsoft.Build.Framework.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
 
-  <!-- pick correct version of msxml3.dll, msxml6.dll, and jscript9.dll based on release you are supporting -->
+  <!-- pick the correct version of msxml3.dll, msxml6.dll, and jscript9.dll based on the release you are supporting -->
   <!-- the versions of these files in the 1903 release have this issue fixed, so they don’t need to be blocked -->
   <!-- RS1 Windows 1607
   <Deny  ID="ID_DENY_MSXML3"        FriendlyName="msxml3.dll"         FileName="msxml3.dll" MinimumFileVersion ="8.110.14393.2550"/>
@@ -892,7 +892,7 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   <FileRuleRef RuleID="ID_DENY_WMIC"/>
   <FileRuleRef RuleID="ID_DENY_MWFC" /> 
   <FileRuleRef RuleID="ID_DENY_WFC" /> 
-  <!-- Uncomment the relevant line(s) below if you have uncommented them in the rule definitions above.
+  <!-- uncomment the relevant line(s) below if you have uncommented them in the rule definitions above
   <FileRuleRef RuleID="ID_DENY_MSXML3" /> 
   <FileRuleRef RuleID="ID_DENY_MSXML6" /> 
   <FileRuleRef RuleID="ID_DENY_JSCRIPT9" />


### PR DESCRIPTION
msxml3.dll, msxml6.dll, and jscript9.dll do not have to be blocked if using 1903, as the previous issue was fixed in this release