### PR TITLE
MD-ATP/Exploit Protection: corrections & updates

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
@@ -141,7 +141,7 @@ You can use Group Policy to deploy the configuration you've created to multiple 
 
 ### Use Group Policy to distribute the configuration
 
-1. On your Group Policy management machine, open the [Group Policy Management Console](https://docs.microsoft.com/previous-versions/windows/desktop/gpmc/group-policy-management-console-portal)), right-click the Group Policy Object you want to configure and click **Edit**.
+1. On your Group Policy management machine, open the [Group Policy Management Console](https://docs.microsoft.com/previous-versions/windows/desktop/gpmc/group-policy-management-console-portal), right-click the Group Policy Object you want to configure and click **Edit**.
 
 2. In the **Group Policy Management Editor** go to **Computer configuration** and click **Administrative templates**.
 

--- a/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
@@ -21,11 +21,11 @@ manager: dansimp
 
 **Applies to:**
 
-* [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
+* [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](microsoft-defender-advanced-threat-protection.md)
 
 Exploit protection applies helps protect devices from malware that use exploits to spread and infect. It consists of a number of mitigations that can be applied at either the operating system level, or at the individual app level.
 
-Many of the features that are part of the [Enhanced Mitigation Experience Toolkit (EMET)](https://technet.microsoft.com/security/jj653751) are now included in exploit protection.
+Many of the features that are part of the [Enhanced Mitigation Experience Toolkit (EMET)](https://support.microsoft.com/help/2458544/) are now included in exploit protection.
 
 You use the Windows Security app or PowerShell to create a set of mitigations (known as a configuration). You can then export this configuration as an XML file and share it with multiple machines on your network so they all have the same set of mitigation settings.
 
@@ -33,7 +33,7 @@ You can also convert and import an existing EMET configuration XML file into an 
 
 This topic describes how to create a configuration file and deploy it across your network, and how to convert an EMET configuration.
 
-The [Evaluation Package](https://aka.ms/mp7z2w) contains a sample configuration file (name *ProcessMitigation-Selfhost-v4.xml* that you can use to see how the XML structure looks. The sample file also contains settings that have been converted from an EMET configuration. You can open the file in a text editor (such as Notepad) or import it directly into exploit protection and then review the settings in the Windows Security app, as described further in this topic.
+The [Evaluation Package](https://demo.wd.microsoft.com/Page/EP) contains a sample configuration file (name *ProcessMitigation-Selfhost-v4.xml* that you can use to see how the XML structure looks. The sample file also contains settings that have been converted from an EMET configuration. You can open the file in a text editor (such as Notepad) or import it directly into exploit protection and then review the settings in the Windows Security app, as described further in this topic.
 
 ## Create and export a configuration file
 
@@ -141,7 +141,7 @@ You can use Group Policy to deploy the configuration you've created to multiple 
 
 ### Use Group Policy to distribute the configuration
 
-1. On your Group Policy management machine, open the [Group Policy Management Console](https://technet.microsoft.com/library/cc731212.aspx), right-click the Group Policy Object you want to configure and click **Edit**.
+1. On your Group Policy management machine, open the [Group Policy Management Console](https://docs.microsoft.com/previous-versions/windows/desktop/gpmc/group-policy-management-console-portal)), right-click the Group Policy Object you want to configure and click **Edit**.
 
 2. In the **Group Policy Management Editor** go to **Computer configuration** and click **Administrative templates**.
 
@@ -158,7 +158,7 @@ You can use Group Policy to deploy the configuration you've created to multiple 
     * https://localhost:8080/Config.xml
     * C:\ExploitConfigfile.xml
 
-6. Click **OK** and [Deploy the updated GPO as you normally do](https://msdn.microsoft.com/library/ee663280(v=vs.85).aspx).
+6. Click **OK** and [Deploy the updated GPO as you normally do](https://docs.microsoft.com/windows/win32/srvnodes/group-policy).
 
 ## Related topics
 

--- a/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/import-export-exploit-protection-emet-xml.md
@@ -33,7 +33,7 @@ You can also convert and import an existing EMET configuration XML file into an 
 
 This topic describes how to create a configuration file and deploy it across your network, and how to convert an EMET configuration.
 
-The [Evaluation Package](https://demo.wd.microsoft.com/Page/EP) contains a sample configuration file (name *ProcessMitigation-Selfhost-v4.xml* that you can use to see how the XML structure looks. The sample file also contains settings that have been converted from an EMET configuration. You can open the file in a text editor (such as Notepad) or import it directly into exploit protection and then review the settings in the Windows Security app, as described further in this topic.
+The [Evaluation Package](https://demo.wd.microsoft.com/Page/EP) contains a sample configuration file (name *ProcessMitigation.xml* (Selfhost v4) that you can use to see how the XML structure looks. The sample file also contains settings that have been converted from an EMET configuration. You can open the file in a text editor (such as Notepad) or import it directly into exploit protection and then review the settings in the Windows Security app, as described further in this topic.
 
 ## Create and export a configuration file
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6531 (**Redirect Exploit protection "Evaluation Package" link directly to right site**), the aka.ms link to the Evaluation Package points to the Windows Defender test ground page.
The suggestion is to point the link directly to the Exploit Protection (EP) page instead.

Thanks to @beerisgood for reporting this issue.

Additional changes: Link corrections and updates to counteract the fact that some of the old technet links do not lead directly to the correct topic pages, so it is better to insert traceable direct links instead.

I have not found any formatting worth correcting on this page, so the various outdated or bad links will be the main focus in this PR.

**Changes proposed:**
- Replace the aka.ms/mp7z2w link with the direct EP download page link
- Rename the XML filename from `ProcessMitigation-Selfhost-v4.xml` to *ProcessMitigation.xml* (Selfhost v4)
- Replace technet/msdn links with current docs.microsoft.com page links
- Replace 1 technet link with support.microsoft.com/help
- Remove bad go.microsoft.com/fwlink (Windows 10 edition comparison PDF)
- Insert direct link to local neighboring page for MD-ATP (same folder)

**Ticket closure or reference:**

Closes #6531