### PR TITLE
Fix Defender Operational event log name

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/evaluate-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/evaluate-attack-surface-reduction.md
@@ -50,7 +50,7 @@ You can also use Group Policy, Intune, or MDM CSPs to configure and deploy the s
 
 ## Review attack surface reduction events in Windows Event Viewer
 
-To review apps that would have been blocked, open Event Viewer and filter for Event ID 1121 in the Microsoft-Windows-Windows-Defender/Operational log. The following table lists all network protection events.
+To review apps that would have been blocked, open Event Viewer and filter for Event ID 1121 in the Microsoft-Windows-Windows Defender/Operational log. The following table lists all network protection events.
 
  Event ID | Description
 -|-


### PR DESCRIPTION
Log name does not have a - between Windows and Defender. Updating would help those copying the event log name into an event forwarder or searching a SIEM.