### PR TITLE
 GPO Names and Behaviour Has Changed (via #5110)

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -37,7 +37,7 @@ The auto-enrollment relies on the presence of an MDM service and the Azure Activ
 
 When the auto-enrollment Group Policy is enabled, a task is created in the background that initiates the MDM enrollment. The task will use the existing MDM service configuration from the Azure Active Directory information of the user. If multi-factor authentication is required, the user will get a prompt to complete the authentication. Once the enrollment is configured, the user can check the status in the Settings page.
 
-In Windows 10, version 1709, when the same policy is configured in GP and MDM, the GP policy wins (GP policy takes precedence over MDM). Since Windows 10, version 1803, a new setting allows you to change the policy conflict winner to MDM. For additional information, see [Windows 10 Group Policy vs. Intune MDM Policy who wins?](https://blogs.technet.microsoft.com/cbernier/2018/04/02/windows-10-group-policy-vs-intune-mdm-policy-who-wins/).
+In Windows 10, version 1709 or later, when the same policy is configured in GP and MDM, the GP policy wins (GP policy takes precedence over MDM). Since Windows 10, version 1803, a new setting allows you to change the policy conflict winner to MDM. For additional information, see [Windows 10 Group Policy vs. Intune MDM Policy who wins?](https://blogs.technet.microsoft.com/cbernier/2018/04/02/windows-10-group-policy-vs-intune-mdm-policy-who-wins/).
 
 For this policy to work, you must verify that the MDM service provider allows the GP triggered MDM enrollment for domain joined devices.
 
@@ -90,7 +90,7 @@ You may contact your domain administrators to verify if the group policy has bee
 This procedure is only for illustration purposes to show how the new auto-enrollment policy works. It is not recommended for the production environment in the enterprise. For bulk deployment, you should use the [Group Policy Management Console process](#configure-the-auto-enrollment-for-a-group-of-devices).
 
 Requirements:
-- AD-joined PC running Windows 10, version 1709
+- AD-joined PC running Windows 10, version 1709 or later
 - Enterprise has MDM service already configured 
 - Enterprise AD must be registered with Azure AD
 
@@ -106,7 +106,7 @@ Requirements:
 
     ![MDM policies](images/autoenrollment-mdm-policies.png)
 
-4. Double-click **Enable Automatic MDM enrollment using default Azure AD credentials**.
+4. Double-click **Enable automatic MDM enrollment using default Azure AD credentials** (previously called **Auto MDM Enrollment with AAD Token** in Windows 10, version 1709). For ADMX files in Windows 10, version 1903 and later, select **User Credential** (support for Device Credential is coming) as the Selected Credential Type to use. User Credential enrolls Windows 10, version 1709 and later once an Intune licensed user logs into the device. Device Credential will enroll the device and then assign a user later, once support for this is available.
 
     ![MDM autoenrollment policy](images/autoenrollment-policy.png)
 
@@ -159,26 +159,23 @@ Learn more by reading [What is Conditional Access?](https://docs.microsoft.com/a
 ## Configure the auto-enrollment for a group of devices
 
 Requirements:
-- AD-joined PC running Windows 10, version 1709
+- AD-joined PC running Windows 10, version 1709 or later
 - Enterprise has MDM service already configured (with Intune or a third party service provider)
 - Enterprise AD must be integrated with Azure AD.
 - Ensure that PCs belong to same computer group.
 
 > [!IMPORTANT]
-> If you do not see the policy, it may be because you don’t have the ADMX installed for Windows 10, version 1803, version 1809, or version 1903. To fix the issue, follow these steps (Note: the latest MDM.admx is backwards compatible):        
+
+> If you do not see the policy, it may be because you don’t have the ADMX installed for Windows 10, version 1903 or version 1809. To fix the issue, follow these steps:        
 >   1. Download:  
->   1803 -->[Administrative Templates (.admx) for Windows 10 April 2018 Update (1803)](https://www.microsoft.com/download/details.aspx?id=56880) or  
->   1809 --> [Administrative Templates for Windows 10 October 2018 Update (1809)](https://www.microsoft.com/download/details.aspx?id=57576) or
->   1903 --> [Administrative Templates (.admx) for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495&WT.mc_id=rss_alldownloads_all)
->   2. Install the package on the Primary Domain Controller (PDC).
+>   1903 -->[Administrative Templates for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495) or  
+>   1809 --> [Administrative Templates for Windows 10 October 2018 Update (1809)](https://www.microsoft.com/download/details.aspx?id=57576).
+>   2. Install the package.
 >   3. Navigate, depending on the version to the folder:
->   1803 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 April 2018 Update (1803) v2**, or  
->   1809 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 October 2018 Update (1809) v2**, or
->   1903 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2019 Update (1903) v3**
->   4. Rename the extracted Policy Definitions folder to **PolicyDefinitions**.
->   5. Copy PolicyDefinitions folder to **C:\Windows\SYSVOL\domain\Policies**. 
->   (If this folder does not exist, then be aware that you will be switching to a [central policy store](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra) for your entire domain).
->   6. Restart the Primary Domain Controller for the policy to be available.
+>   1903 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2019 Update (1903) v3**, or  
+>   1809 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 October 2018 Update (1809) v2**
+>   4. Copy the policy definitions folder to **C:\Windows\SYSVOL\domain\Policies** or **%windir%\sysvol\domain_name\policies\PolicyDefinitions** if a Group Policy Central Store exists.
+
 >   This procedure will work for any future version as well.
 
 1. Create a Group Policy Object (GPO) and enable the Group Policy **Computer Configuration** > **Policies** > **Administrative Templates** > **Windows Components** > **MDM** > **Enable automatic MDM enrollment using default Azure AD credentials**.
@@ -188,7 +185,6 @@ Requirements:
 5. Enforce a GPO link.
 
 ## Troubleshoot auto-enrollment of devices
-
 Investigate the log file if you have issues even after performing all the mandatory verification steps. The first log file to investigate is the event log on the target Windows 10 device. 
 
 To collect Event Viewer logs:
@@ -242,9 +238,9 @@ To collect Event Viewer logs:
 - [Link a Group Policy Object](https://technet.microsoft.com/library/cc732979(v=ws.11).aspx)
 - [Filter Using Security Groups](https://technet.microsoft.com/library/cc752992(v=ws.11).aspx)
 - [Enforce a Group Policy Object Link](https://technet.microsoft.com/library/cc753909(v=ws.11).aspx)
+- [Group Policy Central Store](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra)
 
 ### Useful Links
 
 - [Windows 10 Administrative Templates for Windows 10 May 2019 Update 1903](https://www.microsoft.com/download/details.aspx?id=58495)
 - [Windows 10 Administrative Templates for Windows 10 October 2018 Update 1809](https://www.microsoft.com/download/details.aspx?id=57576)
-- [Windows 10 Administrative Templates for Windows 10 April 2018 Update 1803](https://www.microsoft.com/download/details.aspx?id=56880)


### PR DESCRIPTION
This PR is a follow-up replacement of PR #5110, with resolved merge conflicts.

Credits due @brianreidc7, where they wrote:

> "Enable automatic MDM enrollment using default Azure AD credentials" is the GPO name and it has two sub options. Not sure if Device Certificate is working at the moment, but the pictures are wrong, but User Certificate is working and so the docs should at least say to use that for now