### PR TITLE
Update interactive-logon-prompt-user-to-change-password-before-expira…

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
+++ b/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
@@ -37,7 +37,7 @@ This policy setting determines when users are warned that their passwords are ab
 
 -  Configure user passwords to expire periodically. Users need warning that their password is going to expire, or they might  get locked out of the system.
 -  Set **Interactive logon: Prompt user to change password before expiration** to five days. When their password expiration date is five or fewer days away, users will see a dialog box each time that they log on to the domain.
--  When you set the policy to zero, there is no password expiration warning when the user logs on. During a long-running logon session, you would get the warning on the day the password expires or when it is already expired.
+-  When you set the policy to zero, there is no password expiration warning when the user logs on. During a long-running logon session, you would get the warning on the day the password expires or when it already has expired.
 
 ### Location
 

--- a/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
+++ b/windows/security/threat-protection/security-policy-settings/interactive-logon-prompt-user-to-change-password-before-expiration.md
@@ -37,7 +37,7 @@ This policy setting determines when users are warned that their passwords are ab
 
 -  Configure user passwords to expire periodically. Users need warning that their password is going to expire, or they might  get locked out of the system.
 -  Set **Interactive logon: Prompt user to change password before expiration** to five days. When their password expiration date is five or fewer days away, users will see a dialog box each time that they log on to the domain.
--  Don't set the value to zero, which displays the password expiration warning every time the user logs on.
+-  When you set the policy to zero, there is no password expiration warning when the user logs on. During a long-running logon session, you would get the warning on the day the password expires or when it is already expired.
 
 ### Location
 


### PR DESCRIPTION
…tion.md

The description of the value at zero is incorrect.
I verified in the source of Winlogon that you never get a reminder when the value is 0, only when the password expires the same day or when it has expired already.