### PR TITLE
Threat Protection/Auditing: event 4985 page link

### DIFF
--- a/windows/security/threat-protection/auditing/audit-other-privilege-use-events.md
+++ b/windows/security/threat-protection/auditing/audit-other-privilege-use-events.md
@@ -2,7 +2,7 @@
 title: Audit Other Privilege Use Events (Windows 10)
 description: This security policy setting is not used.
 ms.assetid: 5f7f5b25-42a6-499f-8aa2-01ac79a2a63c
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ms.author: dansimp
 ms.pagetype: security
@@ -17,8 +17,8 @@ ms.date: 04/19/2017
 # Audit Other Privilege Use Events
 
 **Applies to**
--   Windows 10
--   Windows Server 2016
+- Windows 10
+- Windows Server 2016
 
 
 This auditing subcategory should not have any events in it, but for some reason Success auditing will enable generation of event 4985(S): The state of a transaction has changed.
@@ -31,7 +31,7 @@ This auditing subcategory should not have any events in it, but for some reason 
 
 **Events List:**
 
--   [4985](event-4674.md)(S): The state of a transaction has changed.
+-   [4985](event-4985.md)(S): The state of a transaction has changed.
 
 
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6470 (**Incorrect link**), the current link named "4985(S): The state of a transaction has changed." links to Event 4674(S, F): "An operation was attempted on a privileged object."

This typo is a "no-brainer" and is likely the result of a copy-paste mistake or a mass conversion oversight, not a dedicated operation.

Thanks to @azupwn for pointing out this issue.

**Changes proposed:**
- Insert the correct event number 4985 in the link
- Reduce markdown bullet list spacing from 3 to 1 under "Applies to"
- Removal of 1 end-of-line whitespace in the metadata section

**Ticket closure or reference:**

Closes #6470