### PR TITLE
Quotes are not supported when using GPO

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
@@ -137,7 +137,7 @@ Value: c:\path|e:\path|c:\Whitelisted.exe
 ## PowerShell
 
 > [!WARNING]
->If you manage your computers and devices with Intune, Configuration Manager, or other enterprise-level management platform, the management software will overwrite any conflicting PowerShell settings on startup.
+> If you manage your computers and devices with Intune, Configuration Manager, or other enterprise-level management platform, the management software will overwrite any conflicting PowerShell settings on startup.
 
 1. Type **powershell** in the Start menu, right-click **Windows PowerShell** and click **Run as administrator**.
 

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
@@ -129,7 +129,10 @@ Value: c:\path|e:\path|c:\Whitelisted.exe
 
      ![Group policy setting showing a blank attack surface reduction rule ID and value of 1](../images/asr-rules-gp.png)
 
-5. To exclude files and folders from ASR rules, select the **Exclude files and paths from Attack surface reduction rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item. Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
+5. To exclude files and folders from ASR rules, select the **Exclude files and paths from Attack surface reduction rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.
+
+> [!WARNING]
+> Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
 
 ## PowerShell
 

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
@@ -136,7 +136,7 @@ Value: c:\path|e:\path|c:\Whitelisted.exe
 
 ## PowerShell
 
->[!WARNING]
+> [!WARNING]
 >If you manage your computers and devices with Intune, Configuration Manager, or other enterprise-level management platform, the management software will overwrite any conflicting PowerShell settings on startup.
 
 1. Type **powershell** in the Start menu, right-click **Windows PowerShell** and click **Run as administrator**.

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-attack-surface-reduction.md
@@ -129,7 +129,7 @@ Value: c:\path|e:\path|c:\Whitelisted.exe
 
      ![Group policy setting showing a blank attack surface reduction rule ID and value of 1](../images/asr-rules-gp.png)
 
-5. To exclude files and folders from ASR rules, select the **Exclude files and paths from Attack surface reduction rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item.
+5. To exclude files and folders from ASR rules, select the **Exclude files and paths from Attack surface reduction rules** setting and set the option to **Enabled**. Click **Show** and enter each file or folder in the **Value name** column. Enter **0** in the **Value** column for each item. Do not use quotes as they are not supported for either the **Value name** column or the **Value** column.
 
 ## PowerShell
 


### PR DESCRIPTION
Quotes are not supported for ASR exclusions, we need to make this clear to our customers, as it is very confusing to them when reading the ADMX template for the setting - because the ADMX template for this setting actually contains double quotes.