### PR TITLE
Windows Update: code blocks vs. translation errors

### DIFF
--- a/windows/deployment/update/windows-update-resources.md
+++ b/windows/deployment/update/windows-update-resources.md
@@ -3,7 +3,6 @@ title: Windows Update - Additional resources
 description: Additional resources for Windows Update
 ms.prod: w10
 ms.mktglfcycl:
-
 audience: itpro
 author: jaimeo
 ms.localizationpriority: medium
@@ -17,7 +16,7 @@ ms.topic: article
 
 # Windows Update - additional resources
 
->Applies to: Windows 10
+> Applies to: Windows 10
 
 The following resources provide additional information about using Windows Update.
 
@@ -37,10 +36,11 @@ The following resources provide additional information about using Windows Updat
 [This script](https://gallery.technet.microsoft.com/scriptcenter/Reset-WindowsUpdateps1-e0c5eb78) will completely reset the Windows Update client settings. It has been tested on Windows 7, 8, 10, and Windows Server 2012 R2. It will configure the services and registry keys related to Windows Update for default settings. It will also clean up files related to Windows Update, in addition to BITS related data.
 
 
-[This script](https://gallery.technet.microsoft.com/scriptcenter/Reset-Windows-Update-Agent-d824badc) allow reset the Windows Update Agent resolving issues with Windows Update.
+[This script](https://gallery.technet.microsoft.com/scriptcenter/Reset-Windows-Update-Agent-d824badc) allows you to reset the Windows Update Agent, resolving issues with Windows Update.
 
 
 ## Reset Windows Update components manually
+
 1. Open a Windows command prompt. To open a command prompt, click **Start > Run**. Copy and paste (or type) the following command and then press ENTER:
    ```
    cmd
@@ -56,17 +56,22 @@ The following resources provide additional information about using Windows Updat
    ```
 4. If this is your first attempt at resolving your Windows Update issues by using the steps in this article, go to step 5 without carrying out the steps in step 4. The steps in step 4 should only be performed at this point in the troubleshooting if you cannot resolve your Windows Update issues after following all steps but step 4. The steps in step 4 are also performed by the "Aggressive" mode of the Fix it Solution above.
    1. Rename the following folders to *.BAK:
-      - %systemroot%\SoftwareDistribution\DataStore
-      - %systemroot%\SoftwareDistribution\Download
-      - %systemroot%\system32\catroot2
-
-      To do this, type the following commands at a command prompt. Press ENTER after you type each command.
-      - Ren %systemroot%\SoftwareDistribution\DataStore *.bak
-      - Ren %systemroot%\SoftwareDistribution\Download *.bak
-      - Ren %systemroot%\system32\catroot2 *.bak
+   ```
+   %systemroot%\SoftwareDistribution\DataStore
+   %systemroot%\SoftwareDistribution\Download
+   %systemroot%\system32\catroot2
+   ```
+   To do this, type the following commands at a command prompt. Press ENTER after you type each command.
+   ```
+   Ren %systemroot%\SoftwareDistribution\DataStore *.bak
+   Ren %systemroot%\SoftwareDistribution\Download *.bak
+   Ren %systemroot%\system32\catroot2 *.bak
+   ```
    2. Reset the BITS service and the Windows Update service to the default security descriptor. To do this, type the following commands at a command prompt. Press ENTER after you type each command.
-      - sc.exe sdset bits D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)
-      - sc.exe sdset wuauserv D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)
+   ```
+   sc.exe sdset bits D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)
+   sc.exe sdset wuauserv D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)
+   ```
 5. Type the following command at a command prompt, and then press ENTER:
    ```
    cd /d %windir%\system32


### PR DESCRIPTION
**Description:**

As reported in issue ticket #6953 (**Translations errors caused by missing code block**), there are several remaining lines of text directly referencing file paths and/or OS commands where the commands and their parameters get translated due to a lack of MarkDown code blocks.

Thanks to @sebbu2 for reporting this issue.
***
**Changes proposed:**
- Encapsulate (enclose) CLi commands and folder paths in MD back ticks
- Remove MD bullet point indicators from the encapsulated lines
***
- Whitespace & grammar corrections:
    - Normalize indentation, for the code blocks in particular
    - Add missing MarkDown indent marker compatibility spacing
    - Add blank line after H2 heading (MD codestyle standard)
    - Grammar improvement: "allow reset"  -> 'allows you to reset'
    - Add readability comma to the same sentence
    - Remove redundant blank line in the metadata section
***
**Ticket closure or reference:**

Closes #6953