### PR TITLE
Deployment/Update: standardize double quote marks

### DIFF
--- a/windows/deployment/update/media-dynamic-update.md
+++ b/windows/deployment/update/media-dynamic-update.md
@@ -8,7 +8,7 @@ itproauthor: jaimeo
 author: SteveDiAcetis
 ms.localizationpriority: medium
 ms.author: jaimeo
-ms.reviewer: 
+ms.reviewer:
 manager: laurawi
 ms.collection: M365-modern-desktop
 ms.topic: article
@@ -88,7 +88,7 @@ The main operating system file (install.wim) contains multiple editions of Windo
 
 ### Additional languages and features
 
-You don't have to add more languages and features to the image to accomplish the updates, but it's an opportunity to customize the image with more languages, Optional Components, and Features on Demand beyond what is in your starting image. To do this, it's important to make these changes in the correct order: first apply servicing stack updates, followed by language additions, then by feature additions, and finally the latest cumulative update. The provided sample script installs a second language (in this case Japanese (ja-JP)). Since this language is backed by an lp.cab, there's no need to add a Language Experience Pack. Japanese is added to both the main operating system and to the recovery environment to allow the user to see the recovery screens in Japanese. This includes adding localized versions of the packages currently installed in the recovery image. 
+You don't have to add more languages and features to the image to accomplish the updates, but it's an opportunity to customize the image with more languages, Optional Components, and Features on Demand beyond what is in your starting image. To do this, it's important to make these changes in the correct order: first apply servicing stack updates, followed by language additions, then by feature additions, and finally the latest cumulative update. The provided sample script installs a second language (in this case Japanese (ja-JP)). Since this language is backed by an lp.cab, there's no need to add a Language Experience Pack. Japanese is added to both the main operating system and to the recovery environment to allow the user to see the recovery screens in Japanese. This includes adding localized versions of the packages currently installed in the recovery image.
 
 Optional Components, along with the .Net feature, can be installed offline, however doing so creates pending operations that require the device to restart. As a result, the call to perform image cleanup would fail. There are two options to avoid this. One option is to skip the image cleanup step, though that will result in a larger install.wim. Another option is to install the .Net and Optional Components in a step after cleanup but before export. This is the option in the sample script. By doing this, you will have to start with the original install.wim (with no pending actions) when you maintain or update the image the next time (for example, the next month).
 
@@ -107,8 +107,8 @@ These examples are for illustration only, and therefore lack error handling. The
 
 The script starts by declaring global variables and creating folders to use for mounting images. Then, make a copy of the original media, from \oldMedia to \newMedia, keeping the original media in case there is a script error and it's necessary to start over from a known state. Also, it will provide a comparison of old versus new media to evaluate changes. To ensure that the new media updates, make sure they are not read-only.
 
-```
-function Get-TS { return "{0:HH:mm:ss}" -f (Get-Date) } 
+```PowerShell
+function Get-TS { return "{0:HH:mm:ss}" -f (Get-Date) }
 
 Write-Host "$(Get-TS): Starting media refresh"
 
@@ -121,19 +121,19 @@ $LANG = "ja-jp"
 $LANG_FONT_CAPABILITY = "jpan"
 
 # Declare Dynamic Update packages
-$LCU_PATH = “C:\mediaRefresh\packages\LCU.msu”
-$SSU_PATH = “C:\mediaRefresh\packages\SSU_DU.msu”
+$LCU_PATH = "C:\mediaRefresh\packages\LCU.msu"
+$SSU_PATH = "C:\mediaRefresh\packages\SSU_DU.msu"
 $SETUP_DU_PATH = "C:\mediaRefresh\packages\Setup_DU.cab"
-$SAFE_OS_DU_PATH = “C:\mediaRefresh\packages\SafeOS_DU.cab”
-$DOTNET_CU_PATH = "C:\mediaRefresh\packages\DotNet_CU.msu”
+$SAFE_OS_DU_PATH = "C:\mediaRefresh\packages\SafeOS_DU.cab"
+$DOTNET_CU_PATH = "C:\mediaRefresh\packages\DotNet_CU.msu"
 
 # Declare folders for mounted images and temp files
 $WORKING_PATH = "C:\mediaRefresh\temp"
 $MEDIA_OLD_PATH = "C:\mediaRefresh\oldMedia"
 $MEDIA_NEW_PATH = "C:\mediaRefresh\newMedia"
-$MAIN_OS_MOUNT = $WORKING_PATH + "\MainOSMount”
-$WINRE_MOUNT = $WORKING_PATH + "\WinREMount”
-$WINPE_MOUNT = $WORKING_PATH + "\WinPEMount”
+$MAIN_OS_MOUNT = $WORKING_PATH + "\MainOSMount"
+$WINRE_MOUNT = $WORKING_PATH + "\WinREMount"
+$WINPE_MOUNT = $WORKING_PATH + "\WinPEMount"
 
 # Mount the language pack ISO
 Write-Host "$(Get-TS): Mounting LP ISO"
@@ -152,7 +152,7 @@ $OS_LP_PATH = $LP_ISO_DRIVE_LETTER + ":\x64\langpacks\" + "Microsoft-Windows-Cli
 # Mount the Features on Demand ISO
 Write-Host "$(Get-TS): Mounting FOD ISO"
 $FOD_ISO_DRIVE_LETTER = (Mount-DiskImage -ImagePath $FOD_ISO_PATH -ErrorAction stop | Get-Volume).DriveLetter
-$FOD_PATH = $FOD_ISO_DRIVE_LETTER + ":\" 
+$FOD_PATH = $FOD_ISO_DRIVE_LETTER + ":\"
 
 # Create folders for mounting images and storing temporary files
 New-Item -ItemType directory -Path $WORKING_PATH -ErrorAction Stop | Out-Null
@@ -162,9 +162,10 @@ New-Item -ItemType directory -Path $WINPE_MOUNT -ErrorAction stop | Out-Null
 
 # Keep the original media, make a copy of it for the new, updateed media.
 Write-Host "$(Get-TS): Copying original media to new media path"
-Copy-Item -Path $MEDIA_OLD_PATH“\*” -Destination $MEDIA_NEW_PATH -Force -Recurse -ErrorAction stop | Out-Null
+Copy-Item -Path $MEDIA_OLD_PATH"\*" -Destination $MEDIA_NEW_PATH -Force -Recurse -ErrorAction stop | Out-Null
 Get-ChildItem -Path $MEDIA_NEW_PATH -Recurse | Where-Object { -not $_.PSIsContainer -and $_.IsReadOnly } | ForEach-Object { $_.IsReadOnly = $false }
 ```
+
 ### Update WinRE
 
 The script assumes that only a single edition is being updated, indicated by Index = 1 (Windows 10 Education Edition). Then the script mounts the image, saves Winre.wim to the working folder, and mounts it. It then applies servicing stack Dynamic Update, since its s are used for updating other s. Since the script is optionally adding Japanese, it adds the language pack to the image, and installs the Japanese versions of all optional packages already installed in Winre.wim. Then, it applies the Safe OS Dynamic Update package.
@@ -174,28 +175,28 @@ It finishes by cleaning and exporting the image to reduce the image size.
 > [!NOTE]
 > Skip adding the latest cumulative update to Winre.wim because it contains unnecessary s in the recovery environment. The s that are updated and applicable are contained in the safe operating system Dynamic Update package. This also helps to keep the image small.
 
-```
+```PowerShell
 # Mount the main operating system, used throughout the script
 Write-Host "$(Get-TS): Mounting main OS"
-Mount-WindowsImage -ImagePath $MEDIA_NEW_PATH"\sources\install.wim” -Index 1 -Path $MAIN_OS_MOUNT -ErrorAction stop| Out-Null  
+Mount-WindowsImage -ImagePath $MEDIA_NEW_PATH"\sources\install.wim" -Index 1 -Path $MAIN_OS_MOUNT -ErrorAction stop| Out-Null
 
 #
 # update Windows Recovery Environment (WinRE)
 #
-Copy-Item -Path $MAIN_OS_MOUNT"\windows\system32\recovery\winre.wim” -Destination $WORKING_PATH"\winre.wim” -Force -Recurse -ErrorAction stop | Out-Null
+Copy-Item -Path $MAIN_OS_MOUNT"\windows\system32\recovery\winre.wim" -Destination $WORKING_PATH"\winre.wim" -Force -Recurse -ErrorAction stop | Out-Null
 Write-Host "$(Get-TS): Mounting WinRE"
-Mount-WindowsImage -ImagePath $WORKING_PATH"\winre.wim” -Index 1 -Path $WINRE_MOUNT -ErrorAction stop | Out-Null 
+Mount-WindowsImage -ImagePath $WORKING_PATH"\winre.wim" -Index 1 -Path $WINRE_MOUNT -ErrorAction stop | Out-Null
 
 # Add servicing stack update
 Write-Host "$(Get-TS): Adding package $SSU_PATH"
-Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $SSU_PATH -ErrorAction stop | Out-Null  
+Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $SSU_PATH -ErrorAction stop | Out-Null
 
 #
 # Optional: Add the language to recovery environment
 #
 # Install lp.cab cab
 Write-Host "$(Get-TS): Adding package $WINPE_OC_LP_PATH"
-Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $WINPE_OC_LP_PATH -ErrorAction stop | Out-Null  
+Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $WINPE_OC_LP_PATH -ErrorAction stop | Out-Null
 
 # Install language cabs for each optional package installed
 $WINRE_INSTALLED_OC = Get-WindowsPackage -Path $WINRE_MOUNT
@@ -211,7 +212,7 @@ Foreach ($PACKAGE in $WINRE_INSTALLED_OC) {
             if ($WINPE_OC_LANG_CABS.Contains($OC_CAB)) {
                 $OC_CAB_PATH = Join-Path $WINPE_OC_LANG_PATH $OC_CAB
                 Write-Host "$(Get-TS): Adding package $OC_CAB_PATH"
-                Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $OC_CAB_PATH -ErrorAction stop | Out-Null  
+                Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $OC_CAB_PATH -ErrorAction stop | Out-Null
             }
         }
     }
@@ -226,10 +227,10 @@ if ( (Test-Path -Path $WINPE_FONT_SUPPORT_PATH) ) {
 # Add TTS support for the new language
 if (Test-Path -Path $WINPE_SPEECH_TTS_PATH) {
     if ( (Test-Path -Path $WINPE_SPEECH_TTS_LANG_PATH) ) {
-            
+
         Write-Host "$(Get-TS): Adding package $WINPE_SPEECH_TTS_PATH"
         Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $WINPE_SPEECH_TTS_PATH -ErrorAction stop | Out-Null
-            
+
         Write-Host "$(Get-TS): Adding package $WINPE_SPEECH_TTS_LANG_PATH"
         Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $WINPE_SPEECH_TTS_LANG_PATH -ErrorAction stop | Out-Null
     }
@@ -237,45 +238,46 @@ if (Test-Path -Path $WINPE_SPEECH_TTS_PATH) {
 
 # Add Safe OS
 Write-Host "$(Get-TS): Adding package $SAFE_OS_DU_PATH"
-Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $SAFE_OS_DU_PATH -ErrorAction stop | Out-Null   
+Add-WindowsPackage -Path $WINRE_MOUNT -PackagePath $SAFE_OS_DU_PATH -ErrorAction stop | Out-Null
 
 # Perform image cleanup
 Write-Host "$(Get-TS): Performing image cleanup on WinRE"
 DISM /image:$WINRE_MOUNT /cleanup-image /StartComponentCleanup | Out-Null
 
 # Dismount
-Dismount-WindowsImage -Path $WINRE_MOUNT  -Save -ErrorAction stop | Out-Null 
+Dismount-WindowsImage -Path $WINRE_MOUNT  -Save -ErrorAction stop | Out-Null
 
 # Export
-Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\winre2.wim”
-Export-WindowsImage -SourceImagePath $WORKING_PATH"\winre.wim” -SourceIndex 1 -DestinationImagePath $WORKING_PATH"\winre2.wim” -ErrorAction stop | Out-Null
-Move-Item -Path $WORKING_PATH"\winre2.wim” -Destination $WORKING_PATH"\winre.wim” -Force -ErrorAction stop | Out-Null
+Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\winre2.wim"
+Export-WindowsImage -SourceImagePath $WORKING_PATH"\winre.wim" -SourceIndex 1 -DestinationImagePath $WORKING_PATH"\winre2.wim" -ErrorAction stop | Out-Null
+Move-Item -Path $WORKING_PATH"\winre2.wim" -Destination $WORKING_PATH"\winre.wim" -Force -ErrorAction stop | Out-Null
 ```
+
 ### Update WinPE
 
 This script is similar to the one that updates WinRE, but instead it mounts Boot.wim, applies the packages with the latest cumulative update last, and saves. It repeats this for all images inside of Boot.wim, typically two images. It starts by applying the servicing stack Dynamic Update. Since the script is customizing this media with Japanese, it installs the language pack from the WinPE folder on the language pack ISO. Additionally, add font support and text to speech (TTS) support. Since the script is adding a new language, it rebuilds lang.ini, used to identify languages installed in the image. Finally, it cleans and exports Boot.wim, and copies it back to the new media.
 
-```
-# 
+```PowerShell
+#
 # update Windows Preinstallation Environment (WinPE)
-# 
+#
 
 # Get the list of images contained within WinPE
-$WINPE_IMAGES = Get-WindowsImage -ImagePath $MEDIA_NEW_PATH“\sources\boot.wim”
+$WINPE_IMAGES = Get-WindowsImage -ImagePath $MEDIA_NEW_PATH"\sources\boot.wim"
 
 Foreach ($IMAGE in $WINPE_IMAGES) {
 
     # update WinPE
     Write-Host "$(Get-TS): Mounting WinPE"
-    Mount-WindowsImage -ImagePath $MEDIA_NEW_PATH“\sources\boot.wim” -Index $IMAGE.ImageIndex -Path $WINPE_MOUNT -ErrorAction stop | Out-Null  
+    Mount-WindowsImage -ImagePath $MEDIA_NEW_PATH"\sources\boot.wim" -Index $IMAGE.ImageIndex -Path $WINPE_MOUNT -ErrorAction stop | Out-Null
 
     # Add SSU
     Write-Host "$(Get-TS): Adding package $SSU_PATH"
     Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $SSU_PATH -ErrorAction stop | Out-Null
-        
+
     # Install lp.cab cab
     Write-Host "$(Get-TS): Adding package $WINPE_OC_LP_PATH"
-    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $WINPE_OC_LP_PATH -ErrorAction stop | Out-Null  
+    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $WINPE_OC_LP_PATH -ErrorAction stop | Out-Null
 
     # Install language cabs for each optional package installed
     $WINPE_INSTALLED_OC = Get-WindowsPackage -Path $WINPE_MOUNT
@@ -287,12 +289,12 @@ Foreach ($IMAGE in $WINPE_IMAGES) {
 
             $INDEX = $PACKAGE.PackageName.IndexOf("-Package")
             if ($INDEX -ge 0) {
-                
+
                 $OC_CAB = $PACKAGE.PackageName.Substring(0, $INDEX) + "_" + $LANG + ".cab"
                 if ($WINPE_OC_LANG_CABS.Contains($OC_CAB)) {
                     $OC_CAB_PATH = Join-Path $WINPE_OC_LANG_PATH $OC_CAB
                     Write-Host "$(Get-TS): Adding package $OC_CAB_PATH"
-                    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $OC_CAB_PATH -ErrorAction stop | Out-Null  
+                    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $OC_CAB_PATH -ErrorAction stop | Out-Null
                 }
             }
         }
@@ -307,10 +309,10 @@ Foreach ($IMAGE in $WINPE_IMAGES) {
     # Add TTS support for the new language
     if (Test-Path -Path $WINPE_SPEECH_TTS_PATH) {
         if ( (Test-Path -Path $WINPE_SPEECH_TTS_LANG_PATH) ) {
-            
+
             Write-Host "$(Get-TS): Adding package $WINPE_SPEECH_TTS_PATH"
             Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $WINPE_SPEECH_TTS_PATH -ErrorAction stop | Out-Null
-            
+
             Write-Host "$(Get-TS): Adding package $WINPE_SPEECH_TTS_LANG_PATH"
             Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $WINPE_SPEECH_TTS_LANG_PATH -ErrorAction stop | Out-Null
         }
@@ -320,39 +322,40 @@ Foreach ($IMAGE in $WINPE_IMAGES) {
     if ( (Test-Path -Path $WINPE_MOUNT"\sources\lang.ini") ) {
         Write-Host "$(Get-TS): Updating lang.ini"
         DISM /image:$WINPE_MOUNT /Gen-LangINI /distribution:$WINPE_MOUNT | Out-Null
-    }    
-    
+    }
+
     # Add latest cumulative update
     Write-Host "$(Get-TS): Adding package $LCU_PATH"
-    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $LCU_PATH -ErrorAction stop | Out-Null  
+    Add-WindowsPackage -Path $WINPE_MOUNT -PackagePath $LCU_PATH -ErrorAction stop | Out-Null
 
     # Perform image cleanup
     Write-Host "$(Get-TS): Performing image cleanup on WinPE"
     DISM /image:$WINPE_MOUNT /cleanup-image /StartComponentCleanup | Out-Null
 
     # Dismount
-    Dismount-WindowsImage -Path $WINPE_MOUNT -Save -ErrorAction stop | Out-Null 
+    Dismount-WindowsImage -Path $WINPE_MOUNT -Save -ErrorAction stop | Out-Null
 
     #Export WinPE
-    Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\boot2.wim”
-    Export-WindowsImage -SourceImagePath $MEDIA_NEW_PATH“\sources\boot.wim” -SourceIndex $IMAGE.ImageIndex -DestinationImagePath $WORKING_PATH"\boot2.wim" -ErrorAction stop | Out-Null
+    Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\boot2.wim"
+    Export-WindowsImage -SourceImagePath $MEDIA_NEW_PATH"\sources\boot.wim" -SourceIndex $IMAGE.ImageIndex -DestinationImagePath $WORKING_PATH"\boot2.wim" -ErrorAction stop | Out-Null
 
 }
 
-Move-Item -Path $WORKING_PATH"\boot2.wim" -Destination $MEDIA_NEW_PATH“\sources\boot.wim” -Force -ErrorAction stop | Out-Null
+Move-Item -Path $WORKING_PATH"\boot2.wim" -Destination $MEDIA_NEW_PATH"\sources\boot.wim" -Force -ErrorAction stop | Out-Null
 ```
+
 ### Update the main operating system
 
 For this next phase, there is no need to mount the main operating system, since it was already mounted in the previous scripts. This script starts by applying the servicing stack Dynamic Update. Then, it adds Japanese language support and then the Japanese language features. Unlike the Dynamic Update packages, it leverages `Add-WindowsCapability` to add these features. For a full list of such features, and their associated capability name, see [Available Features on Demand](https://docs.microsoft.com/windows-hardware/manufacture/desktop/features-on-demand-non-language-fod).
 
 Now is the time to enable other Optional Components or add other Features on Demand. If such a feature has an associated cumulative update (for example, .Net), this is the time to apply those. The script then proceeds with applying the latest cumulative update. Finally, the script cleans and exports the image.
- 
+
 You can install Optional Components, along with the .Net feature, offline, but that will require the device to be restarted. This is why the script installs .Net and Optional Components after cleanup and before export.
 
-```
-# 
+```PowerShell
+#
 # update Main OS
-# 
+#
 
 # Add servicing stack update
 Write-Host "$(Get-TS): Adding package $SSU_PATH"
@@ -360,7 +363,7 @@ Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $SSU_PATH -ErrorAction stop
 
 # Optional: Add language to main OS
 Write-Host "$(Get-TS): Adding package $OS_LP_PATH"
-Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $OS_LP_PATH -ErrorAction stop | Out-Null  
+Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $OS_LP_PATH -ErrorAction stop | Out-Null
 
 # Optional: Add a Features on Demand to the image
 Write-Host "$(Get-TS): Adding language FOD: Language.Fonts.Jpan~~~und-JPAN~0.0.1.0"
@@ -385,20 +388,20 @@ Add-WindowsCapability -Name "Language.Speech~~~$LANG~0.0.1.0" -Path $MAIN_OS_MOU
 
 # Add latest cumulative update
 Write-Host "$(Get-TS): Adding package $LCU_PATH"
-Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $LCU_PATH -ErrorAction stop | Out-Null 
+Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $LCU_PATH -ErrorAction stop | Out-Null
 
 # Copy our updated recovery image from earlier into the main OS
-# Note: If I were updating more than 1 edition, I'd want to copy the same recovery image file 
+# Note: If I were updating more than 1 edition, I'd want to copy the same recovery image file
 # into each edition to enable single instancing
-Copy-Item -Path $WORKING_PATH"\winre.wim” -Destination $MAIN_OS_MOUNT"\windows\system32\recovery\winre.wim” -Force -Recurse -ErrorAction stop | Out-Null
+Copy-Item -Path $WORKING_PATH"\winre.wim" -Destination $MAIN_OS_MOUNT"\windows\system32\recovery\winre.wim" -Force -Recurse -ErrorAction stop | Out-Null
 
 # Perform image cleanup
 Write-Host "$(Get-TS): Performing image cleanup on main OS"
 DISM /image:$MAIN_OS_MOUNT /cleanup-image /StartComponentCleanup | Out-Null
 
 #
-# Note: If I wanted to enable additional Optional Components, I'd add these here. 
-# In addition, we'll add .Net 3.5 here as well. Both .Net and Optional Components might require 
+# Note: If I wanted to enable additional Optional Components, I'd add these here.
+# In addition, we'll add .Net 3.5 here as well. Both .Net and Optional Components might require
 # the image to be booted, and thus if we tried to cleanup after installation, it would fail.
 #
 
@@ -413,16 +416,16 @@ Add-WindowsPackage -Path $MAIN_OS_MOUNT -PackagePath $DOTNET_CU_PATH -ErrorActio
 Dismount-WindowsImage -Path $MAIN_OS_MOUNT -Save -ErrorAction stop | Out-Null
 
 # Export
-Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\install2.wim”
-Export-WindowsImage -SourceImagePath $MEDIA_NEW_PATH“\sources\install.wim” -SourceIndex 1 -DestinationImagePath $WORKING_PATH"\install2.wim” -ErrorAction stop | Out-Null
-Move-Item -Path $WORKING_PATH"\install2.wim” -Destination $MEDIA_NEW_PATH“\sources\install.wim” -Force -ErrorAction stop | Out-Null
+Write-Host "$(Get-TS): Exporting image to $WORKING_PATH\install2.wim"
+Export-WindowsImage -SourceImagePath $MEDIA_NEW_PATH"\sources\install.wim" -SourceIndex 1 -DestinationImagePath $WORKING_PATH"\install2.wim" -ErrorAction stop | Out-Null
+Move-Item -Path $WORKING_PATH"\install2.wim" -Destination $MEDIA_NEW_PATH"\sources\install.wim" -Force -ErrorAction stop | Out-Null
 ```
 
 ### Update remaining media files
 
 This part of the script updates the Setup files. It simply copies the individual files in the Setup Dynamic Update package to the new media. This step brings an updated Setup.exe as needed, along with the latest compatibility database, and replacement component manifests.
 
-```
+```PowerShell
 #
 # update remaining files on media
 #
@@ -431,11 +434,12 @@ This part of the script updates the Setup files. It simply copies the individual
 Write-Host "$(Get-TS): Adding package $SETUP_DU_PATH"
 cmd.exe /c $env:SystemRoot\System32\expand.exe $SETUP_DU_PATH -F:* $MEDIA_NEW_PATH"\sources" | Out-Null
 ```
+
 ### Finish up
 
 As a last step, the script removes the working folder of temporary files, and unmounts our language pack and Features on Demand ISOs.
 
-```
+```PowerShell
 #
 # Perform final cleanup
 #
@@ -446,8 +450,7 @@ Remove-Item -Path $WORKING_PATH -Recurse -Force -ErrorAction stop | Out-Null
 # Dismount ISO images
 Write-Host "$(Get-TS): Dismounting ISO images"
 Dismount-DiskImage -ImagePath $LP_ISO_PATH -ErrorAction stop | Out-Null
-Dismount-DiskImage -ImagePath $FOD_ISO_PATH -ErrorAction stop | Out-Null 
+Dismount-DiskImage -ImagePath $FOD_ISO_PATH -ErrorAction stop | Out-Null
 
 Write-Host "$(Get-TS): Media refresh completed!"
 ```
-


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6241 (**Curly quotes in PowerShell script prevent it from working**), this page contains curly double quote marks in its PowerShell scripts and cmdlets. These incorrectly inserted characters within code snippets (or maybe they were incorrectly re-coded some time ago) prevent the code snippets from being read correctly by PowerShell. This PR aims to resolve this issue.

Thanks to @hsehestedt for reporting this issue.

**Changes proposed:**
- Replace incorrect curly quote marks with straight ones
- Add "PowerShell" as MarkDown syntax highlight identifiers
- Remove redundant end-of-line blanks throughout the document

**Ticket closure or reference:**

Closes #6241