### PR TITLE
Updated documentation to reflect that quotes are not supported when u…

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/customize-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/customize-attack-surface-reduction.md
@@ -74,7 +74,10 @@ See the [attack surface reduction](attack-surface-reduction.md) topic for detail
 
 3. Expand the tree to **Windows components > Windows Defender Antivirus > Windows Defender Exploit Guard > Attack surface reduction**.
 
-4. Double-click the **Exclude files and paths from Attack surface reduction Rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.  Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
+4. Double-click the **Exclude files and paths from Attack surface reduction Rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.
+
+> [!WARNING]
+> Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
 
 ### Use PowerShell to exclude files and folders
 

--- a/windows/security/threat-protection/microsoft-defender-atp/customize-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/customize-attack-surface-reduction.md
@@ -74,7 +74,7 @@ See the [attack surface reduction](attack-surface-reduction.md) topic for detail
 
 3. Expand the tree to **Windows components > Windows Defender Antivirus > Windows Defender Exploit Guard > Attack surface reduction**.
 
-4. Double-click the **Exclude files and paths from Attack surface reduction Rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.
+4. Double-click the **Exclude files and paths from Attack surface reduction Rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.  Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
 
 ### Use PowerShell to exclude files and folders
 


### PR DESCRIPTION
…sing GPO

Quotes are not supported for ASR exclusions, we need to make this clear to our customers, as it is very confusing to them when reading the ADMX template for the setting - because the ADMX template for this setting actually contains double quotes.  Went through this with a customer until we found that quotes are not supported:
https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/23141041