### PR TITLE
User credential preferred

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -113,7 +113,7 @@ Requirements:
 
     ![MDM autoenrollment policy](images/autoenrollment-policy.png)
 
-5. Click **Enable**, then click **OK**.
+5. Click **Enable**, and select **User Credential** from the dropdown **Select Credential Type to Use**, then click **OK**.
 
 > [!NOTE]
 > In Windows 10, version 1903, the MDM.admx file was updated to include an option to select which credential is used to enroll the device. **Device Credential** is a new option that will only have an effect on clients that have installed Windows 10, version 1903 or later. 


### PR DESCRIPTION
Even though Device Credential is an option on the GPO, the device credential gives error while auto-enrollment tasks running through the Task Scheduler. To avoid this error we need to choose the User Credential option from the dropdown to auto-enroll the device. The below line has been updated on the document.
5. Click **Enable**, and select **User Credential** from the dropdown **Select Credential Type to Use**, then click **OK**.