### PR TITLE
Update vpnv2-profile-xsd.md

### DIFF
--- a/windows/client-management/mdm/vpnv2-profile-xsd.md
+++ b/windows/client-management/mdm/vpnv2-profile-xsd.md
@@ -194,7 +194,6 @@ Here's the XSD for the ProfileXML node in VPNv2 CSP for Windows 10 and some pro
     <NativeProtocolType>IKEv2</NativeProtocolType>  
     <Authentication>  
       <UserMethod>Eap</UserMethod>  
-      <MachineMethod>Eap</MachineMethod>  
       <Eap>  
        <Configuration>
           <EapHostConfig xmlns="http://www.microsoft.com/provisioning/EapHostConfig">


### PR DESCRIPTION
"MachineMethod>Eap</MachineMethod" should’t be in the example, because

1.  MachineMethod can only be Certificate 
------ see https://docs.microsoft.com/en-gb/windows/client-management/mdm/vpnv2-csp 
........................VPNv2/ProfileName/NativeProfile/Authentication/MachineMethod
                         This is only supported in IKEv2.
                                This value can be one of the following:
                                •	Certificate

2. A profile conatins either UserMethod or MachineMethod but not both