### PR TITLE
Windows/Deployment: VAMT System Requirements

### DIFF
--- a/windows/deployment/volume-activation/vamt-requirements.md
+++ b/windows/deployment/volume-activation/vamt-requirements.md
@@ -38,9 +38,9 @@ The following table lists the system requirements for the VAMT host computer.
 | Hard Disk | 16 GB available hard disk space for x86 or 20 GB for x64 |
 | External Drive | Removable media (Optional) |
 | Display | 1024x768 or higher resolution monitor |
-| Network |Connectivity to remote computers via Windows® Management Instrumentation (TCP/IP) and Microsoft® Activation Web Service on the Internet via HTTPS |
+| Network | Connectivity to remote computers via Windows Management Instrumentation (TCP/IP) and Microsoft Activation Web Service on the Internet via HTTPS |
 | Operating System | Windows 7, Windows 8, Windows 8.1, Windows 10, Windows Server 2008 R2, Windows Server 2012, or later. |
-| Additional Requirements | <ul><li>Connection to a SQL Server database. For more info, see [Install VAMT](install-vamt.md).</li><li>PowerShell 3.0: For Windows 8, Windows 8.1, Windows 10, and Windows Server® 2012, PowerShell is included in the installation. For previous versions of Windows and Windows Server, you must download PowerShell 3.0. To download PowerShell, go to [Download Windows PowerShell 3.0](https://go.microsoft.com/fwlink/p/?LinkId=218356).</li><li>If installing on Windows Server 2008 R2, you must also install .NET Framework 3.51.</li></ul> |
+| Additional Requirements | <ul><li>Connection to a SQL Server database. For more info, see [Install VAMT](install-vamt.md).</li><li>PowerShell 3.0: For Windows 8, Windows 8.1, Windows 10, and Windows Server 2012, PowerShell is included in the installation. For previous versions of Windows and Windows Server, you must download PowerShell 3.0. To download PowerShell, go to [Download Windows PowerShell 3.0](https://go.microsoft.com/fwlink/p/?LinkId=218356).</li><li>If installing on Windows Server 2008 R2, you must also install .NET Framework 3.51.</li></ul> |
 
 ## Related topics
 - [Install and Configure VAMT](install-configure-vamt.md)

--- a/windows/deployment/volume-activation/vamt-requirements.md
+++ b/windows/deployment/volume-activation/vamt-requirements.md
@@ -31,17 +31,16 @@ The Volume Activation Management Tool (VAMT) can be used to perform activations 
 
 The following table lists the system requirements for the VAMT host computer.
 
-|Item |Minimum system requirement |
-|-----|---------------------------|
-|Computer and Processor |1 GHz x86 or x64 processor |
-|Memory |1 GB RAM for x86 or 2 GB RAM for x64 |
-|Hard Disk |16 GB available hard disk space for x86 or 20 GB for x64 |
-|External Drive|Removable media (Optional) |
-|Display |1024x768 or higher resolution monitor |
-|Network |Connectivity to remote computers via Windows® Management Instrumentation (TCP/IP) and Microsoft® Activation Web Service on the Internet via HTTPS |
-|Operating System |Windows 7, Windows 8, Windows 8.1, Windows 10, Windows Server 2008 R2, or Windows Server 2012. |
-|Additional Requirements |<ul><li>Connection to a SQL Server database. For more info, see [Install VAMT](install-vamt.md).</li><li>PowerShell 3.0: For Windows 8, Windows 8.1, Windows 10, and Windows Server® 2012, PowerShell is included in the installation. For previous versions of Windows and 
-Windows Server, you must download PowerShell 3.0. To download PowerShell, go to [Download Windows PowerShell 3.0](https://go.microsoft.com/fwlink/p/?LinkId=218356).</li><li>If installing on Windows Server 2008 R2, you must also install .NET Framework 3.51.</li></ul> |
+| Item | Minimum system requirement |
+| ---- | ---------------------------|
+| Computer and Processor | 1 GHz x86 or x64 processor |
+| Memory | 1 GB RAM for x86 or 2 GB RAM for x64 |
+| Hard Disk | 16 GB available hard disk space for x86 or 20 GB for x64 |
+| External Drive | Removable media (Optional) |
+| Display | 1024x768 or higher resolution monitor |
+| Network |Connectivity to remote computers via Windows® Management Instrumentation (TCP/IP) and Microsoft® Activation Web Service on the Internet via HTTPS |
+| Operating System | Windows 7, Windows 8, Windows 8.1, Windows 10, Windows Server 2008 R2, Windows Server 2012, or later. |
+| Additional Requirements | <ul><li>Connection to a SQL Server database. For more info, see [Install VAMT](install-vamt.md).</li><li>PowerShell 3.0: For Windows 8, Windows 8.1, Windows 10, and Windows Server® 2012, PowerShell is included in the installation. For previous versions of Windows and Windows Server, you must download PowerShell 3.0. To download PowerShell, go to [Download Windows PowerShell 3.0](https://go.microsoft.com/fwlink/p/?LinkId=218356).</li><li>If installing on Windows Server 2008 R2, you must also install .NET Framework 3.51.</li></ul> |
 
 ## Related topics
 - [Install and Configure VAMT](install-configure-vamt.md)


### PR DESCRIPTION
**Description:**

As per user feedback in issue ticket #5818 (**Operating System Requirements**), it is desirable to allow for later versions of Windows Server to be shown in the list of Operating Systems under "Minimum system requirement".

There is also a visible defect in last row of the table, breaking the last one and a half sentence over to the first column of the next row.

Thanks to @laolive382 for posting this request and making me notice the (ever so slightly) broken table.

**Changes proposed:**
- change "2008 R2, or Windows Server 2012" to "2008 R2, Windows Server 2012, or later"
- remove line break in the last row to restore the row structure
- add MarkDown spacing in the table for readability/editing

**issue ticket closure or reference:**

Closes #5818