### PR TITLE
 #7048: link to the Microsoft Defender ATP portal, and reformat Ansible

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/linux-install-with-ansible.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/linux-install-with-ansible.md
@@ -35,14 +35,15 @@ This topic describes how to deploy Microsoft Defender ATP for Linux using Ansibl
 
 Before you get started, please see [the main Microsoft Defender ATP for Linux page](microsoft-defender-atp-linux.md) for a description of prerequisites and system requirements for the current software version.
 
+In addition, for Ansible deployment, you need to be familiar with Ansible administration tasks, have Ansible configured, and know how to deploy playbooks and tasks. Ansible has many ways to complete the same task. These instructions assume availability of supported Ansible modules, such as *apt* and *unarchive* to help deploy the package. Your organization might use a different workflow. Please refer to the [Ansible documentation](https://docs.ansible.com/) for details.
+
 - Ansible needs to be installed on at least on one computer (we will call it the master).
 - SSH must be configured for an administrator account between the master and all clients, and it is recommended be configured with public key authentication.
 - The following software must be installed on all clients:
   - curl
   - python-apt
-  - unzip
 
-- All hosts must be listed in the following format in the `/etc/ansible/hosts` file:
+- All hosts must be listed in the following format in the `/etc/ansible/hosts` or relevant file:
 
     ```bash
     [servers]
@@ -79,55 +80,32 @@ Download the onboarding package from Microsoft Defender Security Center:
 
 ## Create Ansible YAML files
 
-Create subtask or role files that contribute to an actual task. First create the `download_copy_blob.yml` file under the `/etc/ansible/roles` directory:
+Create a subtask or role files that contribute to an playbook or task.
 
-- Copy the onboarding package to all client devices:
-
-    ```bash
-    - name: Copy the zip file
-        copy:
-            src:  /root/WindowsDefenderATPOnboardingPackage.zip
-            dest: /root/WindowsDefenderATPOnboardingPackage.zip
-            owner: root
-            group: root
-            mode: '0644'
-
-    - name: Add Microsoft apt signing key
-      apt_key:
-        url: https://packages.microsoft.com/keys/microsoft.asc
-        state: present
-      when: ansible_os_family == "Debian"
-    ```
-
-- Create the `setup.sh` script that operates on the onboarding file, in this example located in the `/root` directory:
+- Create the onboarding task, `onboarding_setup.yml`:
 
     ```bash
-    #!/bin/bash
-    # We assume WindowsDefenderATPOnboardingPackage.zip is stored in /root
-    cd /root || exit 1
-    # Unzip the archive and create the onboarding file
-    mkdir -p /etc/opt/microsoft/mdatp/
-    unzip WindowsDefenderATPOnboardingPackage.zip
-    cp mdatp_onboard.json /etc/opt/microsoft/mdatp/mdatp_onboard.json
-    ```
+    - name: Create MDATP directories
+      file:
+        path: /etc/opt/microsoft/mdatp/
+        recurse: true
+        state: directory
+        mode: 0755
+        owner: root
+        group: root
 
-- Create the onboarding task, `onboarding_setup.yml`, under the `/etc/ansible/roles` directory:
-
-    ```bash
     - name: Register mdatp_onboard.json
-      stat: path=/etc/opt/microsoft/mdatp/mdatp_onboard.json
+      stat:
+        path: /etc/opt/microsoft/mdatp/mdatp_onboard.json
       register: mdatp_onboard
 
-    - name: Copy the setup script file
-        copy:
-            src: /root/setup.sh
-            dest: /root/setup.sh
-            owner: root
-            group: root
-            mode: '0744'
-
-    - name: Run a script to create the onboarding file
-      script: /root/setup.sh
+    - name: Extract WindowsDefenderATPOnboardingPackage.zip into /etc/opt/microsoft/mdatp
+      unarchive:
+        src: WindowsDefenderATPOnboardingPackage.zip
+        dest: /etc/opt/microsoft/mdatp
+        mode: 0600
+        owner: root
+        group: root
       when: not mdatp_onboard.stat.exists
     ```
 
@@ -150,18 +128,18 @@ Create subtask or role files that contribute to an actual task. First create the
     > In case of Oracle Linux, replace *[distro]* with “rhel”.
 
   ```bash
+  - name: Add Microsoft APT key
+      apt_key:
+          keyserver: https://packages.microsoft.com/
+          id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
+      when: ansible_os_family == "Debian"
+
   - name: Add Microsoft apt repository for MDATP
       apt_repository:
           repo: deb [arch=arm64,armhf,amd64] https://packages.microsoft.com/[distro]/[version]/prod [channel] main
           update_cache: yes
           state: present
           filename: microsoft-[channel].list
-      when: ansible_os_family == "Debian"
-
-  - name: Add Microsoft APT key
-      apt_key:
-          keyserver: https://packages.microsoft.com/
-          id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
       when: ansible_os_family == "Debian"
 
   - name: Add  Microsoft yum repository for MDATP
@@ -175,7 +153,7 @@ Create subtask or role files that contribute to an actual task. First create the
       when: ansible_os_family == "RedHat"
   ```
 
-- Create the actual install/uninstall YAML files under `/etc/ansible/playbooks`.
+- Create the Ansible install and uninstall YAML files.
 
     - For apt-based distributions use the following YAML file:
 
@@ -183,8 +161,7 @@ Create subtask or role files that contribute to an actual task. First create the
         $ cat install_mdatp.yml
         - hosts: servers
             tasks:
-                - include: ../roles/download_copy_blob.yml
-                - include: ../roles/setup_blob.yml
+                - include: ../roles/onboarding_setup.yml
                 - include: ../roles/add_apt_repo.yml
                 - apt:
                     name: mdatp
@@ -207,8 +184,7 @@ Create subtask or role files that contribute to an actual task. First create the
         $ cat install_mdatp_yum.yml
         - hosts: servers
         tasks:
-            - include: ../roles/download_copy_blob.yml
-            - include: ../roles/setup_blob.yml
+            - include: ../roles/onboarding_setup.yml
             - include: ../roles/add_yum_repo.yml
             - yum:
                 name: mdatp
@@ -227,7 +203,7 @@ Create subtask or role files that contribute to an actual task. First create the
 
 ## Deployment
 
-Now run the tasks files under `/etc/ansible/playbooks/`.
+Now run the tasks files under `/etc/ansible/playbooks/` or relevant directory.
 
 - Installation:
 

--- a/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-linux.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-linux.md
@@ -1,6 +1,6 @@
 ---
 title: Microsoft Defender ATP for Linux
-ms.reviewer: 
+ms.reviewer:
 description: Describes how to install and use Microsoft Defender ATP for Linux.
 keywords: microsoft, defender, atp, linux, installation, deploy, uninstallation, puppet, ansible, linux, redhat, ubuntu, debian, sles, suse, centos
 search.product: eADQiWindows 10XVcnh
@@ -14,7 +14,7 @@ author: dansimp
 ms.localizationpriority: medium
 manager: dansimp
 audience: ITPro
-ms.collection: M365-security-compliance 
+ms.collection: M365-security-compliance
 ms.topic: conceptual
 ---
 
@@ -39,7 +39,7 @@ There are several methods and deployment tools that you can use to install and c
 
 In general you need to take the following steps:
 
-- Ensure that you have a Microsoft Defender ATP subscription, and that you have access to the Microsoft Defender ATP portal.
+- Ensure that you have a Microsoft Defender ATP subscription, and that you have access to the [Microsoft Defender ATP portal](microsoft-defender-security-center.md).
 - Deploy Microsoft Defender ATP for Linux using one of the following deployment methods:
   - The command-line tool:
     - [Manual deployment](linux-install-manually.md)
@@ -51,7 +51,7 @@ If you experience any installation failures, refer to [Troubleshooting installat
 
 ### System requirements
 
-- Supported Linux server distributions and versions: 
+- Supported Linux server distributions and versions:
 
   - Red Hat Enterprise Linux 7.2 or higher
   - CentOS 7.2 or higher


### PR DESCRIPTION
In response to  #7048, this PR
- adds a link to the Microsoft Defender ATP portal from the microsoft-defender-atp-linux.md page
- reformats the Ansible instructions and removes the shell script dependency, it also adds a basic disclaimer about Ansible deployment (similar to the one present on the Puppet page).
 
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>