### PR TITLE
Update configure-endpoints-vdi.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/configure-endpoints-vdi.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-endpoints-vdi.md
@@ -136,6 +136,7 @@ If offline servicing is not a viable option for your non-persistent VDI environm
     PsExec.exe -s cmd.exe
     cd "C:\ProgramData\Microsoft\Windows Defender Advanced Threat Protection\Cyber"
     del *.* /f /s /q
+    REG DELETE “HKLM\SOFTWARE\Microsoft\Windows Advanced Threat Protection" /v senseGuid /f
     exit
     ```
 


### PR DESCRIPTION
Adding line to remove senseGuid to prevent re-onboarding via PS1 issue.
Context:
When using the PS1 onboarding script, re-onboarding will fail if the senseGuid already exists from previous onboarding (even if machine is offboarded the senseGuid is not cleaned up automatically)