### PR TITLE
BitLocker/MDT: TPM typo & link updates

### DIFF
--- a/windows/deployment/deploy-windows-mdt/set-up-mdt-for-bitlocker.md
+++ b/windows/deployment/deploy-windows-mdt/set-up-mdt-for-bitlocker.md
@@ -31,15 +31,15 @@ To configure your environment for BitLocker, you will need to do the following:
 4. Configure the rules (CustomSettings.ini) for BitLocker.
 
 > [!NOTE]
-> Even though it is not a BitLocker requirement, we recommend configuring BitLocker to store the recovery password in Active Directory. For additional information about this feature, see [Backing Up BitLocker and TPM Recovery Information to AD DS](https://docs.microsoft.com/windows/security/information-protection/tpm/backup-tpm-recovery-information-to-ad-ds).  
+> Even though it is not a BitLocker requirement, we recommend configuring BitLocker to store the recovery password in Active Directory. For additional information about this feature, see [Backing Up BitLocker and TPM Recovery Information to AD DS](https://docs.microsoft.com/windows/security/information-protection/tpm/backup-tpm-recovery-information-to-ad-ds).
 If you have access to Microsoft BitLocker Administration and Monitoring (MBAM), which is part of Microsoft Desktop Optimization Pack (MDOP), you have additional management features for BitLocker.
 
 > [!NOTE]
-> Backing up TMP to Active Directory was supported only on Windows 10 version 1507 and 1511.
+> Backing up TPM to Active Directory was supported only on Windows 10 version 1507 and 1511.
 
 >[!NOTE]
->Even though it is not a BitLocker requirement, we recommend configuring BitLocker to store the recovery key and TPM owner information in Active Directory. For additional information about these features, see [Backing Up BitLocker and TPM Recovery Information to AD DS](https://go.microsoft.com/fwlink/p/?LinkId=619548). If you have access to Microsoft BitLocker Administration and Monitoring (MBAM), which is part of Microsoft Desktop Optimization Pack (MDOP), you have additional management features for BitLocker.
- 
+>Even though it is not a BitLocker requirement, we recommend configuring BitLocker to store the recovery key and TPM owner information in Active Directory. For additional information about these features, see [Backing Up BitLocker and TPM Recovery Information to AD DS](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-7/dd875529(v=ws.10)). If you have access to Microsoft BitLocker Administration and Monitoring (MBAM), which is part of Microsoft Desktop Optimization Pack (MDOP), you have additional management features for BitLocker.
+
 For the purposes of this topic, we will use DC01, a domain controller that is a member of the domain contoso.com for the fictitious Contoso Corporation. For more details on the setup for this topic, please see [Deploy Windows 10 with the Microsoft Deployment Toolkit](deploy-windows-10-with-the-microsoft-deployment-toolkit.md).
 
 ## Configure Active Directory for BitLocker
@@ -95,7 +95,7 @@ Following these steps, you enable the backup of BitLocker and TPM recovery infor
 
 ### Set permissions in Active Directory for BitLocker
 
-In addition to the Group Policy created previously, you need to configure permissions in Active Directory to be able to store the TPM recovery information. In these steps, we assume you have downloaded the [Add-TPMSelfWriteACE.vbs script](https://go.microsoft.com/fwlink/p/?LinkId=167133) from Microsoft to C:\\Setup\\Scripts on DC01.
+In addition to the Group Policy created previously, you need to configure permissions in Active Directory to be able to store the TPM recovery information. In these steps, we assume you have downloaded the [Add-TPMSelfWriteACE.vbs script](https://gallery.technet.microsoft.com/ScriptCenter/b4dee016-053e-4aa3-a278-3cebf70d1191) from Microsoft to C:\\Setup\\Scripts on DC01.
 
 1. On DC01, start an elevated PowerShell prompt (run as Administrator).
 2. Configure the permissions by running the following command:


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6538 (**TPM, not TMP**), there is a typo where the initialism TPM is misspelled as "TMP". Although a common variable in the Microsoft Windows environment, it is not correct in this note.

Thanks to @ntw2 for reporting this typo.

Further changes suggested: Replace 2 out of 3 fwlinks with their current target page links (the third one is a rabbit hole too deep for me to dive into right now).

Regarding the go.microsoft.com/fwlink changes: I am doing this based on clear feedback from Elizabeth Ross in the Windows Server docs team, who recommended that we change those fwlinks as we come across them and find a suitable static or new working target page link. The fwlinks are, more often than not, pointing to outdated or broken technet/msdn pages, so it is better to see the actual landing page links to be able to look up replacements at a later time.

**Changes proposed:**
- "TMP" corrected to TPM (as it should be)
- https://go.microsoft.com/fwlink/p/?LinkId=619548 -> https://docs.microsoft.com/previous-versions/windows/it-pro/windows-7/dd875529(v=ws.10) ((could really do with a new & up to date page))
- https://go.microsoft.com/fwlink/p/?LinkId=167133 -> https://gallery.technet.microsoft.com/ScriptCenter/b4dee016-053e-4aa3-a278-3cebf70d1191 ((marked for retirement, needs a backup or replacement))
- Remove redundant end-of-line whitespace for 2 lines

**Additional notes:**

Please feel free to suggest improved link replacements, especially for the untouched fwlink, [Check to see if the TPM is enabled](https://go.microsoft.com/fwlink/p/?LinkId=619549) (https://go.microsoft.com/fwlink/p/?LinkId=619549). This link lands on the blog archives top menu level without any leads to the archived blog: https://docs.microsoft.com/archive/blogs/ .

**Ticket closure or reference:**

Closes #6538