### PR TITLE
Update mac-exclusions.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-exclusions.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-exclusions.md
@@ -50,7 +50,7 @@ File, folder, and process exclusions support the following wildcards:
 
 Wildcard | Description | Example | Matches | Does not match
 ---|---|---|---|---
-\* |	Matches any number of any characters including none (note that when this wildcard is used inside a path it will substitute only one folder) | `/var/\*/\*.log` | `/var/log/system.log` | `/var/log/nested/system.log`
+\* |	Matches any number of any characters including none (note that when this wildcard is used inside a path it will substitute only one folder) | `/var/*/*.log` | `/var/log/system.log` | `/var/log/nested/system.log`
 ? | Matches any single character | `file?.log` | `file1.log`<br/>`file2.log` | `file123.log`
 
 ## How to configure the list of exclusions


### PR DESCRIPTION
Remove extraneous escape characters in wildcard example, as not required within string?