### PR TITLE
Broken link

### DIFF
--- a/browsers/internet-explorer/ie11-deploy-guide/group-policy-problems-ie11.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/group-policy-problems-ie11.md
@@ -20,7 +20,7 @@ ms.date: 07/27/2017
 If you're having problems with Group Policy and Internet Explorer 11, or if you're looking for high-level information about the concepts and techniques used to troubleshoot Group Policy, as well as links to detailed reference topics, procedures, and troubleshooting scenario guides, see [Group Policy Analysis and Troubleshooting Overview](https://go.microsoft.com/fwlink/p/?LinkId=279872).
 
 ## Group Policy Object-related Log Files
-You can use the Event Viewer to review Group Policy-related messages in the **Windows Logs**, **System** file. All of the Group Policy-related events are shown with a source of **GroupPolicy**. For more information about the Event Viewer, see [What information appears in event logs? (Event Viewer)](https://go.microsoft.com/fwlink/p/?LinkId=294917).
+You can use the Event Viewer to review Group Policy-related messages in the **Windows Logs**, **System** file. All of the Group Policy-related events are shown with a source of **GroupPolicy**
 
  
 


### PR DESCRIPTION
Removing the sentence that has broken link - could not find a suitable replacement  - checked with CSS SME from IE (Louis Shanks) and confirmed that we can remove the sentence with broken link.