### PR TITLE
Security/Threat protection: password length values

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/minimum-password-length.md
+++ b/windows/security/threat-protection/security-policy-settings/minimum-password-length.md
@@ -20,18 +20,18 @@ ms.date: 04/19/2017
 # Minimum password length
 
 **Applies to**
--   Windows 10
+- Windows 10
 
 Describes the best practices, location, values, policy management, and security considerations for the **Minimum password length** security policy setting.
 
 ## Reference
 
-The **Minimum password length** policy setting determines the least number of characters that can make up a password for a user account. You can set a value of between 1 and 14 characters, or you can establish that no password is required by setting the number of characters to 0.
+The **Minimum password length** policy setting determines the least number of characters that can make up a password for a user account. You can set a value of between 1 and 20 characters, or you can establish that no password is required by setting the number of characters to 0.
 
 ### Possible values
 
--   User-specified number of characters between 0 and 14
--   Not defined
+- User-specified number of characters between 0 and 20
+- Not defined
 
 ### Best practices
 
@@ -51,13 +51,13 @@ The following table lists the actual and effective default policy values. Defaul
 
 | Server type or Group Policy Object (GPO) | Default value |
 | - | - |
-| Default domain policy| 7 characters| 
-| Default domain controller policy | Not defined| 
-| Stand-alone server default settings | 0 characters| 
-| Domain controller effective default settings | 7 characters| 
-| Member server effective default settings | 7 characters| 
-| Effective GPO default settings on client computers | 0 characters| 
- 
+| Default domain policy| 7 characters|
+| Default domain controller policy | Not defined|
+| Stand-alone server default settings | 0 characters|
+| Domain controller effective default settings | 7 characters|
+| Member server effective default settings | 7 characters|
+| Effective GPO default settings on client computers | 0 characters|
+
 ## Policy management
 
 This section describes features, tools, and guidance to help you manage this policy.
@@ -80,8 +80,9 @@ Configure the **** policy setting to a value of 8 or more. If the number of char
 
 In most environments, we recommend an eight-character password because it is long enough to provide adequate security, but not too difficult for users to easily remember. This configuration provides adequate defense against a brute force attack. Using the [Password must meet complexity requirements](password-must-meet-complexity-requirements.md) policy setting in addition to the **Minimum password length** setting helps reduce the possibility of a dictionary attack.
 
->**Note:**  Some jurisdictions have established legal requirements for password length as part of establishing security regulations.
- 
+> [!NOTE]
+> Some jurisdictions have established legal requirements for password length as part of establishing security regulations.
+
 ### Potential impact
 
 Requirements for extremely long passwords can actually decrease the security of an organization because users might leave the information in an unsecured location or lose it. If very long passwords are required, mistyped passwords could cause account lockouts and increase the volume of Help Desk calls. If your organization has issues with forgotten passwords due to password length requirements, consider teaching your users about passphrases, which are often easier to remember and, due to the larger number of character combinations, much harder to discover.


### PR DESCRIPTION
**Description:**

As requested by Program Manager Robert Durff (@MSRobertD) in issue ticket #6856 (**Bug: Password length value range is inaccurate.**), the upper value for the supported values for password length should be 20 instead of only 14, verified in preliminary field testing of the GPO Password Policy, described on this page.

The actual upper limit may very well be higher, but 20 is a reasonable value to be used for now, until someone documents the need for higher accuracy in the documentation of this value for the GPO Password Policy.

**Changes proposed:**
- Replace 14 with 20 in both occurrences of 14 as the upper value
- Convert Note text in line 83 to a MarkDown Note blob (MS codestyle)
- Whitespace adjustments:
    - Normalize bullet point list spacing to 1 (codestyle) (3 lines)
    - Remove redundant end-of-line spacing (8 lines)

**Ticket closure or reference:**

Closes #6856