### PR TITLE
Local Accounts/Administrator account: 20016 typo

### DIFF
--- a/windows/security/identity-protection/access-control/local-accounts.md
+++ b/windows/security/identity-protection/access-control/local-accounts.md
@@ -73,7 +73,7 @@ The Administrator account has full control of the files, directories, services, 
 
 The default Administrator account cannot be deleted or locked out, but it can be renamed or disabled.
 
-In Windows 10 and Windows Server 20016, Windows setup disables the built-in Administrator account and creates another local account that is a member of the Administrators group. Members of the Administrators groups can run apps with elevated permissions without using the **Run as Administrator** option. Fast User Switching is more secure than using Runas or different-user elevation.  
+In Windows 10 and Windows Server 2016, Windows setup disables the built-in Administrator account and creates another local account that is a member of the Administrators group. Members of the Administrators groups can run apps with elevated permissions without using the **Run as Administrator** option. Fast User Switching is more secure than using Runas or different-user elevation.  
 
 **Account group membership**
 


### PR DESCRIPTION
**Description:**

As pointed out in issue ticket #6017 (**Double 0 typo**), Windows Server 2016 contains a double 0 typo which needs correction.

Thanks to @vainkop for making us aware of this typo issue.

**Proposed change:**
- Remove the extra 0 to spell Windows Server 2016 correctly.

**issue ticket closure or reference:**

Closes #6017