### PR TITLE
Updated Microsoft browser extension policy URL

### DIFF
--- a/browsers/edge/shortdesc/microsoft-browser-extension-policy-shortdesc.md
+++ b/browsers/edge/shortdesc/microsoft-browser-extension-policy-shortdesc.md
@@ -1,12 +1,13 @@
 ---
 author: dansimp
 ms.author: dansimp
-ms.date:  10/02/2018
+ms.date:  04/23/2020
 ms.reviewer: 
-audience: itpromanager: dansimp
+audience: itpro
+manager: dansimp
 ms.prod: edge
 ms.topic: include
 ---
 
-[Microsoft browser extension policy](https://docs.microsoft.com/legal/windows/agreements/microsoft-browser-extension-policy):
+[Microsoft browser extension policy](https://docs.microsoft.com/legal/microsoft-edge/microsoft-browser-extension-policy:
 This document describes the supported mechanisms for extending or modifying the behavior or user experience of Microsoft Edge and Internet Explorer or the content displayed by these browsers. Any technique not explicitly listed in this document is considered **unsupported**.


### PR DESCRIPTION
Current URL: https://docs.microsoft.com/legal/windows/agreements/microsoft-browser-extension-policy leads to 404.
Updated URL to reflect new URL: https://docs.microsoft.com/legal/microsoft-edge/microsoft-browser-extension-policy.