### PR TITLE
Update Event Id 4624

### DIFF
--- a/windows/security/threat-protection/auditing/event-4624.md
+++ b/windows/security/threat-protection/auditing/event-4624.md
@@ -230,7 +230,7 @@ This event generates when a logon session is created (on destination machine). I
 
 **Network Information:**
 
--   **Workstation Name** \[Type = UnicodeString\]**:** machine name from which logon attempt was performed.
+-   **Workstation Name** \[Type = UnicodeString\]**:** machine name to which logon attempt was performed.
 
 -   **Source Network Address** \[Type = UnicodeString\]**:** IP address of machine from which logon attempt was performed.
 


### PR DESCRIPTION
In the Network information section, the workstation name is mentioned with 'machine name from which logon attempt was performed.' that has been modified to "machine name to which logon attempt was performed." (please notice 'to' instead of 'from'). The workstation name has to be the computer name of the target computer not the source computer. Please check the issue reported on https://github.com/MicrosoftDocs/windows-itpro-docs/issues/6438, thanks.