### PR TITLE
chore: Whitespace consistency & MD compatibility

### DIFF
--- a/browsers/edge/about-microsoft-edge.md
+++ b/browsers/edge/about-microsoft-edge.md
@@ -2,7 +2,7 @@
 title: Microsoft Edge system and language requirements
 description: Overview information about Microsoft Edge, the default browser for Windows 10. This topic includes links to other Microsoft Edge topics.
 ms.assetid: 70377735-b2f9-4b0b-9658-4cf7c1d745bb
-ms.reviewer: 
+ms.reviewer:
 audience: itpro
 manager: dansimp
 ms.author: dansimp
@@ -17,7 +17,7 @@ ms.date: 10/02/2018
 ---
 
 # Microsoft Edge system and language requirements
->Applies to:  Microsoft Edge on Windows 10 and Windows 10 Mobile
+> Applies to:  Microsoft Edge on Windows 10 and Windows 10 Mobile
 
 > [!NOTE]
 > You've reached the documentation for Microsoft Edge version 45 and earlier. To see the documentation for Microsoft Edge version 77 or later, go to the [Microsoft Edge documentation landing page](https://docs.microsoft.com/DeployEdge/).
@@ -25,8 +25,8 @@ ms.date: 10/02/2018
 Microsoft Edge is the new, default web browser for Windows 10, helping you to experience modern web standards, better performance, improved security, and increased reliability. Microsoft Edge lets you stay up-to-date through the Microsoft Store and to manage your enterprise through Group Policy or your mobile device management (MDM) tools.
 
 
->[!IMPORTANT]
->The Long-Term Servicing Branch (LTSB) versions of Windows, including Windows Server 2016, don’t include Microsoft Edge or many other Universal Windows Platform (UWP) apps. Systems running the LTSB operating systems do not support these apps because their services get frequently updated with new functionality. For customers who require the LTSB for specialized devices, we recommend using Internet Explorer 11.
+> [!IMPORTANT]
+> The Long-Term Servicing Branch (LTSB) versions of Windows, including Windows Server 2016, don’t include Microsoft Edge or many other Universal Windows Platform (UWP) apps. Systems running the LTSB operating systems do not support these apps because their services get frequently updated with new functionality. For customers who require the LTSB for specialized devices, we recommend using Internet Explorer 11.
 
 
 ## Minimum system requirements
@@ -49,7 +49,7 @@ Some of the components might also need additional system resources. Check the co
 
 ## Supported languages
 
-Microsoft Edge supports all of the same languages as Windows 10 and you can use the [Microsoft Translator extension](https://www.microsoft.com/p/translator-for-microsoft-edge/9nblggh4n4n3) to translate foreign language web pages and text selections for 60+ languages. 
+Microsoft Edge supports all of the same languages as Windows 10 and you can use the [Microsoft Translator extension](https://www.microsoft.com/p/translator-for-microsoft-edge/9nblggh4n4n3) to translate foreign language web pages and text selections for 60+ languages.
 
 If the extension does not work after install, restart Microsoft Edge. If the extension still does not work, provide feedback through the Feedback Hub.
 

--- a/browsers/edge/group-policies/favorites-management-gp.md
+++ b/browsers/edge/group-policies/favorites-management-gp.md
@@ -1,43 +1,43 @@
 ---
 title: Microsoft Edge - Favorites group policies
 description: Configure Microsoft Edge to either show or hide the favorites bar on all pages. Microsoft Edge hides the favorites bar by default but shows the favorites bar on the Start and New tab pages. Also, by default, the favorites bar toggle, in Settings, is set to Off but enabled allowing users to make changes.
-services: 
-keywords: 
+services:
+keywords:
 ms.localizationpriority: medium
 audience: itpro
 manager: dansimp
 author: dansimp
 ms.author: dansimp
 ms.date: 10/02/2018
-ms.reviewer: 
+ms.reviewer:
 ms.topic: reference
 ms.prod: edge
 ms.mktglfcycl: explore
 ms.sitesec: library
 ---
 
-# Favorites 
+# Favorites
 
 > [!NOTE]
 > You've reached the documentation for Microsoft Edge version 45 and earlier. To see the documentation for Microsoft Edge version 77 or later, go to the [Microsoft Edge documentation landing page](https://docs.microsoft.com/DeployEdge/).
 
-You can customize the favorites bar, for example, you can turn off features such as Save a Favorite and Import settings, and hide or show the favorites bar on all pages.  Another customization you can make is provisioning a standard list of favorites, including folders, to appear in addition to the user’s favorites. If it’s important to keep the favorites in both IE11 and Microsoft Edge synced, you can turn on syncing where changes to the list of favorites in one browser reflect in the other. 
+You can customize the favorites bar, for example, you can turn off features such as Save a Favorite and Import settings, and hide or show the favorites bar on all pages.  Another customization you can make is provisioning a standard list of favorites, including folders, to appear in addition to the user’s favorites. If it’s important to keep the favorites in both IE11 and Microsoft Edge synced, you can turn on syncing where changes to the list of favorites in one browser reflect in the other.
 
->[!TIP]
->You can find the Favorites under C:\\Users\\<_username_>\\Favorites.
+> [!TIP]
+> You can find the Favorites under C:\\Users\\<_username_>\\Favorites.
 
 You can find the Microsoft Edge Group Policy settings in the following location of the Group Policy Editor unless otherwise noted in the policy:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Edge\\**
 
-## Configure Favorites Bar 
+## Configure Favorites Bar
 [!INCLUDE [configure-favorites-bar-include](../includes/configure-favorites-bar-include.md)]
 
-## Keep favorites in sync between Internet Explorer and Microsoft Edge 
-[!INCLUDE [keep-fav-sync-ie-edge-include](../includes/keep-fav-sync-ie-edge-include.md)] 
+## Keep favorites in sync between Internet Explorer and Microsoft Edge
+[!INCLUDE [keep-fav-sync-ie-edge-include](../includes/keep-fav-sync-ie-edge-include.md)]
 
 ## Prevent changes to Favorites on Microsoft Edge
-[!INCLUDE [prevent-changes-to-favorites-include](../includes/prevent-changes-to-favorites-include.md)] 
+[!INCLUDE [prevent-changes-to-favorites-include](../includes/prevent-changes-to-favorites-include.md)]
 
-## Provision Favorites 
+## Provision Favorites
 [!INCLUDE [provision-favorites-include](../includes/provision-favorites-include.md)]

--- a/browsers/edge/group-policies/interoperability-enterprise-guidance-gp.md
+++ b/browsers/edge/group-policies/interoperability-enterprise-guidance-gp.md
@@ -7,7 +7,7 @@ manager: dansimp
 ms.author: dansimp
 author: dansimp
 ms.date: 10/02/2018
-ms.reviewer: 
+ms.reviewer:
 ms.prod: edge
 ms.mktglfcycl: explore
 ms.sitesec: library
@@ -21,11 +21,10 @@ ms.topic: reference
 
 Microsoft Edge is the default browser experience for Windows 10 and Windows 10 Mobile. However, Microsoft Edge lets you continue to use IE11 for sites that are on your corporate intranet or included on your Enterprise Mode Site List. If you are running web apps that continue to use ActiveX controls, x-ua-compatible headers, or legacy document modes, you need to keep running them in IE11. IE11 offers additional security, manageability, performance, backward compatibility, and modern standards support.
 
->[!TIP] 
->If you are running an earlier version of Internet Explorer, we recommend upgrading to IE11, so that any legacy apps continue to work correctly.
+> [!TIP]
+> If you are running an earlier version of Internet Explorer, we recommend upgrading to IE11, so that any legacy apps continue to work correctly.
 
-**Technology not supported by Microsoft Edge**  
-
+**Technology not supported by Microsoft Edge**
 
 - ActiveX controls
 
@@ -39,20 +38,19 @@ Microsoft Edge is the default browser experience for Windows 10 and Windows 10 M
 
 - Legacy document modes
 
-If you have specific websites and apps that you know have compatibility problems with Microsoft Edge, you can use the Enterprise Mode site list so that the websites automatically open using Internet Explorer 11. Additionally, if you know that your intranet sites aren't going to work correctly with Microsoft Edge, you can set all intranet sites to open using IE11 automatically. 
+If you have specific websites and apps that you know have compatibility problems with Microsoft Edge, you can use the Enterprise Mode site list so that the websites automatically open using Internet Explorer 11. Additionally, if you know that your intranet sites aren't going to work correctly with Microsoft Edge, you can set all intranet sites to open using IE11 automatically.
 
 Using Enterprise Mode means that you can continue to use Microsoft Edge as your default browser, while also ensuring that your apps continue working on IE11.
 
 ## Relevant group policies
 
+1. [Configure the Enterprise Mode Site List](#configure-the-enterprise-mode-site-list)
 
-1.  [Configure the Enterprise Mode Site List](#configure-the-enterprise-mode-site-list)
+2. [Send all intranet sites to Internet Explorer 11](#send-all-intranet-sites-to-internet-explorer-11)
 
-2.  [Send all intranet sites to Internet Explorer 11](#send-all-intranet-sites-to-internet-explorer-11)
+3. [Show message when opening sites in Internet Explorer](#show-message-when-opening-sites-in-internet-explorer)
 
-3.  [Show message when opening sites in Internet Explorer](#show-message-when-opening-sites-in-internet-explorer)
-
-4.  [(IE11 policy) Send all sites not included in the Enterprise Mode Site List to Microsoft Edge](#ie11-policy-send-all-sites-not-included-in-the-enterprise-mode-site-list-to-microsoft-edge)
+4. [(IE11 policy) Send all sites not included in the Enterprise Mode Site List to Microsoft Edge](#ie11-policy-send-all-sites-not-included-in-the-enterprise-mode-site-list-to-microsoft-edge)
 
 You can find the Microsoft Edge Group Policy settings in the following location of the Group Policy Editor unless otherwise noted in the policy:
 

--- a/browsers/edge/includes/configure-home-button-include.md
+++ b/browsers/edge/includes/configure-home-button-include.md
@@ -3,7 +3,8 @@ author: eavena
 ms.author: eravena
 ms.date:  10/28/2018
 ms.reviewer:
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---

--- a/browsers/edge/includes/configure-home-button-include.md
+++ b/browsers/edge/includes/configure-home-button-include.md
@@ -2,15 +2,15 @@
 author: eavena
 ms.author: eravena
 ms.date:  10/28/2018
-ms.reviewer: 
+ms.reviewer:
 audience: itpromanager: dansimp
 ms.prod: edge
 ms.topic: include
 ---
 
-<!-- ## Configure Home Button-->  
->*Supported versions: Microsoft Edge on Windows 10, version 1809*<br>
->*Default setting: Disabled or not configured (Show home button and load the Start page)*
+<!-- ## Configure Home Button-->
+> *Supported versions: Microsoft Edge on Windows 10, version 1809*<br>
+> *Default setting: Disabled or not configured (Show home button and load the Start page)*
 
 
 [!INCLUDE [configure-home-button-shortdesc](../shortdesc/configure-home-button-shortdesc.md)]
@@ -28,9 +28,8 @@ ms.topic: include
 ---
 
 
->[!TIP]
->If you want to make changes to this policy:<ol><li>Enable the **Unlock Home Button** policy.</li><li>Make changes to the **Configure Home Button** policy or **Set Home Button URL** policy.</li><li>Disable the **Unlock Home Button** policy.</li></ol>
-
+> [!TIP]
+> If you want to make changes to this policy:<ol><li>Enable the **Unlock Home Button** policy.</li><li>Make changes to the **Configure Home Button** policy or **Set Home Button URL** policy.</li><li>Disable the **Unlock Home Button** policy.</li></ol>
 
 ### ADMX info and settings
 #### ADMX info
@@ -43,19 +42,17 @@ ms.topic: include
 #### MDM settings
 - **MDM name:** Browser/[ConfigureHomeButton](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-configurehomebutton)
 - **Supported devices:** Desktop and Mobile
-- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/ConfigureHomeButton 
+- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/ConfigureHomeButton
 - **Data type:** Integer
 
 #### Registry settings
-- **Path:** HKLM\Software\Policies\Microsoft\MicrosoftEdge\Internet Settings 
+- **Path:** HKLM\Software\Policies\Microsoft\MicrosoftEdge\Internet Settings
 - **Value name:** ConfigureHomeButton
 - **Value type:** REG_DWORD
 
 ### Related policies
 
 - [Set Home Button URL](../available-policies.md#set-home-button-url): [!INCLUDE [set-home-button-url-shortdesc](../shortdesc/set-home-button-url-shortdesc.md)]
-
-- [Unlock Home Button](../available-policies.md#unlock-home-button): [!INCLUDE [unlock-home-button-shortdesc](../shortdesc/unlock-home-button-shortdesc.md)] 
-
+- [Unlock Home Button](../available-policies.md#unlock-home-button): [!INCLUDE [unlock-home-button-shortdesc](../shortdesc/unlock-home-button-shortdesc.md)]
 
 <hr>

--- a/browsers/edge/includes/configure-open-edge-with-include.md
+++ b/browsers/edge/includes/configure-open-edge-with-include.md
@@ -3,7 +3,8 @@ author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
 ms.reviewer:
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---

--- a/browsers/edge/includes/configure-open-edge-with-include.md
+++ b/browsers/edge/includes/configure-open-edge-with-include.md
@@ -2,7 +2,7 @@
 author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
-ms.reviewer: 
+ms.reviewer:
 audience: itpromanager: dansimp
 ms.prod: edge
 ms.topic: include
@@ -10,8 +10,8 @@ ms.topic: include
 
 <!-- Configure Open Microsoft Edge With-->
 
->*Supported versions: Microsoft Edge on Windows 10, version 1809*<br>
->*Default setting:  Enabled (A specific page or pages)*
+> *Supported versions: Microsoft Edge on Windows 10, version 1809*<br>
+> *Default setting:  Enabled (A specific page or pages)*
 
 [!INCLUDE [configure-open-microsoft-edge-with-shortdesc](../shortdesc/configure-open-microsoft-edge-with-shortdesc.md)]
 
@@ -31,10 +31,8 @@ ms.topic: include
 
 ---
 
-
->[!TIP]
->If you want to make changes to this policy:<ol><li>Set the **Disabled Lockdown of Start Pages** policy to not configured.</li><li>Make changes to the **Configure Open Microsoft With** policy.</li><li>Enable the **Disabled Lockdown of Start Pages** policy.</li></ol>
-
+> [!TIP]
+> If you want to make changes to this policy:<ol><li>Set the **Disabled Lockdown of Start Pages** policy to not configured.</li><li>Make changes to the **Configure Open Microsoft With** policy.</li><li>Enable the **Disabled Lockdown of Start Pages** policy.</li></ol>
 
 
 ### ADMX info and settings
@@ -58,11 +56,7 @@ ms.topic: include
 ### Related policies
 
 - [Configure Start pages](../available-policies.md#configure-start-pages): [!INCLUDE [configure-start-pages-shortdesc](../shortdesc/configure-start-pages-shortdesc.md)]
-
 - [Disable lockdown of Start pages](../available-policies.md#disable-lockdown-of-start-pages): [!INCLUDE [disable-lockdown-of-start-pages-shortdesc](../shortdesc/disable-lockdown-of-start-pages-shortdesc.md)]
-
-
-
 
 
 ---

--- a/browsers/edge/includes/provision-favorites-include.md
+++ b/browsers/edge/includes/provision-favorites-include.md
@@ -3,7 +3,8 @@ author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
 ms.reviewer:
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---

--- a/browsers/edge/includes/provision-favorites-include.md
+++ b/browsers/edge/includes/provision-favorites-include.md
@@ -2,21 +2,21 @@
 author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
-ms.reviewer: 
+ms.reviewer:
 audience: itpromanager: dansimp
 ms.prod: edge
 ms.topic: include
 ---
 
 <!-- ## Provision Favorites -->
->*Supported versions: Microsoft Edge on Windows 10, version 1511 or later*<br>
->*Default setting:  Disabled or not configured (Customizable)*
+> *Supported versions: Microsoft Edge on Windows 10, version 1511 or later*<br>
+> *Default setting:  Disabled or not configured (Customizable)*
 
 [!INCLUDE [provision-favorites-shortdesc](../shortdesc/provision-favorites-shortdesc.md)]
 
 
->[!IMPORTANT]
->Enable only this policy or the Keep favorites in sync between Internet Explorer and Microsoft Edge policy. If you enable both, Microsoft Edge prevents users from syncing their favorites between the two browsers.
+> [!IMPORTANT]
+> Enable only this policy or the Keep favorites in sync between Internet Explorer and Microsoft Edge policy. If you enable both, Microsoft Edge prevents users from syncing their favorites between the two browsers.
 
 ### Supported values
 
@@ -38,7 +38,7 @@ ms.topic: include
 #### MDM settings
 - **MDM name:** Browser/[ProvisionFavorites](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-provisionfavorites)
 - **Supported devices:** Desktop
-- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/ProvisionFavorites 
+- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/ProvisionFavorites
 - **Data type:** String
 
 #### Registry settings

--- a/browsers/edge/includes/send-all-intranet-sites-ie-include.md
+++ b/browsers/edge/includes/send-all-intranet-sites-ie-include.md
@@ -2,20 +2,20 @@
 author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
-ms.reviewer: 
+ms.reviewer:
 audience: itpromanager: dansimp
 ms.prod: edge
 ms.topic: include
 ---
 
 <!-- ## Send all intranet sites to Internet Explorer 11 -->
->*Supported versions: Microsoft Edge on Windows 10*<br>
->*Default setting:  Disabled or not configured*
+> *Supported versions: Microsoft Edge on Windows 10*<br>
+> *Default setting:  Disabled or not configured*
 
-[!INCLUDE [send-all-intranet-sites-to-ie-shortdesc](../shortdesc/send-all-intranet-sites-to-ie-shortdesc.md)] 
+[!INCLUDE [send-all-intranet-sites-to-ie-shortdesc](../shortdesc/send-all-intranet-sites-to-ie-shortdesc.md)]
 
->[!TIP]
->Microsoft Edge does not support ActiveX controls, Browser Helper Objects, VBScript, or other legacy technology. If you have websites or web apps that still use this technology and needs IE11 to run, you can add them to the Enterprise Mode site list, using Enterprise Mode Site List Manager. 
+> [!TIP]
+> Microsoft Edge does not support ActiveX controls, Browser Helper Objects, VBScript, or other legacy technology. If you have websites or web apps that still use this technology and needs IE11 to run, you can add them to the Enterprise Mode site list, using Enterprise Mode Site List Manager.
 
 
 ### Supported values
@@ -30,7 +30,7 @@ ms.topic: include
 
 ### ADMX info and settings
 #### ADMX info
-- **GP English name:** Send all intranet sites to Internet Explorer 11 
+- **GP English name:** Send all intranet sites to Internet Explorer 11
 - **GP name:** SendIntranetTraffictoInternetExplorer
 - **GP path:** Windows Components/Microsoft Edge
 - **GP ADMX file name:** MicrosoftEdge.admx
@@ -38,7 +38,7 @@ ms.topic: include
 #### MDM settings
 - **MDM name:** Browser/[SendIntranetTraffictoInternetExplorer](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-sendintranettraffictointernetexplorer)
 - **Supported devices:** Desktop
-- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/SendIntranetTraffictoInternetExplorer 
+- **URI full path:** ./Vendor/MSFT/Policy/Config/Browser/SendIntranetTraffictoInternetExplorer
 - **Data type:** Integer
 
 #### Registry settings
@@ -53,7 +53,7 @@ ms.topic: include
 
 
 ### Related topics
-- [Blog: How Microsoft Edge and Internet Explorer 11 on Windows 10 work better together in the Enterprise](https://go.microsoft.com/fwlink/p/?LinkID=624035). Many customers depend on legacy features only available in older versions of Internet Explorer and are familiar with our Enterprise Mode tools for IE11. The Enterprise Mode has been extended to support to Microsoft Edge by opening any site specified on the Enterprise Mode Site List in IE11. IT Pros can use their existing IE11 Enterprise Mode Site List, or they can create a new one specifically for Microsoft Edge. By keeping Microsoft Edge as the default browser in Windows 10 and only opening legacy line of business sites in IE11 when necessary, you can help keep newer development projects on track, using the latest web standards on Microsoft Edge. 
+- [Blog: How Microsoft Edge and Internet Explorer 11 on Windows 10 work better together in the Enterprise](https://go.microsoft.com/fwlink/p/?LinkID=624035). Many customers depend on legacy features only available in older versions of Internet Explorer and are familiar with our Enterprise Mode tools for IE11. The Enterprise Mode has been extended to support to Microsoft Edge by opening any site specified on the Enterprise Mode Site List in IE11. IT Pros can use their existing IE11 Enterprise Mode Site List, or they can create a new one specifically for Microsoft Edge. By keeping Microsoft Edge as the default browser in Windows 10 and only opening legacy line of business sites in IE11 when necessary, you can help keep newer development projects on track, using the latest web standards on Microsoft Edge.
 
 - [Enterprise Mode for Internet Explorer 11 (IE11)](https://go.microsoft.com/fwlink/p/?linkid=618377).  Learn how to set up and use Enterprise Mode and the Enterprise Mode Site List Manager in your company.
 

--- a/browsers/edge/includes/send-all-intranet-sites-ie-include.md
+++ b/browsers/edge/includes/send-all-intranet-sites-ie-include.md
@@ -3,7 +3,8 @@ author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
 ms.reviewer:
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---

--- a/browsers/edge/microsoft-edge-kiosk-mode-deploy.md
+++ b/browsers/edge/microsoft-edge-kiosk-mode-deploy.md
@@ -1,8 +1,8 @@
 ---
 title: Deploy Microsoft Edge Legacy kiosk mode
 description: Microsoft Edge Legacy kiosk mode works with assigned access to allow IT admins to create a tailored browsing experience designed for kiosk devices. To use Microsoft Edge Legacy kiosk mode, you must configure Microsoft Edge Legacy as an application in assigned access.
-ms.assetid: 
-ms.reviewer: 
+ms.assetid:
+ms.reviewer:
 audience: itpro
 manager: dansimp
 author: dansimp
@@ -16,28 +16,28 @@ ms.date: 01/17/2020
 
 # Deploy Microsoft Edge Legacy kiosk mode
 
->Applies to: Microsoft Edge Legacy (version 45 and earlier) on Windows 10, version 1809 or later 
->Professional, Enterprise, and Education
+> Applies to: Microsoft Edge Legacy (version 45 and earlier) on Windows 10, version 1809 or later
+> Professional, Enterprise, and Education
 
 > [!NOTE]
 > You've reached the documentation for Microsoft Edge Legacy (version 45 and earlier.) To see the documentation for Microsoft Edge version 77 or later, go to the [Microsoft Edge documentation landing page](https://docs.microsoft.com/DeployEdge/). For information about kiosk mode in the new version of Microsoft Edge, see [Microsoft Edge kiosk mode](https://docs.microsoft.com/DeployEdge/microsoft-edge-kiosk-mode).
 
 In the Windows 10 October 2018 Update, we added the capability to use Microsoft Edge Legacy as a kiosk using assigned access. With assigned access, you create a tailored browsing experience locking down a Windows 10 device to only run as a single-app or multi-app kiosk.  Assigned access restricts a local standard user account so that it only has access to one or more Windows app, such as Microsoft Edge Legacy in kiosk mode.
 
-In this topic, you'll learn: 
+In this topic, you'll learn:
 
 - How to configure the behavior of Microsoft Edge Legacy when it's running in kiosk mode with assigned access.
-- What's required to run Microsoft Edge Legacy kiosk mode on your kiosk devices.  
-- You'll also learn how to set up your kiosk device using either Windows Setting or Microsoft Intune or an other MDM service. 
+- What's required to run Microsoft Edge Legacy kiosk mode on your kiosk devices.
+- You'll also learn how to set up your kiosk device using either Windows Setting or Microsoft Intune or an other MDM service.
 
-At the end of this topic, you can find a list of [supported policies](#supported-policies-for-kiosk-mode) for kiosk mode and a [feature comparison](#feature-comparison-of-kiosk-mode-and-kiosk-browser-app) of the kiosk mode policy and kiosk browser app.  You also find instructions on how to provide us feedback or get support. 
+At the end of this topic, you can find a list of [supported policies](#supported-policies-for-kiosk-mode) for kiosk mode and a [feature comparison](#feature-comparison-of-kiosk-mode-and-kiosk-browser-app) of the kiosk mode policy and kiosk browser app.  You also find instructions on how to provide us feedback or get support.
 
 
 ## Kiosk mode configuration types
 
->**Policy** = Configure kiosk mode (ConfigureKioskMode)
+> **Policy** = Configure kiosk mode (ConfigureKioskMode)
 
-Microsoft Edge Legacy kiosk mode supports four configurations types that depend on how Microsoft Edge Legacy is set up with assigned access, either as a single-app or multi-app kiosk. These configuration types help you determine what is best suited for your kiosk device or scenario.  
+Microsoft Edge Legacy kiosk mode supports four configurations types that depend on how Microsoft Edge Legacy is set up with assigned access, either as a single-app or multi-app kiosk. These configuration types help you determine what is best suited for your kiosk device or scenario.
 
 - Learn about [creating a kiosk experience](https://docs.microsoft.com/windows-hardware/customize/enterprise/create-a-kiosk-image)
 
@@ -50,9 +50,9 @@ Microsoft Edge Legacy kiosk mode supports four configurations types that depend 
 
 ### Important things to note before getting started
 
-- There are [required steps to follow](#setup- required-for-microsoft-edge-legacy-kiosk-mode) in order to use the following Microsoft Edge Legacy kiosk mode types either alongside the new version of Microsoft Edge or prevent the new version of Microsoft Edge from being installed on your kiosk device. 
+- There are [required steps to follow](#setup- required-for-microsoft-edge-legacy-kiosk-mode) in order to use the following Microsoft Edge Legacy kiosk mode types either alongside the new version of Microsoft Edge or prevent the new version of Microsoft Edge from being installed on your kiosk device.
 
--  The public browsing kiosk types run Microsoft Edge Legacy InPrivate mode to protect user data with a browsing experience designed for public kiosks. 
+-  The public browsing kiosk types run Microsoft Edge Legacy InPrivate mode to protect user data with a browsing experience designed for public kiosks.
 
 -  Microsoft Edge Legacy kiosk mode has a built-in timer to help keep data safe in public browsing sessions. When the idle time (no user activity) meets the time limit, a confirmation message prompts the user to continue, and if no user activity Microsoft Edge Legacy resets the session to the default URL. By default, the idle timer is 5 minutes, but you can choose a value of your own.
 
@@ -67,7 +67,7 @@ Microsoft Edge Legacy kiosk mode supports four configurations types that depend 
    - [Guidelines for choosing an app for assigned access (kiosk mode)](https://aka.ms/Ul7dw3).
 
 
-### Supported configuration types 
+### Supported configuration types
 
 [!INCLUDE [configure-kiosk-mode-supported-values-include](includes/configure-kiosk-mode-supported-values-include.md)]
 
@@ -75,9 +75,9 @@ Microsoft Edge Legacy kiosk mode supports four configurations types that depend 
 
 Now that you're familiar with the different kiosk mode configurations and have the one you want to use in mind, you can use one of the following methods to set up Microsoft Edge Legacy kiosk mode:
 
--   **Windows Settings.** Use only to set up a couple of single-app devices because you perform these steps physically on each device.  For a multi-app kiosk device, use Microsoft Intune or other MDM service. 
+-   **Windows Settings.** Use only to set up a couple of single-app devices because you perform these steps physically on each device.  For a multi-app kiosk device, use Microsoft Intune or other MDM service.
 
--   **Microsoft Intune or other MDM service.** Use to set up several single-app or multi-app kiosk devices. Microsoft Intune and other MDM service providers offer more options for customizing the Microsoft Edge Legacy kiosk mode experience using any of the [Supported policies for kiosk mode](#supported-policies-for-kiosk-mode).  
+-   **Microsoft Intune or other MDM service.** Use to set up several single-app or multi-app kiosk devices. Microsoft Intune and other MDM service providers offer more options for customizing the Microsoft Edge Legacy kiosk mode experience using any of the [Supported policies for kiosk mode](#supported-policies-for-kiosk-mode).
 
 
 ### Prerequisites
@@ -89,14 +89,14 @@ Now that you're familiar with the different kiosk mode configurations and have t
 - URL to load when the kiosk launches. The URL that you provide sets the Home button, Start page, and New Tab page.
 
 - _**For Microsoft Intune or other MDM service**_, you must have the AppUserModelID (AUMID) to set up Microsoft Edge Legacy:
- 
+
   ```
   Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge
   ```
 
 ### Setup required for Microsoft Edge Legacy kiosk mode
 
-When the new version of Microsoft Edge Stable channel is installed, Microsoft Edge Legacy is hidden and all attempts to launch Microsoft Edge Legacy are redirected to the new version of Microsoft Edge. 
+When the new version of Microsoft Edge Stable channel is installed, Microsoft Edge Legacy is hidden and all attempts to launch Microsoft Edge Legacy are redirected to the new version of Microsoft Edge.
 
 To continue using Microsoft Edge Legacy kiosk mode on your kiosk devices take one of the following actions:
 
@@ -104,11 +104,11 @@ To continue using Microsoft Edge Legacy kiosk mode on your kiosk devices take on
 - To prevent Microsoft Edge Stable channel from being installed on your kiosk devices deploy the Microsoft Edge [Allow installation default](https://docs.microsoft.com/DeployEdge/microsoft-edge-update-policies#installdefault) policy for Stable channel or consider using the [Blocker toolkit](https://docs.microsoft.com/DeployEdge/microsoft-edge-blocker-toolkit) to disable automatic delivery of Microsoft Edge.
 
 > [!NOTE]
-> For more information about accessing Microsoft Edge Legacy after installing Microsoft Edge, see [How to access the old version of Microsoft Edge](https://docs.microsoft.com/DeployEdge/microsoft-edge-sysupdate-access-old-edge).  
+> For more information about accessing Microsoft Edge Legacy after installing Microsoft Edge, see [How to access the old version of Microsoft Edge](https://docs.microsoft.com/DeployEdge/microsoft-edge-sysupdate-access-old-edge).
 
 ### Use Windows Settings
 
-Windows Settings is the simplest and the only way to set up one or a couple of single-app devices.  
+Windows Settings is the simplest and the only way to set up one or a couple of single-app devices.
 
 1.  On the kiosk device, open Windows Settings, and in the search field type **kiosk** and then select **Set up a kiosk (assigned access)**.
 
@@ -120,9 +120,9 @@ Windows Settings is the simplest and the only way to set up one or a couple of s
 
 5.  Select how Microsoft Edge Legacy displays when running in kiosk mode:
 
-    -   **As a digital sign or interactive display** - Displays a specific site in full-screen mode, running Microsoft Edge Legacy InPrivate protecting user data.   
+    -   **As a digital sign or interactive display** - Displays a specific site in full-screen mode, running Microsoft Edge Legacy InPrivate protecting user data.
 
-    -   **As a public browser** - Runs a limited multi-tab version of Microsoft Edge Legacy, protecting user data.   
+    -   **As a public browser** - Runs a limited multi-tab version of Microsoft Edge Legacy, protecting user data.
 
 6.  Select **Next**.
 
@@ -136,23 +136,23 @@ Windows Settings is the simplest and the only way to set up one or a couple of s
 
 11. Restart the kiosk device and sign in with the local kiosk account to validate the configuration.
 
-**_Congratulations!_** <p>You’ve just finished setting up a single-app kiosk device using Windows Settings. 
+**_Congratulations!_** <p>You’ve just finished setting up a single-app kiosk device using Windows Settings.
 
-**_What's next?_** 
+**_What's next?_**
 
 - User your new kiosk device. <p>
    OR<p>
 - Make changes to your kiosk device. In Windows Settings, on the **Set up a kiosk** page, make your changes to **Choose a kiosk mode** and **Set up Microsoft Edge Legacy**.
 
----  
+---
 
 
 ### Use Microsoft Intune or other MDM service
 
 With this method, you can use Microsoft Intune or other MDM services to configure Microsoft Edge Legacy kiosk mode in assigned access and how it behaves on a kiosk device. To learn about a few app fundamentals and requirements before adding them to Intune, see [Add apps to Microsoft Intune](https://docs.microsoft.com/intune/apps-add).
 
->[!IMPORTANT]
->If you are using a local account as a kiosk account in Microsoft Intune, make sure to sign into this account and then sign out before configuring the kiosk device.
+> [!IMPORTANT]
+> If you are using a local account as a kiosk account in Microsoft Intune, make sure to sign into this account and then sign out before configuring the kiosk device.
 
 1. In Microsoft Intune or other MDM service, configure [AssignedAccess](https://docs.microsoft.com/windows/client-management/mdm/assignedaccess-csp) to prevent users from accessing the file system, running executables, or other apps.
 
@@ -166,7 +166,7 @@ With this method, you can use Microsoft Intune or other MDM services to configur
    | **[ConfigureHomeButton](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-configurehomebutton)**<p>![](images/icon-thin-line-computer.png)  | Configure how the Home Button behaves.<p><p>**URI full path:** ./Vendor/MSFT/Policy/Config/Browser/ConfigureHomeButton<p>**Data type:** Integer<p> **Allowed values:**<ul><li>**0 (default)** - Not configured. Show home button, and load the default Start page.</li><li>**1** - Enabled. Show home button and load New Tab page</li><li>**2** - Enabled. Show home button & set a specific page.</li><li>**3** - Enabled. Hide the home button.</li></ul>   |
    | **[SetHomeButtonURL](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-sethomebuttonurl)**<p>![](images/icon-thin-line-computer.png)   | If you set ConfigureHomeButton to 2, configure the home button URL.<p><p>**URI full path:** ./Vendor/MSFT/Policy/Config/Browser/SetHomeButtonURL <p>**Data type:** String<p>**Allowed values:** Enter a URL, for example, https://www.bing.com   |
    | **[SetNewTabPageURL](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser#browser-setnewtabpageurl)**<p>![](images/icon-thin-line-computer.png)   | Set a custom URL for the New Tab page.<p><p>**URI full path:** ./Vendor/MSFT/Policy/Config/Browser/SetNewTabPageURL <p>**Data type:** String<p>**Allowed values:** Enter a URL, for example, https://www.msn.com    |
-    
+
 
 **_Congratulations!_** <p>You’ve just finished setting up a kiosk or digital signage with policies for Microsoft Edge Legacy kiosk mode using Microsoft Intune or other MDM service.
 
@@ -177,7 +177,7 @@ With this method, you can use Microsoft Intune or other MDM services to configur
 
 ## Supported policies for kiosk mode
 
-Use any of the Microsoft Edge Legacy policies listed below to enhance the kiosk experience depending on the Microsoft Edge Legacy kiosk mode type you configure. To learn more about these policies, see [Policy CSP - Browser](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser). 
+Use any of the Microsoft Edge Legacy policies listed below to enhance the kiosk experience depending on the Microsoft Edge Legacy kiosk mode type you configure. To learn more about these policies, see [Policy CSP - Browser](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-browser).
 
 Make sure to check with your provider for instructions.
 
@@ -251,18 +251,18 @@ Make sure to check with your provider for instructions.
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![Not supported](images/148766.png) = Not applicable or not supported <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![Supported](images/148767.png) = Supported
 
----  
+---
 
 ## Feature comparison of kiosk mode and kiosk browser app
 
 In the following table, we show you the features available in both Microsoft Edge Legacy kiosk mode and Kiosk Browser app available in Microsoft Store. Both kiosk mode and kiosk browser app work in assigned access.
 
 
-|                        **Feature**                        |                                                                  **Microsoft Edge Legacy kiosk mode**                                                                  |                                                             **Microsoft Kiosk browser app**                                                             |
+|                        **Feature**                        |                                                                  **Microsoft Edge Legacy kiosk mode**                                                           |                                                             **Microsoft Kiosk browser app**                                                             |
 |-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------:|
 |                       Print support                       |                                                                 ![Supported](images/148767.png)                                                                 |                                                           ![Not supported](images/148766.png)                                                           |
 |                     Multi-tab support                     |                                                                 ![Supported](images/148767.png)                                                                 |                                                           ![Not supported](images/148766.png)                                                           |
-|                  Allow/Block URL support                  | ![Not Supported](images/148766.png)                                                             ![Supported](images/148767.png)                                                             |
+|                  Allow/Block URL support                  |                                                             ![Not Supported](images/148766.png)                                                                 |                                                             ![Supported](images/148767.png)                                                             |
 |                   Configure Home Button                   |                                                                 ![Supported](images/148767.png)                                                                 |                                                             ![Supported](images/148767.png)                                                             |
 |                   Set Start page(s) URL                   |                                                                 ![Supported](images/148767.png)                                                                 |                                              ![Supported](images/148767.png) <p>*Same as Home button URL*                                               |
 |                   Set New Tab page URL                    |                                                                 ![Supported](images/148767.png)                                                                 |                                                           ![Not supported](images/148766.png)                                                           |
@@ -280,6 +280,6 @@ To prevent access to unwanted websites on your kiosk device, use Windows Defende
 
 ## Provide feedback or get support
 
-To provide feedback on Microsoft Edge Legacy kiosk mode in Feedback Hub, select **Microsoft Edge** as the  **Category**, and **All other issues** as the subcategory. 
+To provide feedback on Microsoft Edge Legacy kiosk mode in Feedback Hub, select **Microsoft Edge** as the  **Category**, and **All other issues** as the subcategory.
 
 **_For multi-app kiosk only._** If you have set up the Feedback Hub in assigned access, you can you submit the feedback from the device running Microsoft Edge in kiosk mode in which you can include diagnostic logs. In the Feedback Hub, select **Microsoft Edge** as the **Category**, and **All other issues** as the subcategory.

--- a/browsers/edge/web-app-compat-toolkit.md
+++ b/browsers/edge/web-app-compat-toolkit.md
@@ -1,6 +1,6 @@
 ---
 title: Web Application Compatibility lab kit
-ms.reviewer: 
+ms.reviewer:
 audience: itpro
 manager: dansimp
 description: Learn how to use the web application compatibility toolkit for Microsoft Edge.
@@ -14,7 +14,7 @@ ms.localizationpriority: high
 
 # Web Application Compatibility lab kit
 
->Updated: October, 2017
+> Updated: October, 2017
 
 Upgrading web applications to modern standards is the best long-term solution to ensure compatibility with today’s web browsers, but using backward compatibility can save time and money. Internet Explorer 11 has features that can ease your browser and operating system upgrades, reducing web application testing and remediation costs. On Windows 10, you can standardize on Microsoft Edge for faster, safer browsing and fall back to Internet Explorer 11 just for sites that need backward compatibility.
 
@@ -22,7 +22,7 @@ The Web Application Compatibility Lab Kit is a primer for the features and techn
 
 The Web Application Compatibility Lab Kit includes:
 
-- A pre-configured Windows 7 and Windows 10 virtual lab environment with: 
+- A pre-configured Windows 7 and Windows 10 virtual lab environment with:
    - Windows 7 Enterprise Evaluation
    - Windows 10 Enterprise Evaluation (version 1607)
    - Enterprise Mode Site List Manager
@@ -36,10 +36,10 @@ Depending on your environment, your web apps may "just work” using the methods
 
 There are two versions of the lab kit available:
 
-- Full version (8 GB) - includes a complete virtual lab environment 
+- Full version (8 GB) - includes a complete virtual lab environment
 - Lite version (400 MB) - includes guidance for running the Lab Kit on your own Windows 7 or Windows 10 operating system
 
-The Web Application Compatibility Lab Kit is also available in the following languages: 
+The Web Application Compatibility Lab Kit is also available in the following languages:
 
 - Chinese (Simplified)
 - Chinese (Traditional)
@@ -48,11 +48,11 @@ The Web Application Compatibility Lab Kit is also available in the following lan
 - Italian
 - Japanese
 - Korean
-- Portuguese (Brazil) 
+- Portuguese (Brazil)
 - Russian
 - Spanish
 
 [DOWNLOAD THE LAB KIT](https://www.microsoft.com/evalcenter/evaluate-windows-10-web-application-compatibility-lab)
 
->[!TIP]
->Please use a broad bandwidth to download this content to enhance your downloading experience. Lab environment requires 8 GB of available memory and 100 GB of free disk space.
+> [!TIP]
+> Please use a broad bandwidth to download this content to enhance your downloading experience. Lab environment requires 8 GB of available memory and 100 GB of free disk space.

--- a/browsers/enterprise-mode/create-change-request-enterprise-mode-portal.md
+++ b/browsers/enterprise-mode/create-change-request-enterprise-mode-portal.md
@@ -8,7 +8,7 @@ ms.prod: ie11
 title: Create a change request using the Enterprise Mode Site List Portal (Internet Explorer 11 for IT Pros)
 ms.sitesec: library
 ms.date: 07/27/2017
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ms.author: dansimp
 ---
@@ -17,16 +17,16 @@ ms.author: dansimp
 
 **Applies to:**
 
--   Windows 10
--   Windows 8.1
--   Windows 7
--   Windows Server 2012 R2
--   Windows Server 2008 R2 with Service Pack 1 (SP1)
+- Windows 10
+- Windows 8.1
+- Windows 7
+- Windows Server 2012 R2
+- Windows Server 2008 R2 with Service Pack 1 (SP1)
 
 Employees assigned to the Requester role can create a change request. A change request is used to tell the Approvers and the Administrator that a website needs to be added or removed from the Enterprise Mode Site List. The employee can navigate to each stage of the process by using the workflow links provided at the top of each page of the portal.
 
->[!Important]
->Each Requester must have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct. 
+> [!Important]
+> Each Requester must have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct.
 
 **To create a new change request**
 1. The Requester (an employee that has been assigned the Requester role) signs into the Enterprise Mode Site List Portal, and clicks **Create new request**.
@@ -36,7 +36,7 @@ Employees assigned to the Requester role can create a change request. A change r
 2. Fill out the required fields, based on the group and the app, including:
 
     - **Group name.** Select the name of your group from the dropdown box.
-    
+
     - **App name.** Type the name of the app you want to add, delete, or update in the Enterprise Mode Site List.
 
         - **Search all apps.** If you can't remember the name of your app, you can click **Search all apps** and search the list.
@@ -58,15 +58,15 @@ Employees assigned to the Requester role can create a change request. A change r
     - **App best viewed in.** Select the best browser experience for the app. This can be Internet Explorer 5 through Internet Explorer 11 or one of the IE7Enterprise or IE8Enterprise modes.
 
     - **Is an x-ua tag used?** Select **Yes** or **No** whether an x-ua-compatible tag is used by the app. For more info about x-ua-compatible tags, see the topics in [Defining document compatibility](https://msdn.microsoft.com/library/cc288325(v=vs.85).aspx).
-    
+
 4. Click **Save and continue** to save the request and get the app info sent to the pre-production environment site list for testing.
-    
+
     A message appears that the request was successful, including a **Request ID** number, saying that the change is being made to the pre-production environment site list.
 
 5. The Requester gets an email with a batch script, that when run, configures their test machine for the pre-production environment, along with the necessary steps to make sure the changed info is correct.
 
     - **If the change is correct.** The Requester asks the approvers to approve the change request by selecting **Successful** and clicking **Send for approval**.
-        
+
     - **If the change is incorrect.** The Requester can rollback the change in pre-production or ask for help from the Administrator.
 
 ## Next steps

--- a/browsers/enterprise-mode/enterprise-mode-features-include.md
+++ b/browsers/enterprise-mode/enterprise-mode-features-include.md
@@ -1,4 +1,5 @@
 ### Enterprise Mode features
+
 Enterprise Mode includes the following features:
 
 - **Improved web app and website compatibility.** Through improved emulation, Enterprise Mode lets many legacy web apps run unmodified on IE11, supporting several site patterns that aren’t currently supported by existing document modes.
@@ -8,8 +9,8 @@ Download the [Enterprise Mode Site List Manager (schema v.2)](https://go.microso
 
 - **Centralized control.** You can specify the websites or web apps to interpret using Enterprise Mode, through an XML file on a website or stored locally. Domains and paths within those domains can be treated differently, allowing granular control. Use Group Policy to let users turn Enterprise Mode on or off from the Tools menu and to decide whether the Enterprise browser profile appears on the Emulation tab of the F12 developer tools.
 
-    >[!Important]
-    >All centrally-made decisions override any locally-made choices. 
+    > [!Important]
+    > All centrally-made decisions override any locally-made choices.
 
 - **Integrated browsing.** When Enterprise Mode is set up, users can browse the web normally, letting the browser change modes automatically to accommodate Enterprise Mode sites.
 

--- a/browsers/enterprise-mode/verify-changes-preprod-enterprise-mode-portal.md
+++ b/browsers/enterprise-mode/verify-changes-preprod-enterprise-mode-portal.md
@@ -8,7 +8,7 @@ ms.prod: ie11
 title: Verify your changes using the Enterprise Mode Site List Portal (Internet Explorer 11 for IT Pros)
 ms.sitesec: library
 ms.date: 07/27/2017
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ms.author: dansimp
 ---
@@ -17,18 +17,18 @@ ms.author: dansimp
 
 **Applies to:**
 
--   Windows 10
--   Windows 8.1
--   Windows 7
--   Windows Server 2012 R2
--   Windows Server 2008 R2 with Service Pack 1 (SP1)
+- Windows 10
+- Windows 8.1
+- Windows 7
+- Windows Server 2012 R2
+- Windows Server 2008 R2 with Service Pack 1 (SP1)
 
->[!Important]
->This step requires that each Requester have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct. 
+> [!Important]
+> This step requires that each Requester have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct.
 
 The Requester successfully submits a change request to the Enterprise Mode Site List Portal and then gets an email, including:
 
-- **EMIE_RegKey**. A batch file that when run, sets the registry key to point to the local pre-production Enterprise Mode Site List. 
+- **EMIE_RegKey**. A batch file that when run, sets the registry key to point to the local pre-production Enterprise Mode Site List.
 
 - **Test steps**. The suggested steps about how to test the change request details to make sure they're accurate in the pre-production environment.
 

--- a/browsers/includes/import-into-the-enterprise-mode-site-list-mgr-include.md
+++ b/browsers/includes/import-into-the-enterprise-mode-site-list-mgr-include.md
@@ -3,7 +3,8 @@ author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
 ms.reviewer:
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---

--- a/browsers/includes/import-into-the-enterprise-mode-site-list-mgr-include.md
+++ b/browsers/includes/import-into-the-enterprise-mode-site-list-mgr-include.md
@@ -2,7 +2,7 @@
 author: eavena
 ms.author: eravena
 ms.date:  10/02/2018
-ms.reviewer: 
+ms.reviewer:
 audience: itpromanager: dansimp
 ms.prod: edge
 ms.topic: include
@@ -10,8 +10,8 @@ ms.topic: include
 
 If you need to replace your entire site list because of errors, or simply because it’s out of date, you can import your exported Enterprise Mode site list using the Enterprise Mode Site List Manager.
 
->[!IMPORTANT]
->Importing your file overwrites everything that’s currently in the tool, so make sure it’s what want to do.
+> [!IMPORTANT]
+> Importing your file overwrites everything that’s currently in the tool, so make sure it’s what want to do.
 
 1.  In the Enterprise Mode Site List Manager, click **File \> Import**.
 

--- a/browsers/includes/interoperability-goals-enterprise-guidance.md
+++ b/browsers/includes/interoperability-goals-enterprise-guidance.md
@@ -26,8 +26,8 @@ You must continue using IE11 if web apps use any of the following:
 
 If you have uninstalled IE11, you can download it from the Microsoft Store or the [Internet Explorer 11 download page](https://go.microsoft.com/fwlink/p/?linkid=290956). Alternatively, you can use Enterprise Mode with Microsoft Edge to transition only the sites that need these technologies to load in IE11. 
 
->[!TIP]
->If you want to use Group Policy to set Internet Explorer as your default browser, you can find the info here, [Set the default browser using Group Policy](https://go.microsoft.com/fwlink/p/?LinkId=620714).  
+> [!TIP]
+> If you want to use Group Policy to set Internet Explorer as your default browser, you can find the info here, [Set the default browser using Group Policy](https://go.microsoft.com/fwlink/p/?LinkId=620714).  
 
 
 |Technology  |Why it existed  |Why we don't need it anymore  |
@@ -38,4 +38,3 @@ If you have uninstalled IE11, you can download it from the Microsoft Store or th
 
 
 ---
-

--- a/browsers/internet-explorer/ie11-deploy-guide/create-change-request-enterprise-mode-portal.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/create-change-request-enterprise-mode-portal.md
@@ -8,7 +8,7 @@ ms.prod: ie11
 title: Create a change request using the Enterprise Mode Site List Portal (Internet Explorer 11 for IT Pros)
 ms.sitesec: library
 ms.date: 07/27/2017
-ms.reviewer: 
+ms.reviewer:
 audience: itpro
 manager: dansimp
 ms.author: dansimp
@@ -18,16 +18,16 @@ ms.author: dansimp
 
 **Applies to:**
 
--   Windows 10
--   Windows 8.1
--   Windows 7
--   Windows Server 2012 R2
--   Windows Server 2008 R2 with Service Pack 1 (SP1)
+- Windows 10
+- Windows 8.1
+- Windows 7
+- Windows Server 2012 R2
+- Windows Server 2008 R2 with Service Pack 1 (SP1)
 
 Employees assigned to the Requester role can create a change request. A change request is used to tell the Approvers and the Administrator that a website needs to be added or removed from the Enterprise Mode Site List. The employee can navigate to each stage of the process by using the workflow links provided at the top of each page of the portal.
 
->[!Important]
->Each Requester must have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct. 
+> [!Important]
+> Each Requester must have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct.
 
 **To create a new change request**
 1. The Requester (an employee that has been assigned the Requester role) signs into the Enterprise Mode Site List Portal, and clicks **Create new request**.
@@ -37,7 +37,7 @@ Employees assigned to the Requester role can create a change request. A change r
 2. Fill out the required fields, based on the group and the app, including:
 
     - **Group name.** Select the name of your group from the dropdown box.
-    
+
     - **App name.** Type the name of the app you want to add, delete, or update in the Enterprise Mode Site List.
 
         - **Search all apps.** If you can't remember the name of your app, you can click **Search all apps** and search the list.
@@ -59,16 +59,17 @@ Employees assigned to the Requester role can create a change request. A change r
     - **App best viewed in.** Select the best browser experience for the app. This can be Internet Explorer 5 through Internet Explorer 11 or one of the IE7Enterprise or IE8Enterprise modes.
 
     - **Is an x-ua tag used?** Select **Yes** or **No** whether an x-ua-compatible tag is used by the app. For more info about x-ua-compatible tags, see the topics in [Defining document compatibility](https://msdn.microsoft.com/library/cc288325(v=vs.85).aspx).
-    
+
 4. Click **Save and continue** to save the request and get the app info sent to the pre-production environment site list for testing.
-    
+
     A message appears that the request was successful, including a **Request ID** number, saying that the change is being made to the pre-production environment site list.
 
 5. The Requester gets an email with a batch script, that when run, configures their test machine for the pre-production environment, along with the necessary steps to make sure the changed info is correct.
 
     - **If the change is correct.** The Requester asks the approvers to approve the change request by selecting **Successful** and clicking **Send for approval**.
-        
+
     - **If the change is incorrect.** The Requester can rollback the change in pre-production or ask for help from the Administrator.
 
 ## Next steps
+
 After the change request is created, the Requester must make sure the suggested changes work in the pre-production environment. For these steps, see the [Verify your changes using the Enterprise Mode Site List Portal](verify-changes-preprod-enterprise-mode-portal.md) topic.

--- a/browsers/internet-explorer/ie11-deploy-guide/verify-changes-preprod-enterprise-mode-portal.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/verify-changes-preprod-enterprise-mode-portal.md
@@ -8,7 +8,7 @@ ms.prod: ie11
 title: Verify your changes using the Enterprise Mode Site List Portal (Internet Explorer 11 for IT Pros)
 ms.sitesec: library
 ms.date: 07/27/2017
-ms.reviewer: 
+ms.reviewer:
 audience: itpro
 manager: dansimp
 ms.author: dansimp
@@ -18,18 +18,18 @@ ms.author: dansimp
 
 **Applies to:**
 
--   Windows 10
--   Windows 8.1
--   Windows 7
--   Windows Server 2012 R2
--   Windows Server 2008 R2 with Service Pack 1 (SP1)
+- Windows 10
+- Windows 8.1
+- Windows 7
+- Windows Server 2012 R2
+- Windows Server 2008 R2 with Service Pack 1 (SP1)
 
->[!Important]
->This step requires that each Requester have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct. 
+> [!Important]
+> This step requires that each Requester have access to a test machine with Administrator rights, letting him or her get to the pre-production environment to make sure that the requested change is correct.
 
 The Requester successfully submits a change request to the Enterprise Mode Site List Portal and then gets an email, including:
 
-- **EMIE_RegKey**. A batch file that when run, sets the registry key to point to the local pre-production Enterprise Mode Site List. 
+- **EMIE_RegKey**. A batch file that when run, sets the registry key to point to the local pre-production Enterprise Mode Site List.
 
 - **Test steps**. The suggested steps about how to test the change request details to make sure they're accurate in the pre-production environment.
 

--- a/browsers/internet-explorer/ie11-deploy-guide/what-is-enterprise-mode.md
+++ b/browsers/internet-explorer/ie11-deploy-guide/what-is-enterprise-mode.md
@@ -20,11 +20,11 @@ ms.date: 10/25/2018
 
 **Applies to:**
 
--   Windows 10
--   Windows 8.1
--   Windows 7
--   Windows Server 2012 R2
--   Windows Server 2008 R2 with Service Pack 1 (SP1)
+- Windows 10
+- Windows 8.1
+- Windows 7
+- Windows Server 2012 R2
+- Windows Server 2008 R2 with Service Pack 1 (SP1)
 
 Internet Explorer and Microsoft Edge can work together to support your legacy web apps, while still defaulting to the higher bar for security and modern experiences enabled by Microsoft Edge. Working with multiple browsers can be difficult, particularly if you have a substantial number of internal sites. To help manage this dual-browser experience, we are introducing a new web tool specifically targeted towards larger organizations: the [Enterprise Mode Site List Portal](https://github.com/MicrosoftEdge/enterprise-mode-site-list-portal).
 
@@ -33,7 +33,7 @@ If you have specific websites and apps that you know have compatibility problems
 
 Using Enterprise Mode means that you can continue to use Microsoft Edge as your default browser, while also ensuring that your apps continue working on IE11.
 
->[!TIP]
+> [!TIP]
 > If you are running an earlier version of Internet Explorer, we recommend upgrading to IE11, so that any legacy apps continue to work correctly.
 
 For Windows 10 and Windows 10 Mobile, Microsoft Edge is the default browser experience. However, Microsoft Edge lets you continue to use IE11 for sites that are on your corporate intranet or included on your Enterprise Mode Site List. 
@@ -54,8 +54,8 @@ Download the [Enterprise Mode Site List Manager (schema v.2)](https://go.microso
 
 - **Centralized control.** You can specify the websites or web apps to interpret using Enterprise Mode, through an XML file on a website or stored locally. Domains and paths within those domains can be treated differently, allowing granular control. Use Group Policy to let users turn Enterprise Mode on or off from the Tools menu and to decide whether the Enterprise browser profile appears on the Emulation tab of the F12 developer tools.
 
-    >[!Important]
-    >All centrally-made decisions override any locally-made choices. 
+    > [!Important]
+    > All centrally-made decisions override any locally-made choices. 
 
 - **Integrated browsing.** When Enterprise Mode is set up, users can browse the web normally, letting the browser change modes automatically to accommodate Enterprise Mode sites.
 
@@ -121,11 +121,11 @@ There are 2 versions of this tool, both supported on Windows 7, Windows 8.1, and
 
 - [Enterprise Mode Site List Manager (schema v.1)](https://www.microsoft.com/download/details.aspx?id=42501). This is an older version of the schema that you must use if you want to create and update your Enterprise Mode Site List for devices running the v.1 version of the schema.
 
-	We strongly recommend moving to the new schema, v.2. For more info, see [Enterprise Mode schema v.2 guidance](enterprise-mode-schema-version-2-guidance.md).
+    We strongly recommend moving to the new schema, v.2. For more info, see [Enterprise Mode schema v.2 guidance](enterprise-mode-schema-version-2-guidance.md).
 
 - [Enterprise Mode Site List Manager (schema v.2)](https://www.microsoft.com/download/details.aspx?id=49974). The updated version of the schema, including new functionality. You can use this version of the schema to create and update your Enterprise Mode Site List for devices running the v.2 version of the schema.
 
-	If you open a v.1 version of your Enterprise Mode Site List using this version, it will update the schema to v.2, automatically. For more info, see [Enterprise Mode schema v.1 guidance](enterprise-mode-schema-version-1-guidance.md).
+    If you open a v.1 version of your Enterprise Mode Site List using this version, it will update the schema to v.2, automatically. For more info, see [Enterprise Mode schema v.1 guidance](enterprise-mode-schema-version-1-guidance.md).
 
 If your list is too large to add individual sites, or if you have more than one person managing the site list, we recommend using the Enterprise Site List Portal.
 

--- a/browsers/internet-explorer/ie11-faq/faq-ie11-blocker-toolkit.md
+++ b/browsers/internet-explorer/ie11-faq/faq-ie11-blocker-toolkit.md
@@ -5,8 +5,8 @@ description: Get answers to commonly asked questions about the Internet Explorer
 author: dansimp
 ms.author: dansimp
 ms.prod: ie11
-ms.assetid: 
-ms.reviewer: 
+ms.assetid:
+ms.reviewer:
 audience: itpro
 manager: dansimp
 title: Internet Explorer 11 Blocker Toolkit - Frequently Asked Questions
@@ -16,50 +16,50 @@ ms.date: 05/10/2018
 
 # Internet Explorer 11 Blocker Toolkit - Frequently Asked Questions
 
-Get answers to commonly asked questions about the Internet Explorer 11 Blocker Toolkit.  
+Get answers to commonly asked questions about the Internet Explorer 11 Blocker Toolkit.
 
->[!Important]
->If you administer your company’s environment using an update management solution, such as Windows Server Update Services (WSUS) or System Center 2012 Configuration Manager, you don’t need to use the Internet Explorer 11 Blocker Toolkit. Update management solutions let you completely manage your Windows Updates and Microsoft Updates, including your Internet Explorer 11 deployment.
+> [!Important]
+> If you administer your company’s environment using an update management solution, such as Windows Server Update Services (WSUS) or System Center 2012 Configuration Manager, you don’t need to use the Internet Explorer 11 Blocker Toolkit. Update management solutions let you completely manage your Windows Updates and Microsoft Updates, including your Internet Explorer 11 deployment.
 
--   [Automatic updates delivery process](#automatic-updates-delivery-process)
+- [Automatic updates delivery process](#automatic-updates-delivery-process)
 
--   [How the Internet Explorer 11 Blocker Toolkit works](#how-the-internet-explorer-11-blocker-toolkit-works)
+- [How the Internet Explorer 11 Blocker Toolkit works](#how-the-internet-explorer-11-blocker-toolkit-works)
 
--   [Internet Explorer 11 Blocker Toolkit and other update services](#internet-explorer-11-blocker-toolkit-and-other-update-services)
+- [Internet Explorer 11 Blocker Toolkit and other update services](#internet-explorer-11-blocker-toolkit-and-other-update-services)
 
 ## Automatic Updates delivery process
 
 
-**Q. Which users will receive Internet Explorer 11 as an important update?**  
-A. Users running either Windows 7 with Service Pack 1 (SP1) or the 64-bit version of Windows Server 2008 R2 with Service Pack 1 (SP1) will receive Internet Explorer 11 as an important update, if Automatic Updates are turned on. Windows Update is manually run. Automatic Updates will automatically download and install the Internet Explorer 11 files if it’s turned on. For more information about how Internet Explorer works with Automatic Updates and information about other deployment blocking options, see [Internet Explorer 11 Delivery through automatic updates](../ie11-deploy-guide/ie11-delivery-through-automatic-updates.md).  
-  
-**Q. When is the Blocker Toolkit available?**  
-A. The Blocker Toolkit is currently available from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=40722).  
-  
-**Q. What tools can I use to manage Windows Updates and Microsoft Updates in my company?**  
-A. We encourage anyone who wants full control over their company’s deployment of Windows Updates and Microsoft Updates, to use [Windows Server Update Services (WSUS)](https://docs.microsoft.com/windows-server/administration/windows-server-update-services/get-started/windows-server-update-services-wsus), a free tool for users of Windows Server. You can also use the more advanced configuration management tool, [System Center 2012 Configuration Manager](https://technet.microsoft.com/library/gg682041.aspx).  
-  
-**Q. How long does the blocker mechanism work?**  
-A. The Internet Explorer 11 Blocker Toolkit uses a registry key value to permanently turn off the automatic delivery of Internet Explorer 11. This behavior lasts as long as the registry key value isn’t removed or changed.   
-  
-**Q. Why should I use the Internet Explorer 11 Blocker Toolkit to stop delivery of Internet Explorer 11? Why can’t I just disable all of Automatic Updates?**  
-A. Automatic Updates provide you with ongoing critical security and reliability updates. Turning this feature off can leave your computers more vulnerable. Instead, we suggest that you use an update management solution, such as WSUS, to fully control your environment while leaving this feature running, managing how and when the updates get to your user’s computers.  
-  
+**Q. Which users will receive Internet Explorer 11 as an important update?**
+A. Users running either Windows 7 with Service Pack 1 (SP1) or the 64-bit version of Windows Server 2008 R2 with Service Pack 1 (SP1) will receive Internet Explorer 11 as an important update, if Automatic Updates are turned on. Windows Update is manually run. Automatic Updates will automatically download and install the Internet Explorer 11 files if it’s turned on. For more information about how Internet Explorer works with Automatic Updates and information about other deployment blocking options, see [Internet Explorer 11 Delivery through automatic updates](../ie11-deploy-guide/ie11-delivery-through-automatic-updates.md).
+
+**Q. When is the Blocker Toolkit available?**
+A. The Blocker Toolkit is currently available from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=40722).
+
+**Q. What tools can I use to manage Windows Updates and Microsoft Updates in my company?**
+A. We encourage anyone who wants full control over their company’s deployment of Windows Updates and Microsoft Updates, to use [Windows Server Update Services (WSUS)](https://docs.microsoft.com/windows-server/administration/windows-server-update-services/get-started/windows-server-update-services-wsus), a free tool for users of Windows Server. You can also use the more advanced configuration management tool, [System Center 2012 Configuration Manager](https://technet.microsoft.com/library/gg682041.aspx).
+
+**Q. How long does the blocker mechanism work?**
+A. The Internet Explorer 11 Blocker Toolkit uses a registry key value to permanently turn off the automatic delivery of Internet Explorer 11. This behavior lasts as long as the registry key value isn’t removed or changed.
+
+**Q. Why should I use the Internet Explorer 11 Blocker Toolkit to stop delivery of Internet Explorer 11? Why can’t I just disable all of Automatic Updates?**
+A. Automatic Updates provide you with ongoing critical security and reliability updates. Turning this feature off can leave your computers more vulnerable. Instead, we suggest that you use an update management solution, such as WSUS, to fully control your environment while leaving this feature running, managing how and when the updates get to your user’s computers.
+
 The Internet Explorer 11 Blocker Toolkit safely allows Internet Explorer 11 to download and install in companies that can’t use WSUS, Configuration Manager, or
-other update management solution.  
-  
-**Q. Why don’t we just block URL access to Windows Update or Microsoft Update?**  
+other update management solution.
+
+**Q. Why don’t we just block URL access to Windows Update or Microsoft Update?**
 A. Blocking the Windows Update or Microsoft Update URLs also stops delivery of critical security and reliability updates for all of the supported versions of the Windows operating system; leaving your computers more vulnerable.
 
 ## How the Internet Explorer 11 Blocker Toolkit works
 
-**Q. How should I test the Internet Explorer 11 Blocker Toolkit in my company?**  
-A. Because the toolkit only sets a registry key to turn on and off the delivery of Internet Explorer 11, there should be no additional impact or side effects to your environment. No additional testing should be necessary.  
-  
-**Q. What’s the registry key used to block delivery of Internet Explorer 11?**  
-A. HKLM\\SOFTWARE\\Microsoft\\Internet Explorer\\Setup\\11.0  
-  
-**Q. What’s the registry key name and values?**  
+**Q. How should I test the Internet Explorer 11 Blocker Toolkit in my company?**
+A. Because the toolkit only sets a registry key to turn on and off the delivery of Internet Explorer 11, there should be no additional impact or side effects to your environment. No additional testing should be necessary.
+
+**Q. What’s the registry key used to block delivery of Internet Explorer 11?**
+A. HKLM\\SOFTWARE\\Microsoft\\Internet Explorer\\Setup\\11.0
+
+**Q. What’s the registry key name and values?**
 The registry key name is **DoNotAllowIE11**, where:
 
 -   A value of **1** turns off the automatic delivery of Internet Explorer 11 using Automatic Updates and turns off the Express install option.
@@ -67,23 +67,23 @@ The registry key name is **DoNotAllowIE11**, where:
 -   Not providing a registry key, or using a value of anything other than **1**, lets the user install Internet Explorer 11 through Automatic Updates or a
     manual update.
 
-**Q. Does the Internet Explorer 11 Blocker Toolkit stop users from manually installing Internet Explorer 11?**  
-A. No. The Internet Explorer 11 Blocker Toolkit only stops computers from automatically installing Internet Explorer 11 through Automatic Updates. Users can still download and install Internet Explorer 11 from the Microsoft Download Center or from external media.  
-  
-**Q. Does the Internet Explorer 11 Blocker Toolkit stop users from automatically upgrading to Internet Explorer 11?**  
-A. Yes. The Internet Explorer 11 Blocker Toolkit also prevents Automatic Updates from automatically upgrading a computer from Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 to Internet Explorer 11.  
-  
-**Q. How does the provided script work?**  
+**Q. Does the Internet Explorer 11 Blocker Toolkit stop users from manually installing Internet Explorer 11?**
+A. No. The Internet Explorer 11 Blocker Toolkit only stops computers from automatically installing Internet Explorer 11 through Automatic Updates. Users can still download and install Internet Explorer 11 from the Microsoft Download Center or from external media.
+
+**Q. Does the Internet Explorer 11 Blocker Toolkit stop users from automatically upgrading to Internet Explorer 11?**
+A. Yes. The Internet Explorer 11 Blocker Toolkit also prevents Automatic Updates from automatically upgrading a computer from Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 to Internet Explorer 11.
+
+**Q. How does the provided script work?**
 A. The script accepts one of two command line options:
 
 -   **Block:** Creates the registry key that stops Internet Explorer 11 from installing through Automatic Updates.
 
 -   **Unblock:** Removes the registry key that stops Internet Explorer 11 from installing through Automatic Updates.
 
-**Q. What’s the ADM template file used for?**  
-A. The Administrative Template (.adm file) lets you import the new Group Policy environment and use Group Policy Objects to centrally manage all of the computers in your company.  
-  
-**Q. Is the tool localized?**  
+**Q. What’s the ADM template file used for?**
+A. The Administrative Template (.adm file) lets you import the new Group Policy environment and use Group Policy Objects to centrally manage all of the computers in your company.
+
+**Q. Is the tool localized?**
 A. No. The tool isn’t localized, it’s only available in English (en-us). However, it does work, without any modifications, on any language edition of the supported operating systems.
 
 ## Internet Explorer 11 Blocker Toolkit and other update services
@@ -91,17 +91,17 @@ A. No. The tool isn’t localized, it’s only available in English (en-us). How
 **Q: Is there a version of the Internet Explorer Blocker Toolkit that will prevent automatic installation of IE11?**<br>
 Yes. The IE11 Blocker Toolkit is available for download. For more information, see [Toolkit to Disable Automatic Delivery of IE11](https://go.microsoft.com/fwlink/p/?LinkId=328195) on the Microsoft Download Center.
 
-**Q. Does the Internet Explorer 11 blocking mechanism also block delivery of Internet Explorer 11 through update management solutions, like WSUS?**  
-A. No. You can still deploy Internet Explorer 11 using one of the upgrade management solutions, even if the blocking mechanism is activated. The Internet Explorer 11 Blocker Toolkit is only intended for companies that don’t use upgrade management solutions.  
-  
-**Q. If WSUS is set to 'auto-approve' Update Rollup packages (this is not the default configuration), how do I stop Internet Explorer 11 from automatically installing throughout my company?**  
+**Q. Does the Internet Explorer 11 blocking mechanism also block delivery of Internet Explorer 11 through update management solutions, like WSUS?**
+A. No. You can still deploy Internet Explorer 11 using one of the upgrade management solutions, even if the blocking mechanism is activated. The Internet Explorer 11 Blocker Toolkit is only intended for companies that don’t use upgrade management solutions.
+
+**Q. If WSUS is set to 'auto-approve' Update Rollup packages (this is not the default configuration), how do I stop Internet Explorer 11 from automatically installing throughout my company?**
 A. You only need to change your settings if:
 
--   You use WSUS to manage updates and allow auto-approvals for Update Rollup installation.  
+-   You use WSUS to manage updates and allow auto-approvals for Update Rollup installation.
 
     -and-
 
--   You have computers running either Windows 7 SP1 or Windows Server 2008 R2 (SP1) with Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 installed.  
+-   You have computers running either Windows 7 SP1 or Windows Server 2008 R2 (SP1) with Internet Explorer 8, Internet Explorer 9, or Internet Explorer 10 installed.
 
     -and-
 
@@ -112,10 +112,10 @@ If these scenarios apply to your company, see [Internet Explorer 11 delivery thr
 
 ## Additional resources
 
--   [Internet Explorer 11 Blocker Toolkit download](https://www.microsoft.com/download/details.aspx?id=40722)
+- [Internet Explorer 11 Blocker Toolkit download](https://www.microsoft.com/download/details.aspx?id=40722)
 
--   [Internet Explorer 11 FAQ for IT pros](https://docs.microsoft.com/internet-explorer/ie11-faq/faq-for-it-pros-ie11)
+- [Internet Explorer 11 FAQ for IT pros](https://docs.microsoft.com/internet-explorer/ie11-faq/faq-for-it-pros-ie11)
 
--   [Internet Explorer 11 delivery through automatic updates](../ie11-deploy-guide/ie11-delivery-through-automatic-updates.md)
+- [Internet Explorer 11 delivery through automatic updates](../ie11-deploy-guide/ie11-delivery-through-automatic-updates.md)
 
--   [Internet Explorer 11 deployment guide](https://docs.microsoft.com/internet-explorer/ie11-deploy-guide/index)
+- [Internet Explorer 11 deployment guide](https://docs.microsoft.com/internet-explorer/ie11-deploy-guide/index)

--- a/browsers/internet-explorer/ie11-ieak/index.md
+++ b/browsers/internet-explorer/ie11-ieak/index.md
@@ -14,12 +14,12 @@ manager: dansimp
 
 # Internet Explorer Administration Kit 11 (IEAK 11) - Administrator's Guide
 
-The Internet Explorer Administration Kit (IEAK) simplifies the creation, deployment, and management of customized Internet Explorer packages. You can use the IEAK to configure the out-of-box Internet Explorer experience or to manage user settings after Internet Explorer deployment. 
+The Internet Explorer Administration Kit (IEAK) simplifies the creation, deployment, and management of customized Internet Explorer packages. You can use the IEAK to configure the out-of-box Internet Explorer experience or to manage user settings after Internet Explorer deployment.
 
 Use this guide to learn about the several options and processes you'll need to consider while you're using the Internet Explorer Administration Kit 11 (IEAK 11) to customize, deploy, and manage Internet Explorer 11 for your employee's devices.
 
->[!IMPORTANT]
->Because this content isn't intended to be a step-by-step guide, not all of the steps are necessary.
+> [!IMPORTANT]
+> Because this content isn't intended to be a step-by-step guide, not all of the steps are necessary.
 
 
 ## Included technology
@@ -41,7 +41,7 @@ IE11 and IEAK 11 offers differing experiences between Windows 7 and Windows 8.1 
 
 ## Related topics
 - [IEAK 11 - Frequently Asked Questions](../ie11-faq/faq-ieak11.md)
-- [Download IEAK 11](ieak-information-and-downloads.md) 
+- [Download IEAK 11](ieak-information-and-downloads.md)
 - [IEAK 11 administrators guide](https://docs.microsoft.com/internet-explorer/ie11-ieak/index)
 - [IEAK 11 licensing guidelines](licensing-version-and-features-ieak11.md)
 - [Internet Explorer 11 - FAQ for IT Pros](../ie11-faq/faq-for-it-pros-ie11.md)

--- a/browsers/internet-explorer/ie11-ieak/licensing-version-and-features-ieak11.md
+++ b/browsers/internet-explorer/ie11-ieak/licensing-version-and-features-ieak11.md
@@ -6,7 +6,7 @@ author: dansimp
 ms.author: dansimp
 ms.prod: ie11
 ms.assetid: 69d25451-08af-4db0-9daa-44ab272acc15
-ms.reviewer: 
+ms.reviewer:
 audience: itpro
 manager: dansimp
 title: Determine the licensing version and features to use in IEAK 11 (Internet Explorer Administration Kit 11 for IT Pros)
@@ -21,8 +21,8 @@ In addition to the Software License Terms for the Internet Explorer Administrati
 During installation, you must pick a version of IEAK 11, either **External** or **Internal**, based on your license agreement. Your version selection decides the options you can chose, the steps you follow to deploy your Internet Explorer 11 package, and how you manage the browser after deployment.
 
 -   **External Distribution as an Internet Service Provider (ISP), Internet Content Provider (ICP), or Developer.** If you are an ISP or an ICP, your license agreement also states that you must show the Internet Explorer logo on your packaging and promotional goods, as well as on your website.
-    >[!IMPORTANT]
-    >Original Equipment Manufacturers (OEMs) that install IEAK 11 as part of a Windows product, under an OEM license agreement with Microsoft, must use their appropriate Windows OEM Preinstallation document (OPD) as the guide for allowable customizations.
+    > [!IMPORTANT]
+    > Original Equipment Manufacturers (OEMs) that install IEAK 11 as part of a Windows product, under an OEM license agreement with Microsoft, must use their appropriate Windows OEM Preinstallation document (OPD) as the guide for allowable customizations.
 
 -   **Internal Distribution via a Corporate Intranet.** This version is for network admins that plan to directly deploy IE11 into a corporate environment.
 
@@ -64,10 +64,10 @@ During installation, you must pick a version of IEAK 11, either **External** or 
 
 Two installation modes are available to you, depending on how you are planning to use the customized browser created with the software. Each mode requires a separate installation of the software.
 
--   **External Distribution**  
+-   **External Distribution**
     This mode is available to anyone who wants to create a customized browser for distribution outside their company (for example, websites, magazines, retailers, non-profit organizations, independent hardware vendors, independent software vendors, Internet service providers, Internet content providers, software developers, and marketers).
 
--   **Internal Distribution**  
+-   **Internal Distribution**
     This mode is available to companies for the creation and distribution of a customized browser only to their employees over a corporate intranet.
 
 The table below identifies which customizations you may or may not perform based on the mode you selected.
@@ -100,8 +100,8 @@ Support for some of the Internet Explorer settings on the wizard pages varies de
 
 Two installation modes are available to you, depending on how you are planning to use the customized browser created with the software. Each mode requires a separate installation of the software.
 
--   **External Distribution**  
+-   **External Distribution**
     You shall use commercially reasonable efforts to maintain the quality of (i) any non-Microsoft software distributed with Internet Explorer 11, and (ii) any media used for distribution (for example, optical media, flash drives), at a level that meets or exceeds the highest industry standards. If you distribute add-ons with Internet Explorer 11, those add-ons must comply with the [Microsoft browser extension policy](https://docs.microsoft.com/legal/windows/agreements/microsoft-browser-extension-policy).
 
--   **Internal Distribution - corporate intranet**  
+-   **Internal Distribution - corporate intranet**
     The software is solely for use by your employees within your company's organization and affiliated companies through your corporate intranet. Neither you nor any of your employees may permit redistribution of the software to or for use by third parties other than for third parties such as consultants, contractors, and temporary staff accessing your corporate intranet.


### PR DESCRIPTION
**Description:**
- follow-up to my previous PR #6060 (**chore: MarkDown Note marker compatibility spacing**)

**Main directory:** /browsers/

This is a follow-up attempt to standardize the MarkDown Note bubbles by adding the recommended single space after the quote marker.
MarkDown codestyle & whitespace usage consistency is the main goal here.

**Additional proposed changes:**
- Remove redundant end-of-line (EOL) whitespace
- Simplify blank space usage in bullet point lists/numbered lists to 1
- Replace some tab characters with 4 blank spaces (GitHub compatibility)
- Reduce redundant blank line whitespace usage:
    - remove excessive blank lines between sections
    - remove surplus blank lines in minimal bullet point lists

**File-specific improvement change:**
browsers/edge/microsoft-edge-kiosk-mode-deploy.md
- Add back missing table readability spacing and cell dividers.

**Ticket reference or closure:** None that I know of (at least not yet).

**Additional notes:**
- I have split this modification chore into sub-folder sections to keep the number of files within a reasonably manageable amount.
- Some of the whitespace changes could not be applied due to layout.