### PR TITLE
Duplicate entry in Group Policy table

### DIFF
--- a/windows/configuration/kiosk-policies.md
+++ b/windows/configuration/kiosk-policies.md
@@ -40,7 +40,6 @@ Remove access to the context menus for the task bar	| Enabled
 Clear history of recently opened documents on exit |	Enabled
 Prevent users from customizing their Start Screen |	Enabled
 Prevent users from uninstalling applications from Start |		Enabled
-Remove All Programs list from the Start menu |		Enabled
 Remove Run menu from Start Menu	 |	Enabled
 Disable showing balloon notifications as toast |		Enabled
 Do not allow pinning items in Jump Lists |		Enabled


### PR DESCRIPTION
Remove All Programs list from the Start menu is listed twice. Line 43 and Line 63. I propose removing line 43 as line 63 is more accurate. Simple "enabling" the setting isn't enough. You need to enable and choose an action: collapse/collapse and disable/remove and disable.