### PR TITLE
Live Response requirements

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/live-response.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/live-response.md
@@ -59,6 +59,9 @@ You'll need to enable the live response capability in the [Advanced features set
 
     >[!NOTE]
     >Only users with manage security or global admin roles can edit these settings.
+    
+- **Ensure that the machine has an Automation Remediation level assigned to it**<br>
+You'll need to enable, at least, the minimum Remdiation Level for a given Machine Group. Otherwise you won't be able to establish a Live Response session to a member of that group.
 
 - **Enable live response unsigned script execution** (optional) <br>
 


### PR DESCRIPTION
If the Automation Level is not set to the Machine Group that the device belong to, Live Response won't work and will output a message saying that the device is "Not Protected".
We're trying to change the error message internally to make it more clear.