### PR TITLE
Microsoft Security Compliance Toolkit 1.0 : versions missing in the Security Baselines lists

### DIFF
--- a/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
+++ b/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
@@ -27,6 +27,8 @@ The SCT enables administrators to effectively manage their enterprise’s Group 
 The Security Compliance Toolkit consists of:
 
 -   Windows 10 security baselines
+    -   Windows 10 Version 1909 (November 2019 Update)
+    -   Windows 10 Version 1903 (April 2019 Update)
     -   Windows 10 Version 1809 (October 2018 Update)
     -   Windows 10 Version 1803 (April 2018 Update)
     -   Windows 10 Version 1709 (Fall Creators Update)
@@ -41,7 +43,11 @@ The Security Compliance Toolkit consists of:
     -   Windows Server 2012 R2
 
 -   Microsoft Office security baseline
+    -   Office 365 Pro Plus    -   
     -   Office 2016 
+    
+-   Microsoft Edge security baseline
+    -   Edge Browser v80
 
 -   Tools
     -   Policy Analyzer tool

--- a/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
+++ b/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
@@ -47,7 +47,7 @@ The Security Compliance Toolkit consists of:
     -   Office 2016 
     
 -   Microsoft Edge security baseline
-    -   Edge Browser v80
+    -   Edge Browser Version 80
 
 -   Tools
     -   Policy Analyzer tool

--- a/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
+++ b/windows/security/threat-protection/windows-security-configuration-framework/security-compliance-toolkit-10.md
@@ -43,7 +43,7 @@ The Security Compliance Toolkit consists of:
     -   Windows Server 2012 R2
 
 -   Microsoft Office security baseline
-    -   Office 365 Pro Plus    -   
+    -   Office 365 Pro Plus
     -   Office 2016 
     
 -   Microsoft Edge security baseline


### PR DESCRIPTION
This is my own PR , i found this article is not updated with names of security baseline.
So i added the following names 
1. **Windows 10 Version 1909 (November 2019 Update)**
2. **Windows 10 Version 1903 (April 2019 Update)**
3. **Microsoft Edge**
4. **Office 365 Pro Plus**