### PR TITLE
add missing URLs

### DIFF
--- a/windows/deployment/update/windows-update-troubleshooting.md
+++ b/windows/deployment/update/windows-update-troubleshooting.md
@@ -110,7 +110,8 @@ If downloads through a proxy server fail with a 0x80d05001 DO_E_HTTP_BLOCKSIZE_M
 You may choose to apply a rule to permit HTTP RANGE requests for the following URLs: 
 
 *.download.windowsupdate.com  
-*.dl.delivery.mp.microsoft.com  
+*.dl.delivery.mp.microsoft.com
+*.delivery.mp.microsoft.com
 *.emdl.ws.microsoft.com
 
 If you cannot permit RANGE requests, keep in mind that this means you are downloading more content than needed in updates (as delta patching will not work).
@@ -161,6 +162,10 @@ Check that your device can access these Windows Update endpoints:
 - `http://*.download.windowsupdate.com`
 - `http://wustat.windows.com`
 - `http://ntservicepack.microsoft.com`
+- `https://*.prod.do.dsp.mp.microsoft.com`
+- `http://*.dl.delivery.mp.microsoft.com`
+- `https://*.delivery.mp.microsoft.com`
+- `https://tsfe.trafficshaping.dsp.mp.microsoft.com`
  
  Allow these endpoints for future use.
  


### PR DESCRIPTION
Added missing URLs according to https://docs.microsoft.com/en-us/windows/privacy/manage-windows-1809-endpoints#windows-update

In my opinion some of them can be excluded (for example *.dl.delivery.mp.microsoft.com is already included in *.delivery.mp.microsoft.com), but i guess someone else should make that call. I have added all of them, just to be sure.

https://github.com/MicrosoftDocs/windows-itpro-docs/issues/6904