### PR TITLE
Update mac-preferences.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-preferences.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-preferences.md
@@ -371,10 +371,6 @@ The following configuration profile will:
 ### Intune profile
 
 ```XML
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1">
-    <dict>
         <key>PayloadUUID</key>
         <string>C4E6A782-0C8D-44AB-A025-EB893987A295</string>
         <key>PayloadType</key>
@@ -443,8 +439,6 @@ The following configuration profile will:
                 </dict>
             </dict>
         </array>
-    </dict>
-</plist>
 ```
 
 ## Full configuration profile example

--- a/windows/security/threat-protection/microsoft-defender-atp/mac-preferences.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-preferences.md
@@ -524,10 +524,6 @@ The following configuration profile contains entries for all settings described 
 ### Intune profile
 
 ```XML
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1">
-    <dict>
         <key>PayloadUUID</key>
         <string>C4E6A782-0C8D-44AB-A025-EB893987A295</string>
         <key>PayloadType</key>
@@ -634,8 +630,6 @@ The following configuration profile contains entries for all settings described 
                 </dict>
             </dict>
         </array>
-    </dict>
-</plist>
 ```
 
 ## Configuration profile deployment


### PR DESCRIPTION
The format of the .plist for Intune was wrong before. The correct format doesn't have anything wrapped in <xml> or <dict> or <plist>. This needes to be edited as there was an ICM caused due to customer confusion in the documentation. Only key value pairs are needed and required for the correct format