### PR TITLE
MD-ATP for Linux: typos & code block corrections

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/linux-install-manually.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/linux-install-manually.md
@@ -201,15 +201,19 @@ Download the onboarding package from Microsoft Defender Security Center:
 4. From a command prompt, verify that you have the file.
     Extract the contents of the archive:
 
-    ```bash
-    ls -l
-    total 8
-    -rw-r--r-- 1 test  staff  5752 Feb 18 11:22 WindowsDefenderATPOnboardingPackage.zip
+```bash
+ls -l
+```
 
-    unzip WindowsDefenderATPOnboardingPackage.zip
-    Archive:  WindowsDefenderATPOnboardingPackage.zip
-    inflating: WindowsDefenderATPOnboarding.py
-    ```
+`total 8`
+`-rw-r--r-- 1 test  staff  5752 Feb 18 11:22 WindowsDefenderATPOnboardingPackage.zip`
+
+```bash
+unzip WindowsDefenderATPOnboardingPackage.zip
+```
+
+`Archive:  WindowsDefenderATPOnboardingPackage.zip`
+`inflating: WindowsDefenderATPOnboarding.py`
 
 ## Client configuration
 
@@ -231,14 +235,12 @@ Download the onboarding package from Microsoft Defender Security Center:
 
     ```bash
     mdatp --health orgId
-    [your organization identifier]
     ```
 
 4. A few minutes after you complete the installation, you can see the status by running the following command. A return value of `1` denotes that the product is functioning as expected:
 
     ```bash
     mdatp --health healthy
-    1
     ```
 
     > [!IMPORTANT]
@@ -248,22 +250,21 @@ Download the onboarding package from Microsoft Defender Security Center:
 
     - Ensure that real-time protection is enabled (denoted by a result of `1` from running the following command):
 
-        ```bash
-        mdatp --health realTimeProtectionEnabled
-        1
-        ```
+    ```bash
+    mdatp --health realTimeProtectionEnabled
+    ```
 
     - Open a Terminal window. Copy and execute the following command:
 
-        ``` bash
-        curl -o ~/Downloads/eicar.com.txt https://www.eicar.org/download/eicar.com.txt
-        ```
+    ``` bash
+    curl -o ~/Downloads/eicar.com.txt https://www.eicar.org/download/eicar.com.txt
+    ```
 
     - The file should have been quarantined by Microsoft Defender ATP for Linux. Use the following command to list all the detected threats:
 
-        ```bash
-        mdatp --threat --list --pretty
-        ```
+    ```bash
+    mdatp --threat --list --pretty
+    ```
 
 ## Log installation issues
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6443 (**the copy paste fields on this doc are incorrect and can cause errors/confusion**), there are 3 lines incorrectly added into the copy-paste blocks in this deployment description.

There is also at least 1 copy-paste block in need of moving the console output away from the actual commands and out into their own boxes or monospace command line notation.

Thanks to @bled1982 for reporting this issue.

**Changes proposed:**
- Remove 1 line containing "[your organization identifier]"
- Remove 2 occurrences of an unwarranted "1" character line
- Split the 'ls -l' command from the console output
- Split the 'unzip' command from the console output
- Adjust code block indent for 3 double-indented blocks

**Ticket closure or reference:**

Closes #6443