### PR TITLE
chore: MarkDown Note marker compatibility spacing

### DIFF
--- a/browsers/edge/group-policies/new-tab-page-settings-gp.md
+++ b/browsers/edge/group-policies/new-tab-page-settings-gp.md
@@ -22,8 +22,8 @@ ms.topic: reference
 
 Microsoft Edge loads the default New tab page by default.  With the relevant New Tab policies, you can set a URL to load in the New Tab page and prevent users from making changes.  You can also load a blank page instead or let the users choose what loads. 
 
->[!NOTE]
->New tab pages do not load while running InPrivate mode. 
+> [!NOTE]
+> New tab pages do not load while running InPrivate mode. 
 
 ## Relevant group policies
 

--- a/browsers/edge/includes/ie11-send-all-sites-not-in-site-list-include.md
+++ b/browsers/edge/includes/ie11-send-all-sites-not-in-site-list-include.md
@@ -13,8 +13,8 @@ ms.topic: include
 
 By default, all sites open the currently active browser. With this policy, you can automatically open all sites not included in the Enterprise Mode Site List in Microsoft Edge. When you enable this policy, you must also turn on the Internet Explorer\Use the Enterprise Mode IE website list policy and include at least one site in the Enterprise Mode Site List.
 
->[!NOTE]
->If you’ve also enabled the Microsoft Edge [Send all intranet sites to Internet Explorer 11](../available-policies.md#send-all-intranet-sites-to-internet-explorer-11) policy, all intranet sites continue to open in Internet Explorer 11.
+> [!NOTE]
+> If you’ve also enabled the Microsoft Edge [Send all intranet sites to Internet Explorer 11](../available-policies.md#send-all-intranet-sites-to-internet-explorer-11) policy, all intranet sites continue to open in Internet Explorer 11.
 
 You can find the group policy settings in the following location of the Group Policy Editor:
 

--- a/browsers/edge/managing-group-policy-admx-files.md
+++ b/browsers/edge/managing-group-policy-admx-files.md
@@ -19,8 +19,8 @@ ms.date: 10/19/2018
 
 ADMX files, which are registry-based policy settings provide an XML-based structure for defining the display of the Administrative Template policy settings in the Group Policy Object Editor. The ADMX files replace ADM files, which used a different markup language. 
 
->[!NOTE] 
->The administrative tools you use—Group Policy Object Editor and Group Policy Management Console—remain mostly unchanged. In the majority of situations, you won’t notice the presence of ADMX files during your day-to-day Group Policy administration tasks. 
+> [!NOTE] 
+> The administrative tools you use—Group Policy Object Editor and Group Policy Management Console—remain mostly unchanged. In the majority of situations, you won’t notice the presence of ADMX files during your day-to-day Group Policy administration tasks. 
 
 Unlike ADM files, ADMX files are not stored in individual GPOs by default; however, this behavior supports less common scenarios. For domain-based enterprises, you can create a central store location of ADMX files accessible by anyone with permission to create or edit GPOs. Group Policy tools continue to recognize other earlier ADM files you have in your existing environment. The Group Policy Object Editor automatically reads and displays Administrative Template policy settings from both the ADMX and ADM files.
 

--- a/browsers/enterprise-mode/set-up-enterprise-mode-portal.md
+++ b/browsers/enterprise-mode/set-up-enterprise-mode-portal.md
@@ -35,8 +35,8 @@ You must download the deployment folder (**EMIEWebPortal/**), which includes all
 
 2. Install the Node.js® package manager, [npm](https://www.npmjs.com/).
 
-    >[!Note]   
-    >You need to install the npm package manager to replace all the third-party libraries we removed to make the Enterprise Mode Site List Portal open-source.
+    > [!NOTE]   
+    > You need to install the npm package manager to replace all the third-party libraries we removed to make the Enterprise Mode Site List Portal open-source.
 
 3. Open File Explorer and then open the **EMIEWebPortal/** folder.
 
@@ -105,8 +105,8 @@ Create a new Application Pool and the website, by using the IIS Manager.
 
 9. Double-click the **Authentication** icon, right-click on **Windows Authentication**, and then click **Enable**. 
 
-    >[!Note]
-    >You must also make sure that **Anonymous Authentication** is marked as **Enabled**.
+    > [!NOTE]
+    > You must also make sure that **Anonymous Authentication** is marked as **Enabled**.
 
 10. Return to the **<<i>website_name</i>> Home** pane, and double-click the **Connection Strings** icon.
 
@@ -116,8 +116,8 @@ Create a new Application Pool and the website, by using the IIS Manager.
 
     - **Initial catalog.** The name of your database.
 
-        >[!Note]
-        >Step 3 of this topic provides the steps to create your database.
+        > [!NOTE]
+        > Step 3 of this topic provides the steps to create your database.
 
 ## Step 3 - Create and prep your database
 Create a SQL Server database and run our custom query to create the Enterprise Mode Site List tables.
@@ -216,8 +216,8 @@ Register the EMIEScheduler tool and service for production site list changes.
 
 1. Open File Explorer and go to EMIEWebPortal.SchedulerService\EMIEWebPortal.SchedulerService in your deployment directory, and then copy the **App_Data**, **bin**, and **Logs** folders to a separate folder. For example, C:\EMIEService\.
  
-    >[!Important]
-    >If you can't find the **bin** and **Logs** folders, you probably haven't built the Visual Studio solution. Building the solution creates the folders and files.
+    > [!IMPORTANT]
+    > If you can't find the **bin** and **Logs** folders, you probably haven't built the Visual Studio solution. Building the solution creates the folders and files.
 
 2. In Visual Studio start the Developer Command Prompt as an administrator, and then change the directory to the location of the InstallUtil.exe file. For example, _C:\Windows\Microsoft.NET\Framework\v4.0.30319_.
 

--- a/browsers/enterprise-mode/turn-on-enterprise-mode-and-use-a-site-list.md
+++ b/browsers/enterprise-mode/turn-on-enterprise-mode-and-use-a-site-list.md
@@ -1,8 +1,8 @@
 Before you can use a site list with Enterprise Mode, you must turn the functionality on and set up the system for centralized control. By allowing
 centralized control, you can create one global list of websites that render using Enterprise Mode. Approximately 65 seconds after Internet Explorer 11 starts, it looks for a properly formatted site list. If a new site list if found, with a different version number than the active list, IE11 loads and uses the newer version. After the initial check, IE11 won’t look for an updated list again until you restart the browser.
 
->[!NOTE] 
->We recommend that you store and download your website list from a secure web server (https://), to help protect against data tampering. After the list is downloaded, it's stored locally on your employees' computers so if the centralized file location is unavailable, they can still use Enterprise Mode.
+> [!NOTE]
+> We recommend that you store and download your website list from a secure web server (https://), to help protect against data tampering. After the list is downloaded, it's stored locally on your employees' computers so if the centralized file location is unavailable, they can still use Enterprise Mode.
 
 **Group Policy**
 

--- a/browsers/internet-explorer/ie11-deploy-guide/enable-and-disable-add-ons-using-administrative-templates-and-group-policy.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/enable-and-disable-add-ons-using-administrative-templates-and-group-policy.md
@@ -81,8 +81,8 @@ Every add-on has a Class ID (CLSID) that you use to enable and disable specific 
     
 2.  From the copied information, select and copy just the **Class ID** value.
 
-    >[!NOTE]
-    >You want to copy the curly brackets as well as the CLSID: **{47833539-D0C5-4125-9FA8-0819E2EAAC93}**.
+    > [!NOTE]
+    > You want to copy the curly brackets as well as the CLSID: **{47833539-D0C5-4125-9FA8-0819E2EAAC93}**.
 
 3.  Open the Group Policy Management Editor and go to: Computer Configuration\Policies\Administrative Templates\Windows Components\Internet Explorer\Security Features\Add-on Management.
 <br>**-OR-**<br>

--- a/browsers/internet-explorer/ie11-deploy-guide/ie11-delivery-through-automatic-updates.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/ie11-delivery-through-automatic-updates.md
@@ -37,8 +37,8 @@ current version of Internet Explorer.
 
 Internet Explorer 11 replaces Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10. If you decide you don’t want Internet Explorer 11, and you’re running Windows 7 SP1 or Windows Server 2008 R2 with SP1, you can uninstall it from the **View installed updates** section of the **Uninstall an update** page of the Control Panel.
 
->[!Note]
->If a user installs Internet Explorer 11 and then removes it, it won’t be re-offered to that computer through Automatic Updates. Instead, the user will have to manually re-install the app.
+> [!NOTE]
+> If a user installs Internet Explorer 11 and then removes it, it won’t be re-offered to that computer through Automatic Updates. Instead, the user will have to manually re-install the app.
 
 ## Internet Explorer 11 automatic upgrades
 
@@ -52,14 +52,14 @@ If you use Automatic Updates in your company, but want to stop your users from a
 
 -   **Download and use the Internet Explorer 11 Blocker Toolkit.**  Includes a Group Policy template and a script that permanently blocks Internet Explorer 11 from being offered by Windows Update or Microsoft Update as a high-priority update. You can download this kit from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=40722).
 
-    >[!Note]
-    >The toolkit won't stop users with local administrator accounts from manually installing Internet Explorer 11. Using this toolkit also prevents your users from receiving automatic upgrades from Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 to Internet Explorer 11. For more information, see the [Internet Explorer 11 Blocker Toolkit frequently asked questions](../ie11-faq/faq-ie11-blocker-toolkit.md).
+    > [!NOTE]
+    > The toolkit won't stop users with local administrator accounts from manually installing Internet Explorer 11. Using this toolkit also prevents your users from receiving automatic upgrades from Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 to Internet Explorer 11. For more information, see the [Internet Explorer 11 Blocker Toolkit frequently asked questions](../ie11-faq/faq-ie11-blocker-toolkit.md).
 
 -   **Use an update management solution to control update deployment.**
     If you already use an update management solution, like [Windows Server Update Services (WSUS)](https://docs.microsoft.com/windows-server/administration/windows-server-update-services/get-started/windows-server-update-services-wsus) or the more advanced [Microsoft Endpoint Configuration Manager](https://go.microsoft.com/fwlink/?LinkID=276664), you should use that instead of the Internet Explorer Blocker Toolkit.
 
-    >[!Note]
-    >If you use WSUS to manage updates, and Update Rollups are configured for automatic installation, Internet Explorer will automatically install throughout your company. This scenario is discussed in detail in the Knowledge Base article [here](https://support.microsoft.com/kb/946202).
+    > [!NOTE]
+    > If you use WSUS to manage updates, and Update Rollups are configured for automatic installation, Internet Explorer will automatically install throughout your company. This scenario is discussed in detail in the Knowledge Base article [here](https://support.microsoft.com/kb/946202).
 
 Additional information on Internet Explorer 11, including a Readiness Toolkit, technical overview, in-depth feature summary, and Internet Explorer 11 download is available on the [Internet Explorer 11 page of the Microsoft Edge IT Center](https://technet.microsoft.com/microsoft-edge/dn262703.aspx).
 
@@ -81,13 +81,13 @@ Internet Explorer 11 will be released to WSUS as an Update Rollup package. There
 4. Click the rule that automatically approves an update that is classified as
    Update Rollup, and then click **Edit.**
 
-   >[!Note]
-   >If you don’t see a rule like this, you most likely haven’t configured WSUS to automatically approve Update Rollups for installation. In this situation, you don’t have to do anything else.
+   > [!NOTE]
+   > If you don’t see a rule like this, you most likely haven’t configured WSUS to automatically approve Update Rollups for installation. In this situation, you don’t have to do anything else.
 
 5. Click the **Update Rollups** property under the **Step 2: Edit the properties (click an underlined value)** section.
 
-   >[!Note]
-   >The properties for this rule will resemble the following:<ul><li>When an update is in Update Rollups</li><li>Approve the update for all computers</li></ul>
+   > [!NOTE]
+   > The properties for this rule will resemble the following:<ul><li>When an update is in Update Rollups</li><li>Approve the update for all computers</li></ul>
 
 6. Clear the **Update Rollup** check box, and then click **OK**.
 
@@ -105,8 +105,8 @@ Internet Explorer 11 will be released to WSUS as an Update Rollup package. There
 
 13. Check to make sure that Microsoft Internet Explorer 11 is listed as an unapproved update.
 
-    >[!Note]
-    >There may be multiple updates, depending on the imported language and operating system updates.
+    > [!NOTE]
+    > There may be multiple updates, depending on the imported language and operating system updates.
 
 **Optional**
 
@@ -126,8 +126,8 @@ If you need to reset your Update Rollups packages to auto-approve, do this:
 
 7.  Click **OK** to close the **Automatic Approvals** dialog box.
 
->[!Note]
->Because auto-approval rules are only evaluated when an update is first imported into WSUS, turning this rule back on after the Internet Explorer 11 update has been imported and synchronized to the server won’t cause this update to be auto-approved.
+> [!NOTE]
+> Because auto-approval rules are only evaluated when an update is first imported into WSUS, turning this rule back on after the Internet Explorer 11 update has been imported and synchronized to the server won’t cause this update to be auto-approved.
 
 
 ## Additional resources

--- a/browsers/internet-explorer/ie11-deploy-guide/ie11-delivery-through-automatic-updates.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/ie11-delivery-through-automatic-updates.md
@@ -101,7 +101,7 @@ Internet Explorer 11 will be released to WSUS as an Update Rollup package. There
 
 11. Expand *ComputerName*, expand **Updates**, and then click **All Updates**.
 
-12. Choose **Unapproved** in the **Approval**drop down box.
+12. Choose **Unapproved** in the **Approval** drop down box.
 
 13. Check to make sure that Microsoft Internet Explorer 11 is listed as an unapproved update.
 

--- a/browsers/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal.md
@@ -36,8 +36,8 @@ You must download the deployment folder (**EMIEWebPortal/**), which includes all
 
 2. Install the Node.js® package manager, [npm](https://www.npmjs.com/).
 
-    >[!Note]   
-    >You need to install the npm package manager to replace all the third-party libraries we removed to make the Enterprise Mode Site List Portal open-source.
+    > [!NOTE]   
+    > You need to install the npm package manager to replace all the third-party libraries we removed to make the Enterprise Mode Site List Portal open-source.
 
 3. Open File Explorer and then open the **EMIEWebPortal/** folder.
 
@@ -49,8 +49,8 @@ You must download the deployment folder (**EMIEWebPortal/**), which includes all
 
 6. Go back up a directory, open the solution file **EMIEWebPortal.sln** in Visual Studio, open **Web.config** from **EMIEWebPortal/** folder, and replace MSIT-LOB-COMPAT with your server name hosting your database, replace LOBMerged with your database name, and build the entire solution.
 
-      >[!Note]
-      >Step 3 of this topic provides the steps to create your database.
+      > [!NOTE]
+      > Step 3 of this topic provides the steps to create your database.
 
 7. Copy the contents of the **EMIEWebPortal/** folder to a dedicated folder on your file system. For example, _D:\EMIEWebApp_. In a later step, you'll designate this folder as your website in the IIS Manager.
 
@@ -109,8 +109,8 @@ Create a new Application Pool and the website, by using the IIS Manager.
 
 9. Double-click the **Authentication** icon, right-click on **Windows Authentication**, and then click **Enable**. 
 
-    >[!Note]
-    >You must also make sure that **Anonymous Authentication** is marked as **Enabled**.
+    > [!NOTE]
+    > You must also make sure that **Anonymous Authentication** is marked as **Enabled**.
 
 ## Step 3 - Create and prep your database
 Create a SQL Server database and run our custom query to create the Enterprise Mode Site List tables.
@@ -209,8 +209,8 @@ Register the EMIEScheduler tool and service for production site list changes.
 
 1. Open File Explorer and go to EMIEWebPortal.SchedulerService\EMIEWebPortal.SchedulerService in your deployment directory, and then copy the **App_Data**, **bin**, and **Logs** folders to a separate folder. For example, C:\EMIEService\.
  
-    >[!Important]
-    >If you can't find the **bin** and **Logs** folders, you probably haven't built the Visual Studio solution. Building the solution creates the folders and files.
+    > [!IMPORTANT]
+    > If you can't find the **bin** and **Logs** folders, you probably haven't built the Visual Studio solution. Building the solution creates the folders and files.
 
 2. In Visual Studio start the Developer Command Prompt as an administrator, and then change the directory to the location of the InstallUtil.exe file. For example, _C:\Windows\Microsoft.NET\Framework\v4.0.30319_.
 

--- a/browsers/internet-explorer/ie11-deploy-guide/tips-and-tricks-to-manage-ie-compatibility.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/tips-and-tricks-to-manage-ie-compatibility.md
@@ -85,8 +85,8 @@ To see if the site works in the Internet Explorer 5, Internet Explorer 7, Intern
 
 -   Run the site in each document mode until you find the mode in which the site works.
  
-    >[!NOTE]
-    >You will need to make sure the User agent string dropdown matches the same browser version as the Document mode dropdown. For example, if you were testing to see if the site works in Internet Explorer 10, you should update the Document mode dropdown to 10 and the User agent string dropdown to Internet Explorer 10.
+    > [!NOTE]
+    > You will need to make sure the User agent string dropdown matches the same browser version as the Document mode dropdown. For example, if you were testing to see if the site works in Internet Explorer 10, you should update the Document mode dropdown to 10 and the User agent string dropdown to Internet Explorer 10.
 
 -   If you find a mode in which your site works, you will need to add the site  domain, sub-domain, or URL to the Enterprise Mode Site List for the document mode in which the site works, or ask the IT administrator to do so. You can add the *x-ua-compatible* meta tag or HTTP header as well.
 
@@ -116,8 +116,8 @@ If IE8 Enterprise Mode doesn't work, IE7 Enterprise Mode will give you the Compa
 
 If the site works, inform the IT administrator that the site needs to be added to the IE7 Enterprise Mode section.\
 
->[!NOTE]
->Adding the same Web path to the Enterprise Mode and sections of the Enterprise Mode Site List will not work, but we will address this in a future update.
+> [!NOTE]
+> Adding the same Web path to the Enterprise Mode and sections of the Enterprise Mode Site List will not work, but we will address this in a future update.
 
 ### Update the site for modern web standards
 

--- a/browsers/internet-explorer/ie11-deploy-guide/turn-on-enterprise-mode-and-use-a-site-list.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/turn-on-enterprise-mode-and-use-a-site-list.md
@@ -28,8 +28,8 @@ ms.localizationpriority: medium
 
 Before you can use a site list with Enterprise Mode, you need to turn the functionality on and set up the system for centralized control. By allowing centralized control, you can create one global list of websites that render using Enterprise Mode. Approximately 65 seconds after Internet Explorer 11 starts, it looks for a properly formatted site list. If a new site list if found, with a different version number than the active list, IE11 loads and uses the newer version. After the initial check, IE11 won’t look for an updated list again until you restart the browser.
 
->[!NOTE]
->We recommend that you store and download your website list from a secure web server (https://), to help protect against data tampering. After the list is downloaded, it's stored locally on your employees' computers so if the centralized file location is unavailable, they can still use Enterprise Mode.
+> [!NOTE]
+> We recommend that you store and download your website list from a secure web server (https://), to help protect against data tampering. After the list is downloaded, it's stored locally on your employees' computers so if the centralized file location is unavailable, they can still use Enterprise Mode.
 
  **To turn on Enterprise Mode using Group Policy**
 
@@ -63,9 +63,4 @@ Before you can use a site list with Enterprise Mode, you need to turn the functi
 - [Download the Enterprise Mode Site List Manager (schema v.1)](https://go.microsoft.com/fwlink/p/?LinkID=394378)
 - [Add multiple sites to the Enterprise Mode site list using a file and the Enterprise Mode Site List Manager (schema v.1)](add-multiple-sites-to-enterprise-mode-site-list-using-the-version-1-schema-and-enterprise-mode-tool.md)
 - [Add multiple sites to the Enterprise Mode site list using a file and the Enterprise Mode Site List Manager (schema v.2)](add-multiple-sites-to-enterprise-mode-site-list-using-the-version-2-schema-and-enterprise-mode-tool.md)
- 
-
- 
-
-
 

--- a/browsers/internet-explorer/ie11-deploy-guide/user-interface-problems-with-ie11.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/user-interface-problems-with-ie11.md
@@ -46,14 +46,6 @@ For IE11, the UI has been changed to provide just the controls needed to support
 ## Where did the search box go?
 IE11 uses the **One Box** feature, which lets users type search terms directly into the **Address bar**. Any text entered into the **Address bar** that doesn't appear to be a URL is automatically sent to the currently selected search provider.
 
->[!NOTE]
->Depending on how you've set up your intranet search, the text entry might resolve to an intranet site. For more information about this, see  [Intranet problems with Internet Explorer 11](intranet-problems-and-ie11.md).
-
- 
-
- 
-
- 
-
-
+> [!NOTE]
+> Depending on how you've set up your intranet search, the text entry might resolve to an intranet site. For more information about this, see  [Intranet problems with Internet Explorer 11](intranet-problems-and-ie11.md).
 

--- a/browsers/internet-explorer/ie11-deploy-guide/what-is-the-internet-explorer-11-blocker-toolkit.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/what-is-the-internet-explorer-11-blocker-toolkit.md
@@ -29,8 +29,8 @@ ms.date: 05/10/2018
 
 The Internet Explorer 11 Blocker Toolkit lets you turn off the automatic delivery of IE11 through the **Automatic Updates** feature of Windows Update.
 
->[!IMPORTANT]
->The IE11 Blocker Toolkit does not stop users from manually installing IE11 from the [Microsoft Download Center](https://go.microsoft.com/fwlink/p/?linkid=327753). Also, even if you have installed previous versions of the toolkit before, like for Internet Explorer 10, you still need to install this version to prevent the installation of IE11.
+> [!IMPORTANT]
+> The IE11 Blocker Toolkit does not stop users from manually installing IE11 from the [Microsoft Download Center](https://go.microsoft.com/fwlink/p/?linkid=327753). Also, even if you have installed previous versions of the toolkit before, like for Internet Explorer 10, you still need to install this version to prevent the installation of IE11.
 
 ## Install the toolkit
 
@@ -69,13 +69,13 @@ If you use Automatic Updates in your company, but want to stop your users from a
 
 -   **Download and use the Internet Explorer 11 Blocker Toolkit.**  Includes a Group Policy template and a script that permanently blocks Internet Explorer 11 from being offered by Windows Update or Microsoft Update as a high-priority update. You can download this kit from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=40722).
 
-    >[!NOTE]
+    > [!NOTE]
     >The toolkit won't stop users with local administrator accounts from manually installing Internet Explorer 11. Using this toolkit also prevents your users from receiving automatic upgrades from Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 to Internet Explorer 11. For more information, see the [Internet Explorer 11 Blocker Toolkit frequently asked questions](https://docs.microsoft.com/internet-explorer/ie11-faq/faq-for-it-pros-ie11).
 
 -   **Use an update management solution to control update deployment.** If you already use an update management solution, like [Windows Server Update Services (WSUS)](https://docs.microsoft.com/windows-server/administration/windows-server-update-services/get-started/windows-server-update-services-wsus) or the more advanced [System Center 2012 Configuration Manager](https://go.microsoft.com/fwlink/?LinkID=276664), you should use that instead of the Internet Explorer Blocker Toolkit.
 
->[!NOTE]
->If you use WSUS to manage updates, and Update Rollups are configured for automatic installation, Internet Explorer will automatically install throughout your company.
+> [!NOTE]
+> If you use WSUS to manage updates, and Update Rollups are configured for automatic installation, Internet Explorer will automatically install throughout your company.
 
 
 ### Prevent automatic installation of Internet Explorer 11 with WSUS
@@ -90,13 +90,13 @@ Internet Explorer 11 will be released to WSUS as an Update Rollup package. There
 
 4.  Click the rule that automatically approves an update that is classified as Update Rollup, and then click **Edit.**
 
-    >[!NOTE]
-    >If you don’t see a rule like this, you most likely haven’t configured WSUS to automatically approve Update Rollups for installation. In this situation, you don’t have to do anything else.
+    > [!NOTE]
+    > If you don’t see a rule like this, you most likely haven’t configured WSUS to automatically approve Update Rollups for installation. In this situation, you don’t have to do anything else.
 
 5.  Click the **Update Rollups** property under the **Step 2: Edit the properties (click an underlined value)** section.
 
-    >[!NOTE]
-    >The properties for this rule will resemble the following:<ul><li>When an update is in Update Rollups</li><li>Approve the update for all computers</li></ul>
+    > [!NOTE]
+    > The properties for this rule will resemble the following:<ul><li>When an update is in Update Rollups</li><li>Approve the update for all computers</li></ul>
 
 6.  Clear the **Update Rollup** check box, and then click **OK**.
 
@@ -116,8 +116,8 @@ After the new Internet Explorer 11 package is available for download, you should
 
 6.  Check to make sure that Microsoft Internet Explorer 11 is listed as an unapproved update.
 
->[!NOTE]
->There may be multiple updates, depending on the imported language and operating system updates.
+> [!NOTE]
+> There may be multiple updates, depending on the imported language and operating system updates.
 
 ### Optional - Reset update rollups packages to auto-approve
 
@@ -135,8 +135,8 @@ After the new Internet Explorer 11 package is available for download, you should
 
 7.  Click **OK** to close the **Automatic Approvals** dialog box.
 
->[!NOTE]
->Because auto-approval rules are only evaluated when an update is first imported into WSUS, turning this rule back on after the Internet Explorer 11 update has been imported and synchronized to the server won’t cause this update to be auto-approved.
+> [!NOTE]
+> Because auto-approval rules are only evaluated when an update is first imported into WSUS, turning this rule back on after the Internet Explorer 11 update has been imported and synchronized to the server won’t cause this update to be auto-approved.
 
 
 

--- a/browsers/internet-explorer/ie11-faq/faq-ieak11.md
+++ b/browsers/internet-explorer/ie11-faq/faq-ieak11.md
@@ -36,22 +36,22 @@ You can customize and install IEAK 11 on the following supported operating syste
 
 -   Windows Server 2008 R2 Service Pack 1 (SP1)
 
->[!Note]
->IEAK 11 does not support building custom packages for Windows RT.
+> [!NOTE]
+> IEAK 11 does not support building custom packages for Windows RT.
 
 
 **What can I customize with IEAK 11?**
 
 The IEAK 11 enables you to customize branding and settings for Internet Explorer 11. For PCs running Windows 7, the custom package also includes the Internet Explorer executable.
 
->[!Note]
->Internet Explorer 11 is preinstalled on PCs running Windows 8. Therefore, the executable is not included in the customized package.
+> [!NOTE]
+> Internet Explorer 11 is preinstalled on PCs running Windows 8. Therefore, the executable is not included in the customized package.
 
 **Can IEAK 11 build custom Internet Explorer 11 packages in languages other than the language of the in-use IEAK 11 version?**
 Yes. You can use IEAK 11 to build custom Internet Explorer 11 packages in any of the supported 24 languages. You'll select the language for the custom package on the Language Selection page of the customization wizard.
 
->[!Note]
->IEAK 11 is available in 24 languages but can build customized Internet Explorer 11 packages in all languages of the supported operating systems. To download IEAK 11, see [Internet Explorer Administration Kit (IEAK) information and downloads](../ie11-ieak/ieak-information-and-downloads.md).
+> [!NOTE]
+> IEAK 11 is available in 24 languages but can build customized Internet Explorer 11 packages in all languages of the supported operating systems. To download IEAK 11, see [Internet Explorer Administration Kit (IEAK) information and downloads](../ie11-ieak/ieak-information-and-downloads.md).
 
 **Q: Is there a version of the Internet Explorer Administration Kit (IEAK) supporting IE11?**<br>
 Yes. The Internet Explorer Administration Kit 11 (IEAK 11) is available for download. IEAK 11 lets you create custom versions of IE11 for use in your organization. For more information, see the following resources:

--- a/browsers/internet-explorer/ie11-ieak/troubleshooting-custom-browser-pkg-ieak11.md
+++ b/browsers/internet-explorer/ie11-ieak/troubleshooting-custom-browser-pkg-ieak11.md
@@ -98,14 +98,14 @@ Pressing the **F1** button on the **Automatic Version Synchronization** page of 
 ## Certificate installation does not work on IEAK 11
 IEAK 11 doesn't install certificates added using the Add a Root Certificate page of the Internet Explorer Customization Wizard 11. Administrators can manually install certificates using the Certificates Microsoft Management Console snap-in (Certmgr.msc) or using the command-line tool, Certificate Manager (Certmgr.exe).
 
->[!NOTE]
->This applies only when using the External licensing mode of IEAK 11.
+> [!NOTE]
+> This applies only when using the External licensing mode of IEAK 11.
 
 ## The Additional Settings page appears in the wrong language when using a localized version of IEAK 11
 When using IEAK 11 in other languages, the settings on the Additional Settings page appear in the language of the target platform, regardless of the IEAK 11 language.
 
->[!NOTE]
->This applies only when using the Internal licensing mode of IEAK 11.
+> [!NOTE]
+> This applies only when using the Internal licensing mode of IEAK 11.
 
 To work around this issue, run the customization wizard following these steps:
 1. On the **Language Selection** page, select the language that matches the language of your installed IEAK 11.

--- a/browsers/internet-explorer/ie11-ieak/what-ieak-can-do-for-you.md
+++ b/browsers/internet-explorer/ie11-ieak/what-ieak-can-do-for-you.md
@@ -32,8 +32,8 @@ IEAK 10 and newer includes the ability to install using one of the following ins
 - Internal
 - External
 
->[!NOTE]
->IEAK 11 works in network environments, with or without Microsoft Active Directory service.
+> [!NOTE]
+> IEAK 11 works in network environments, with or without Microsoft Active Directory service.
 
 
 ### Corporations


### PR DESCRIPTION
**Description:**

This PR is a standalone attempt to standardize the MarkDown Note bubbles by adding the recommended single space after the quote marker.
MarkDown codestyle consistency is the main goal here.

**Changes proposed:**
- Add single space between the quote marker and the text [!NOTE]
- Add the same spacing to the connected text line in the same bubble
- Apply the same standard to other nearby notes, e.g. [!IMPORTANT]
- Standardize on uppercase [!NOTE] instead of mixed casing ( [!Note] )
- Remove some of the obvious redundant spacing at end-of-file

**Ticket reference or closure:**
None that I know of (at least not yet).

**Additional notes:**
I have split this modification chore into sub-folder sections to keep the number of files within a reasonably manageable amount.