### PR TITLE
WDAC policy/Rule option 18: clarify ambiguity

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create.md
+++ b/windows/security/threat-protection/windows-defender-application-control/select-types-of-rules-to-create.md
@@ -67,7 +67,7 @@ You can set several rule options within a WDAC policy. Table 1 describes each ru
 | **15 Enabled:Invalidate EAs on Reboot** | When the Intelligent Security Graph option (14) is used, WDAC sets an extended file attribute that indicates that the file was authorized to run. This option will cause WDAC to periodically re-validate the reputation for files that were authorized by the ISG.| 
 | **16 Enabled:Update Policy No Reboot** | Use this option to allow future WDAC policy updates to apply without requiring a system reboot. |
 | **17 Enabled:Allow Supplemental Policies** | Use this option on a base policy to allow supplemental policies to expand it. |
-| **18 Disabled:Runtime FilePath Rule Protection** | Disable default FilePath rule protection (apps and executables allowed based on file path rules must come from a file path that’s only writable by an administrator) for the path specified in the FilePathRule parameter of the New-CIPolicyRule cmdlet. |
+| **18 Disabled:Runtime FilePath Rule Protection** | Disable default FilePath rule protection (apps and executables allowed based on file path rules must come from a file path that’s only writable by an administrator) for any FileRule that allows a file based on FilePath. |
 | **19 Enabled:Dynamic Code Security** | Enables policy enforcement for .NET applications and dynamically-loaded libraries. |
 
 ## Windows Defender Application Control file rule levels


### PR DESCRIPTION
**Description:**

According to the latest feedback from Air-Git in issue ticket #5462 (**Option 18 is ambiguous**), in the last part of the Rule option Description, the wording is now precise, but not accurate.

An accurate statement is as follows: "[...] for any FileRule that allows a file based on FilePath."

Thanks to @Air-Git for the continued valuable feedback to MS Docs articles in need of improvement and suggested solutions.

**Proposed change:**
- Adjust the end part of the sentence to be accurate.

**issue ticket closure or reference:**

Closes #5462