### PR TITLE
Applies to: Windows 10, Windows Server 2019

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/interactive-logon-dont-display-username-at-sign-in.md
+++ b/windows/security/threat-protection/security-policy-settings/interactive-logon-dont-display-username-at-sign-in.md
@@ -2,7 +2,7 @@
 title: Interactive logon Don't display username at sign-in (Windows 10)
 description: Describes the best practices, location, values, and security considerations for the Interactive logon Don't display username at sign-in security policy setting.
 ms.assetid: 98b24b03-95fe-4edc-8e97-cbdaa8e314fd
-ms.reviewer: 
+ms.reviewer:
 ms.author: dansimp
 ms.prod: w10
 ms.mktglfcycl: deploy
@@ -20,9 +20,9 @@ ms.date: 04/19/2017
 # Interactive logon: Don't display username at sign-in
 
 **Applies to**
--   Windows Server 2003, Windows Vista, Windows XP, Windows Server 2008, Windows 7, Windows 8.1, Windows Server 2008 R2, Windows Server 2012 R2, Windows Server 2012, Windows 8, Windows 10
+- Windows 10, Windows Server 2019
 
-Describes the best practices, location, values, and security considerations for the **Interactive logon: Don't display username at sign-in** security policy setting. 
+Describes the best practices, location, values, and security considerations for the **Interactive logon: Don't display username at sign-in** security policy setting.
 
 ## Reference
 
@@ -56,7 +56,7 @@ Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Sec
 | Domain controller effective default settings | Not defined|
 | Member server effective default settings | Not defined|
 | Effective GPO default settings on client computers | Not defined|
- 
+
 ## Policy management
 
 This section describes features and tools that are available to help you manage this policy.


### PR DESCRIPTION
**Description:**

As per issue ticket #6441 (**Supported windows versions are not valid**), this article incorrectly lists both deprecated and outdated OS versions, both for Server and Client computers. The article itself states that this policy was introduced in Windows 10, version 1703.

Thanks to @yogeshasalkar for reporting this issue.

**Changes proposed:**
- Change the "Applies to" section to only Windows 10 and Server 2019
- Remove redundant end-of-line whitespace from 3 lines.

**Ticket closure or reference:**

Closes #6441