### PR TITLE
Update mac-install-with-intune.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-install-with-intune.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-install-with-intune.md
@@ -19,6 +19,10 @@ ms.topic: conceptual
 
 # Intune-based deployment for Microsoft Defender ATP for Mac
 
+Note - This documentation explains the legacy method for deploying and configuring Microsoft Defender ATP on macOS devices. The native experience is now avaliable in the MEM console. The release of the native UI in the MEM console provide admins with a much simpler way to configure and dfeploy the application and send it down to macOS devices. This blog post explains the new features: https://techcommunity.microsoft.com/t5/microsoft-endpoint-manager-blog/microsoft-endpoint-manager-simplifies-deployment-of-microsoft/ba-p/1322995
+To configure the app go here: https://docs.microsoft.com/en-us/mem/intune/protect/antivirus-microsoft-defender-settings-macos
+To deploy the app go here: https://docs.microsoft.com/en-us/mem/intune/apps/apps-advanced-threat-protection-macos
+
 **Applies to:**
 
 - [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP) for Mac](microsoft-defender-atp-mac.md)


### PR DESCRIPTION
A note should be added to the very beginning of this article that stands out. This document explains the legacy method for deploying and configurating the Microsoft Defender ATP application on macOS devices. The note should explain this, and point admins to the new docs and the blog post that show the native experience which is much easier.  

The docs to link to from the note are -

Blog: https://techcommunity.microsoft.com/t5/microsoft-endpoint-manager-blog/microsoft-endpoint-manager-simplifies-deployment-of-microsoft/ba-p/1322995
Deployment: https://docs.microsoft.com/en-us/mem/intune/apps/apps-advanced-threat-protection-macos
Configuration: https://docs.microsoft.com/en-us/mem/intune/protect/antivirus-microsoft-defender-settings-macos

In order of steps in the note, the blog should come first, then config, then deployment. Thank you!