### PR TITLE
### Existing Enterprise deployments

### DIFF
--- a/windows/deployment/windows-10-subscription-activation.md
+++ b/windows/deployment/windows-10-subscription-activation.md
@@ -191,6 +191,8 @@ When you have the required Azure AD subscription, group-based licensing is the p
 
 If you are running Windows 10, version 1803 or later, Subscription Activation will automatically pull the firmware-embedded Windows 10 activation key and activate the underlying Pro License. The license will then step-up to Windows 10 Enterprise using Subscription Activation. This automatically migrates your devices from KMS or MAK activated Enterprise to Subscription activated Enterprise. 
 
+Caution: Firmware-embedded Windows 10 activation happens automatically only when we go through OOBE(Out Of Box Experience)
+
 If you are using Windows 10, version 1607, 1703, or 1709 and have already deployed Windows 10 Enterprise, but you want to move away from depending on KMS servers and MAK keys for Windows client machines, you can seamlessly transition as long as the computer has been activated with a firmware-embedded Windows 10 Pro product key.
 
 If the computer has never been activated with a Pro key, run the following script. Copy the text below into a .cmd file and run the file from an elevated command prompt:


### PR DESCRIPTION
I have just added "caution" after the first paragraph, i am making this comment after doing testing in my customer's environment.  If OOBE is automated using unatend.xml, the Firmware-embedded Windows 10 activation doesn't happen automatically, we need to manually activate and then enroll with AAD for E3 license switch to happen