### PR TITLE
Remove Windows Server 2016

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/exploit-protection.md
@@ -24,7 +24,7 @@ ms.custom: asr
 
 - [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
 
-Exploit protection automatically applies a number of exploit mitigation techniques to operating system processes and apps. Exploit protection is supported beginning with Windows 10, version 1709 and Windows Server 2016, version 1803.
+Exploit protection automatically applies a number of exploit mitigation techniques to operating system processes and apps. Exploit protection is supported beginning with Windows 10, version 1709 and Windows Server, version 1803.
 
 > [!TIP]
 > You can visit the Windows Defender Testground website at [demo.wd.microsoft.com](https://demo.wd.microsoft.com?ocid=cx-wddocs-testground) to confirm the feature is working and see how it works.


### PR DESCRIPTION
There is no Windows Server 2016, version 1803. It only exists Windows Server 2016 and Windows Server, Version 1803. Since 2016 doesn't come with Exploit Protection remove it to reduce confusion.