### PR TITLE
WDAC/policy design decisions: typo correction

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/understand-windows-defender-application-control-policy-design-decisions.md
+++ b/windows/security/threat-protection/windows-defender-application-control/understand-windows-defender-application-control-policy-design-decisions.md
@@ -35,7 +35,7 @@ You should consider using WDAC as part of your organization's application contro
 
 -   You have deployed or plan to deploy the supported versions of Windows in your organization.
 -   You need improved control over the access to your organization's applications and the data your users access.
--   Your organization has a well-defined process for application management and deployed.
+-   Your organization has a well-defined process for application management and deployment.
 -   You have resources to test policies against the organization's requirements.
 -   You have resources to involve Help Desk or to build a self-help process for end-user application access issues.
 -   The group's requirements for productivity, manageability, and security can be controlled by restrictive policies.


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6346 (**Typo**), one of the sentences in the bullet point list 
ends with a malformed word or phrase: "... application management and deployed."

Thanks to @TokenRing (Zach) for finding and reporting this grammatical typo.

**Proposed change:**
- Replace the word "deployed" with *deployment* to match the grammar.

**Ticket closure or reference:**

Closes #6346