### PR TITLE
Update troubleshoot-onboarding.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/troubleshoot-onboarding.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/troubleshoot-onboarding.md
@@ -282,6 +282,10 @@ If the verification fails and your environment is using a proxy to connect to th
 
     ![Image of registry key for Microsoft Defender Antivirus](images/atp-disableantispyware-regkey.png)
 
+   > [!NOTE]
+   > In addition, you must ensure that wdfilter.sys and wdboot.sys are set to their default start values of "0".
+   >  - `<Key Path="SYSTEM\CurrentControlSet\Services\WdBoot"><KeyValue Value="0" ValueKind="DWord" Name="Start"/></Key>`
+   >  - `<Key Path="SYSTEM\CurrentControlSet\Services\WdFilter"><KeyValue Value="0" ValueKind="DWord" Name="Start"/></Key>`
 
 ## Troubleshoot onboarding issues on a server
 


### PR DESCRIPTION
Based on multiple support cases - some customers have WdFilter or WdBoot disabled and this blocks onboarding to Defender ATP.