### PR TITLE
Removed note regarding Edge Chromium lack of WIP support

### DIFF
--- a/windows/security/information-protection/windows-information-protection/limitations-with-wip.md
+++ b/windows/security/information-protection/windows-information-protection/limitations-with-wip.md
@@ -145,8 +145,8 @@ This table provides info about the most common problems you might encounter whil
 > [!NOTE]
 > When corporate data is written to disk, WIP uses the Windows-provided Encrypting File System (EFS) to protect it and associate it with your enterprise identity. One caveat to keep in mind is that the Preview Pane in File Explorer will not work for encrypted files. 
 
-> [!NOTE]
-> Chromium-based versions of Microsoft Edge (versions since 79) don't fully support WIP yet. The functionality could be partially enabled by going to the local page **edge://flags/#edge-dataprotection** and setting the **Windows Information Protection** flag to **enabled**.
+
+
 
 > [!NOTE]
 > Help to make this topic better by providing us with edits, additions, and feedback. For info about how to contribute to this topic, see [Contributing to our content](https://github.com/Microsoft/windows-itpro-docs/blob/master/CONTRIBUTING.md).       


### PR DESCRIPTION
@Dansimp Edge Chromium v81 (from April 13th) and later now has support for WIP, as per https://docs.microsoft.com/en-au/deployedge/Microsoft-Edge-security-windows-information-protection and https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-81041653-april-13 hence removing Edge as a known issue from this page.
Please verify with Narendra Acharya if necessary