### PR TITLE
MD-ATP: remove proxy, point to other guidance

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/onboard-downlevel.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/onboard-downlevel.md
@@ -28,23 +28,23 @@ ms.topic: article
 - [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
 
 
->Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-downlevel-abovefoldlink)
+>Want to experience Microsoft Defender ATP? [Sign up for a free trial](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-downlevel-abovefoldlink).
 
 Microsoft Defender ATP extends support to include down-level operating systems, providing advanced attack detection and investigation capabilities on supported Windows versions.
 
->[!IMPORTANT]
->This capability is currently in preview. You'll need to turn on the preview features to take advantage of this feature. For more information, see [Preview features](preview.md).
+> [!IMPORTANT]
+> This capability is currently in preview. You'll need to turn on the preview features to take advantage of this feature. For more information, see [Preview features](preview.md).
 
 To onboard down-level Windows client endpoints to Microsoft Defender ATP, you'll need to:
 - Configure and update System Center Endpoint Protection clients.
 - Install and configure Microsoft Monitoring Agent (MMA) to report sensor data to Microsoft Defender ATP as instructed below.
 
->[!TIP]
+> [!TIP]
 > After onboarding the machine, you can choose to run a detection test to verify that it is properly onboarded to the service. For more information, see [Run a detection test on a newly onboarded Microsoft Defender ATP endpoint](run-detection-test.md).
 
 ## Configure and update System Center Endpoint Protection clients
->[!IMPORTANT]
->This step is required only if your organization uses System Center Endpoint Protection (SCEP).
+> [!IMPORTANT]
+> This step is required only if your organization uses System Center Endpoint Protection (SCEP).
 
 Microsoft Defender ATP integrates with System Center Endpoint Protection to provide visibility to malware detections and to stop propagation of an attack in your organization by banning potentially malicious files or suspected malware. 
 
@@ -59,16 +59,16 @@ The following steps are required to enable this integration:
 Review the following details to verify minimum system requirements:
 - Install the [February 2018 monthly update rollup](https://support.microsoft.com/help/4074598/windows-7-update-kb4074598)
   
-  >[!NOTE]
-  >Only applicable for Windows 7 SP1 Enterprise and Windows 7 SP1 Pro. 
+  > [!NOTE]
+  > Only applicable for Windows 7 SP1 Enterprise and Windows 7 SP1 Pro. 
 
 - Install the [Update for customer experience and diagnostic telemetry](https://support.microsoft.com/help/3080149/update-for-customer-experience-and-diagnostic-telemetry)
 
 - Install either [.NET framework 4.5](https://www.microsoft.com/download/details.aspx?id=30653) (or later) or [KB3154518](https://support.microsoft.com/help/3154518/support-for-tls-system-default-versions-included-in-the-net-framework)
 
-    >[!NOTE]
-    >Only applicable for Windows 7 SP1 Enterprise and Windows 7 SP1 Pro.
-    >Don't install .NET framework 4.0.x, since it will negate the above installation.
+    > [!NOTE]
+    > Only applicable for Windows 7 SP1 Enterprise and Windows 7 SP1 Pro.
+    > Don't install .NET framework 4.0.x, since it will negate the above installation.
 
 - Meet the Azure Log Analytics agent minimum system requirements. For more information, see [Collect data from computers in you environment with Log Analytics](https://docs.microsoft.com/azure/log-analytics/log-analytics-concept-hybrid#prerequisites)
 
@@ -93,29 +93,10 @@ Once completed, you should see onboarded endpoints in the portal within an hour.
 ### Configure proxy and Internet connectivity settings
  
 - Each Windows endpoint must be able to connect to the Internet using HTTPS. This connection can be direct, using a proxy, or through the [OMS Gateway](https://docs.microsoft.com/azure/log-analytics/log-analytics-oms-gateway).
-- If a proxy or firewall is blocking all traffic by default and allowing only specific domains through or HTTPS scanning (SSL inspection) is enabled, make sure that the following URLs are white-listed to permit communication with Microsoft Defender ATP service:
-
-Agent Resource    |    Ports 
-:---|:---
-|    *.oms.opinsights.azure.com    |    443    |
-|    *.blob.core.windows.net    |    443    |
-|    *.azure-automation.net    |    443    |
-|    *.ods.opinsights.azure.com    |    443    |
-|    winatp-gw-cus.microsoft.com     |    443    |
-|    winatp-gw-eus.microsoft.com    |    443    |
-|    winatp-gw-neu.microsoft.com    |    443    |
-|    winatp-gw-weu.microsoft.com    |    443    |
-|winatp-gw-uks.microsoft.com | 443 |
-|winatp-gw-ukw.microsoft.com | 443 | 
-
+- If a proxy or firewall is blocking all traffic by default and allowing only specific domains through or HTTPS scanning (SSL inspection) is enabled, make sure that you [enable access to Microsoft Defender ATP service URLs](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/configure-proxy-internet#enable-access-to-microsoft-defender-atp-service-urls-in-the-proxy-server).
 
 ## Offboard client endpoints
 To offboard, you can uninstall the MMA agent from the endpoint or detach it from reporting to your Microsoft Defender ATP workspace. After offboarding the agent, the endpoint will no longer send sensor data to Microsoft Defender ATP. 
 
->Want to experience Microsoft Defender ATP? [Sign up for a free trial.](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-downlevele-belowfoldlink)
-
-
-
-
-
+> Want to experience Microsoft Defender ATP? [Sign up for a free trial](https://www.microsoft.com/microsoft-365/windows/microsoft-defender-atp?ocid=docs-wdatp-downlevele-belowfoldlink).
 


### PR DESCRIPTION
**Description:**

As requested by @mjcaparas in issue ticket #5569 (**Duplicate, incorrect Internet endpoints**), the outdated and incorrect table has been removed and replaced by a link pointing to the correct table.

Ticket #5568 was closed using the same solution, commit 4b71bf4b03d50b8d9a75b4a43de7e76a8b1af05f .

**Changes proposed:**
- Remove the table "Agent Resource/Ports"
- Update the preceding sentence and add a link
- Move 2 period dots to after the link text & URL
- Whitespace changes:
    - add MarkDown indent marker compatibility spacing
    - Remove redundant trailing blank lines (EOF)

**Ticket closure or reference:**

Closes #5569