### PR TITLE
Update configure-splunk.md, change endpoint URL

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/configure-splunk.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-splunk.md
@@ -78,7 +78,7 @@ You'll need to configure Splunk so that it can pull Microsoft Defender ATP detec
    <td>URL to authenticate the azure app (Default : https://login.microsoftonline.com)</td>
    </tr>
    <td>Endpoint</td>
-   <td>Depending on the location of your datacenter, select any of the following URL: </br></br> <strong>For EU</strong>:  <code>https://wdatp-alertexporter-eu.securitycenter.windows.com/api/alerts</code><br></br><strong>For US:</strong><code>https://wdatp-alertexporter-us.securitycenter.windows.com/api/alerts</code> <br><br> <strong>For UK:</strong><code>https://wdatp-alertexporter-uk.securitycenter.windows.com/api/alerts</code>
+   <td>Depending on the location of your datacenter, select any of the following URL: </br></br> <strong>For EU</strong>:  <code>https://wdatp-alertexporter-eu.securitycenter.windows.com</code><br></br><strong>For US:</strong><code>https://wdatp-alertexporter-us.securitycenter.windows.com</code> <br><br> <strong>For UK:</strong><code>https://wdatp-alertexporter-uk.securitycenter.windows.com</code>
    </tr>
    <tr>
    <td>Tenant ID</td>


### PR DESCRIPTION
See documentation of https://splunkbase.splunk.com/app/4128/ also, the URL's are wrong. It doesn't work with /api/alerts after the domain, Because the splunk app already adds it themself (and makes it https://wdatp-alertexporter-eu.securitycenter.windows.com/api/alerts/api/alerts...) :
input_module_windows_defender_atp_alerts.py:	uri = "%s/%s%s" % (endpoint,"/api/alerts?sinceTimeUtc=",max_date)