### PR TITLE
Update microsoft-surface-brightness-control.md

### DIFF
--- a/devices/surface/microsoft-surface-brightness-control.md
+++ b/devices/surface/microsoft-surface-brightness-control.md
@@ -46,9 +46,14 @@ documentation](https://docs.microsoft.com/windows/desktop/sysinfo/registry).
 1.  Run regedit from a command prompt to open the Windows Registry
     Editor.
     
-      - Computer\HKEY\_LOCAL\_MACHINE\SOFTWARE\Microsoft\Surface\Surface
+      - Computer\HKEY\_LOCAL\_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Surface\Surface
         Brightness Control\	
-		
+    
+    If you're running an older version of Surface Brightness control, run the following command instead:
+    
+      - Computer\HKEY\_LOCAL\_MACHINE\SOFTWARE\Microsoft\Surface\Surface
+        Brightness Control\
+
 
 | Registry Setting | Data| Description  
 |-----------|------------|---------------


### PR DESCRIPTION
This update is a high pri request from Tod Edwards, Sr. Technical Advisor for Devices. Here is what he requested in the work item he filed with the CSS Content team:
-----------------------------------------------------------------------------------------------------------------------------------------------------
Update https://docs.microsoft.com/en-us/surface/microsoft-surface-brightness-control

Version 1.16.137 uses this registry location now:
HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Surface\Surface Brightness Control

We need to keep information on the page that says previous versions of the tool use: 
Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Surface\Surface Brightness Control

If customer doesn't know which version they have, they will know which place they need to edit based on if the registry path exists or not, since the registry location is created when the app is installed.