### PR TITLE
re: #3829, Wrong value for registering devices

### DIFF
--- a/windows/deployment/windows-autopilot/administer.md
+++ b/windows/deployment/windows-autopilot/administer.md
@@ -45,7 +45,7 @@ Several platforms are available to register devices with Windows Autopilot. A su
 
 <tr>
 <td><a href="https://docs.microsoft.com/en-us/intune/enrollment-autopilot">Intune</a></td>
-<td>YES - 175 at a time max</td>
+<td>YES - 500 at a time max</td>
 <td>YES<b>\*</b></td>
 <td>4K HH</td>
 </tr>


### PR DESCRIPTION
#3829 Wrong value for registering devices in Intune

>Its current 500 devices

Our current docs and screenshots agree that the current max is 500; for example, see the link in the table - https://docs.microsoft.com/en-us/intune/enrollment-autopilot - last updated ~6 months after this article, it contains a screenshot listing a max of 500 rows, with one row for each device