### PR TITLE
Unite the bold text of a selected option

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-key-trust-validate-pki.md
+++ b/windows/security/identity-protection/hello-for-business/hello-key-trust-validate-pki.md
@@ -151,7 +151,7 @@ Domain controllers automatically request a certificate from the domain controlle
 7. Expand **Windows Settings**, **Security Settings**, and click **Public Key Policies**.
 8. In the details pane, right-click **Certificate Services Client – Auto-Enrollment** and select **Properties**.
 9. Select **Enabled** from the **Configuration Model** list.
-10. Select the **Renew expired certificates**, **update pending certificates**, and **remove revoked certificates** check box.
+10. Select the **Renew expired certificates, update pending certificates, and remove revoked certificates** check box.
 11. Select the **Update certificates that use certificate templates** check box.
 12. Click **OK**. Close the **Group Policy Management Editor**.
 


### PR DESCRIPTION
This is a single option in the configuration and splitting the bold text sections makes it look like there are 3 different options.
![image](https://user-images.githubusercontent.com/4018286/75625978-02674600-5bcc-11ea-8744-64cddb18663e.png)
