### PR TITLE
TPM requirements for Autopilot updated

### DIFF
--- a/windows/security/information-protection/tpm/tpm-recommendations.md
+++ b/windows/security/information-protection/tpm/tpm-recommendations.md
@@ -123,7 +123,7 @@ The following table defines which Windows features require TPM support.
  TPM Platform Crypto Provider Key Storage Provider| Yes | Yes | Yes
  Virtual Smart Card | Yes | Yes | Yes
  Certificate storage | No | Yes | Yes | TPM is only required when the certificate is stored in the TPM.
- Autopilot | Yes | No | Yes | TPM 2.0 and UEFI firmware is required for white glove and self-deploying scenarios.
+ Autopilot | No | N/A | Yes | If you intend to deploy a scenario which requires TPM (such as white glove and self-deploying mode), then TPM 2.0 and UEFI firmware are required.
  SecureBIO | Yes | No | Yes | TPM 2.0 and UEFI firmware is required.
  DRTM | Yes | No | Yes | TPM 2.0 and UEFI firmware is required.
 


### PR DESCRIPTION
@DulceMontemayor & @Dansimp 
Current table states that Autopilot requires TPM - this is incorrect.
Added N/A for TPM 1.2
Description is a little bit long winded - but I believe necessary to clarify the following:
While Autopilot doesn't need a TPM at all, if you want to leverage scenarios like white glove and self-deploying mode - those need TPM 2.0 as mandatory (TPM 1.2 is not an option)