### PR TITLE
Reorganize topics and fix broken links in CC topic

### DIFF
--- a/windows/security/threat-protection/windows-platform-common-criteria.md
+++ b/windows/security/threat-protection/windows-platform-common-criteria.md
@@ -15,159 +15,227 @@ ms.reviewer:
 
 # Common Criteria Certifications
 
-Microsoft is committed to optimizing the security of its products and services. As part of that commitment, Microsoft supports the Common Criteria certification program, continues to ensure that products incorporate the features and functions required by relevant Common Criteria protection profiles, and completes Common Criteria certifications of Microsoft Windows products.
+Microsoft is committed to optimizing the security of its products and services. As part of that commitment, Microsoft supports the Common Criteria certification program, ensures that products incorporate the features and functions required by relevant Common Criteria Protection Profiles, and completes Common Criteria certifications of Microsoft Windows products.  This topic lists the current and archived certified Windows products, together with relevant documentation from each certification.
 
-## Common Criteria Security Targets
+## Certified Products
 
-### Information for Systems Integrators and Accreditors
+The product releases below are currently certified against the cited Protection Profile, as listed on the [Common Criteria Portal](https://www.commoncriteriaportal.org/products/).  The Security Target describes the product edition(s) in scope, the security functionality in the product, and the assurance measures from the Protection Profile used as part of the evaluation.  The Administrative Guide provides guidance on configuring the product to match the evaluated configuration.  The Certification Report or Validation Report documents the results of the evaluation by the validation team, with the Assurance Activity Report providing details on the evaluator's actions.
 
-The Security Target describes security functionality and assurance measures used to evaluate Windows.
+### Microsoft Windows 10 and Windows Server (November 2019 Update, version 1909)
+Certified against the Protection Profile for General Purpose Operating Systems, including the Extended Package for Wireless Local Area Network Clients and the Module for Virtual Private Network Clients.
 
-- [Microsoft Windows 10 (November 2019 Update)](https://download.microsoft.com/download/b/3/7/b37981cf-040a-4b02-a93c-a3d3a93986bf/Windows%2010%201909%20GP%20OS%20Security%20Target.pdf)
-- [Microsoft Windows 10 (May 2019 Update)](https://download.microsoft.com/download/c/6/9/c6903621-901e-4603-b9cb-fbfe5d6aa691/Windows%2010%201903%20GP%20OS%20Security%20Target.pdf)
-- [Microsoft Windows 10 (October 2018 Update)](https://download.microsoft.com/download/3/f/e/3fe6938d-2c2d-4ef1-85d5-1d42dc68ea89/Windows%2010%20version%201809%20GP%20OS%20Security%20Target.pdf)
-- [Microsoft Windows 10 (April 2018 Update)](https://download.microsoft.com/download/0/7/6/0764E933-DD0B-45A7-9144-1DD9F454DCEF/Windows%2010%201803%20GP%20OS%20Security%20Target.pdf)
-- [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/B/6/A/B6A5EC2C-6351-4FB9-8FF1-643D4BD5BE6E/Windows%2010%201709%20GP%20OS%20Security%20Target.pdf)
-- [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/e/8/b/e8b8c42a-a0b6-4ba1-9bdc-e704e8289697/windows%2010%20version%201703%20gp%20os%20security%20target%20-%20public%20\(january%2016,%202018\)\(final\)\(clean\).pdf)
-- [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/1/c/3/1c3b5ab0-e064-4350-a31f-48312180d9b5/st_vid10823-st.pdf)
-- [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](https://download.microsoft.com/download/1/5/e/15eee6d3-f2a8-4441-8cb1-ce8c2ab91c24/windows%2010%20anniversary%20update%20mdf%20security%20target%20-%20public%20\(april%203%202017\).docx)
-- [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](https://download.microsoft.com/download/f/8/c/f8c1c2a4-719c-48ae-942f-9fd3ce5b238f/windows%2010%20au%20and%20server%202016%20gp%20os%20security%20target%20-%20public%20\(december%202%202016\)%20\(clean\).docx)
-- [Windows 10 (Anniversary Update) and Windows Server 2016 IPsec VPN Client](https://download.microsoft.com/download/b/f/5/bf59e430-e57b-462d-8dca-8ac3c93cfcff/windows%2010%20anniversary%20update%20ipsec%20vpn%20client%20security%20target%20-%20public%20\(december%2029%202016\)%20\(clean\).docx)
-- [Microsoft Windows 10 IPsec VPN Client](https://download.microsoft.com/download/3/7/2/372beb03-b1ed-4bb6-9b9b-b8f43afc570d/st_vid10746-st.pdf)
-- [Microsoft Windows 10 November 2015 Update with Surface Book](https://download.microsoft.com/download/a/c/2/ac2a6ed8-4d2f-4f48-a9bf-f059d6c9af38/windows%2010%20mdf3%20security%20target%20-%20public%20\(june%2022%202016\)\(final\).docx)
-- [Microsoft Windows 10 Mobile with Lumia 950, 950 XL, 550, 635, and Windows 10 with Surface Pro 4](https://www.niap-ccevs.org/st/st_vid10677-st.pdf)
-- [Windows 10 and Windows Server 2012 R2](https://www.commoncriteriaportal.org/files/epfiles/st_windows10.pdf)
-- [Windows 10](https://www.niap-ccevs.org/st/st_vid10677-st.pdf)
-- [Windows 8.1 with Surface 3 and Windows Phone 8.1 with Lumia 635 and Lumia 830](https://www.niap-ccevs.org/st/st_vid10635-st.pdf)
-- [Microsoft Surface Pro 3 and Windows 8.1](https://www.niap-ccevs.org/st/st_vid10632-st.pdf)
-- [Windows 8.1 and Windows Phone 8.1](https://www.niap-ccevs.org/st/st_vid10592-st.pdf)
-- [Windows 8 and Windows Server 2012](https://www.niap-ccevs.org/st/st_vid10520-st.pdf)
-- [Windows 8 and Windows RT](https://www.niap-ccevs.org/st/st_vid10620-st.pdf)
-- [Windows 8 and Windows Server 2012 BitLocker](https://www.commoncriteriaportal.org/files/epfiles/st_vid10540-st.pdf)
-- [Windows 8, Windows RT, and Windows Server 2012 IPsec VPN Client](https://www.commoncriteriaportal.org/files/epfiles/st_vid10529-st.pdf)
-- [Windows 7 and Windows Server 2008 R2](https://www.commoncriteriaportal.org/files/epfiles/st_vid10390-st.pdf)
-- [Microsoft Windows Server 2008 R2 Hyper-V Role](https://www.microsoft.com/download/en/details.aspx?id=29305)
-- [Windows Vista and Windows Server 2008 at EAL4+](https://www.commoncriteriaportal.org/files/epfiles/st_vid10291-st.pdf)
-- [Microsoft Windows Server 2008 Hyper-V Role](https://www.commoncriteriaportal.org/files/epfiles/0570b_pdf.pdf)
-- [Windows Vista and Windows Server 2008 at EAL1](https://www.commoncriteriaportal.org/files/epfiles/efs-t005_msvista_msserver2008_eal1_st_v1.0.pdf)
-- [Windows Server 2003 SP2 including R2, x64, and IA64; Windows XP Professional SP2 and x64 SP2; and Windows XP Embedded SP2](https://www.commoncriteriaportal.org/files/epfiles/st_vid10184-st.pdf)
-- [Windows Server 2003 Certificate Server](https://www.commoncriteriaportal.org/files/epfiles/st_vid9507-st.pdf)
-- [Windows Rights Management Services (RMS) 1.0 SP2](https://www.commoncriteriaportal.org/files/epfiles/st_vid10224-st.pdf)
+- [Security Target](https://download.microsoft.com/download/b/3/7/b37981cf-040a-4b02-a93c-a3d3a93986bf/Windows%2010%201909%20GP%20OS%20Security%20Target.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/7/7/3/77303254-05fb-4009-8a39-bf5fe7484a41/Windows%2010%201909%20GP%20OS%20Administrative%20Guide.pdf)
+- [Certification Report](https://download.microsoft.com/download/9/f/3/9f350b73-1790-4dcb-97f7-a0e65a00b55f/Windows%2010%201909%20GP%20OS%20Certification%20Report.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/0/0/d/00d26b48-a051-4e9a-8036-850d825f8ef9/Windows%2010%201909%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-## Common Criteria Deployment and Administration
+### Microsoft Windows 10 and Windows Server (May 2019 Update, version 1903)
+Certified against the Protection Profile for General Purpose Operating Systems, including the Extended Package for Wireless Local Area Network Clients.
 
-### Information for IT Administrators
+- [Security Target](https://download.microsoft.com/download/c/6/9/c6903621-901e-4603-b9cb-fbfe5d6aa691/Windows%2010%201903%20GP%20OS%20Security%20Target.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/0/b/b/0bb1c6b7-499a-458e-a5f8-e9cf972dfa8d/Windows%2010%201903%20GP%20OS%20Administrative%20Guide.pdf)
+- [Certification Report](https://download.microsoft.com/download/2/1/9/219909ad-2f2a-44cc-8fcb-126f28c74d36/Windows%2010%201903%20GP%20OS%20Certification%20Report.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/2/a/1/2a103b68-cd12-4476-8945-873746b5f432/Windows%2010%201903%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-These documents describe how to configure Windows to replicate the configuration used during the Common Criteria evaluation.
+### Microsoft Windows 10 and Windows Server (October 2018 Update, version 1809)
+Certified against the Protection Profile for General Purpose Operating Systems, including the Extended Package for Wireless Local Area Network Clients.
 
-**Windows 10, Windows 10 Mobile, Windows Server 2016, Windows Server 2012 R2**
+- [Security Target](https://download.microsoft.com/download/3/f/e/3fe6938d-2c2d-4ef1-85d5-1d42dc68ea89/Windows%2010%20version%201809%20GP%20OS%20Security%20Target.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/f/f/1/ff186e32-35cf-47db-98b0-91ff11763d74/Windows%2010%20version%201809%20GP%20OS%20Administrative%20Guide.pdf)
+- [Certification Report](https://download.microsoft.com/download/9/4/0/940ac551-7757-486d-9da1-7aa0300ebac0/Windows%2010%20version%201809%20GP%20OS%20Certification%20Report%20-%202018-61-INF-2795.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/a/6/6/a66bfcf1-f6ef-4991-ab06-5b1c01f91983/Windows%2010%201809%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-- [Microsoft Windows 10 (November 2019 Update)](https://download.microsoft.com/download/7/7/3/77303254-05fb-4009-8a39-bf5fe7484a41/Windows%2010%201909%20GP%20OS%20Administrative%20Guide.pdf)
-- [Microsoft Windows 10 (May 2019 Update)](https://download.microsoft.com/download/0/b/b/0bb1c6b7-499a-458e-a5f8-e9cf972dfa8d/Windows%2010%201903%20GP%20OS%20Administrative%20Guide.pdf)
-- [Microsoft Windows 10 (October 2018 Update)](https://download.microsoft.com/download/f/f/1/ff186e32-35cf-47db-98b0-91ff11763d74/Windows%2010%20version%201809%20GP%20OS%20Administrative%20Guide.pdf)
-- [Microsoft Windows 10 (April 2018 Update)](https://download.microsoft.com/download/6/C/1/6C13FBFF-9CB0-455F-A1C8-3E3CB0ACBD7B/Windows%2010%201803%20GP%20OS%20Administrative%20Guide.pdf)
-- [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/5/D/2/5D26F473-0FCE-4AC4-9065-6AEC0FE5B693/Windows%2010%201709%20GP%20OS%20Administrative%20Guide.pdf)
-- [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/e/9/7/e97f0c7f-e741-4657-8f79-2c0a7ca928e3/windows%2010%20cu%20gp%20os%20operational%20guidance%20\(jan%208%202017%20-%20public\).pdf)
-- [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/d/c/4/dc40b5c8-49c2-4587-8a04-ab3b81eb6fc4/st_vid10823-agd.pdf)
-- [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](https://download.microsoft.com/download/4/c/1/4c1f4ea4-2d66-4232-a0f5-925b2bc763bc/windows%2010%20au%20operational%20guidance%20\(16%20mar%202017\)\(clean\).docx)
-- [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](https://download.microsoft.com/download/b/5/2/b52e9081-05c6-4895-91a3-732bfa0eb4da/windows%2010%20au%20and%20server%202016%20gp%20os%20operational%20guidance%20\(final\).docx)
-- [Windows 10 (Anniversary Update) and Windows Server 2016 IPsec VPN Client Operational Guidance](https://download.microsoft.com/download/2/c/c/2cc8f929-233e-4a40-b673-57b449680984/windows%2010%20au%20and%20server%202016%20ipsec%20vpn%20client%20operational%20guidance%20\(21%20dec%202016\)%20\(public\).docx)
-- [Microsoft Windows 10 IPsec VPN Client](https://download.microsoft.com/download/3/3/f/33fa01dd-b380-46e1-833f-fd85854b4022/st_vid10746-agd.pdf)
-- [Microsoft Windows 10 November 2015 Update with Surface Book Administrative Guide](https://download.microsoft.com/download/3/2/c/32c6fa02-b194-478f-a0f6-0215b47d0f40/windows%2010%20mdf3%20mobile%20device%20pp%20operational%20guidance%20\(may%2027,%202016\)\(public\).docx)
-- [Microsoft Windows 10 Mobile and Windows 10 Administrative Guide](https://download.microsoft.com/download/2/d/c/2dce3435-9328-48e2-9813-c2559a8d39fa/microsoft%20windows%2010%20and%20windows%2010%20mobile%20guidance.pdf)
-- [Windows 10 and Windows Server 2012 R2 Administrative Guide](https://download.microsoft.com/download/0/f/d/0fd33c9a-98ac-499e-882f-274f80f3d4f0/microsoft%20windows%2010%20and%20server%202012%20r2%20gp%20os%20guidance.pdf)
-- [Windows 10 Common Criteria Operational Guidance](https://download.microsoft.com/download/d/6/f/d6fb4cec-f0f2-4d00-ab2e-63bde3713f44/windows%2010%20mobile%20device%20operational%20guidance.pdf)
+### Microsoft Windows 10 and Windows Server (April 2018 Update, version 1803)
+Certified against the Protection Profile for General Purpose Operating Systems, including the Extended Package for Wireless Local Area Network Clients.
 
-**Windows 8.1 and Windows Phone 8.1**
+- [Security Target](https://download.microsoft.com/download/0/7/6/0764E933-DD0B-45A7-9144-1DD9F454DCEF/Windows%2010%201803%20GP%20OS%20Security%20Target.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/6/C/1/6C13FBFF-9CB0-455F-A1C8-3E3CB0ACBD7B/Windows%2010%201803%20GP%20OS%20Administrative%20Guide.pdf)
+- [Certification Report](https://download.microsoft.com/download/6/7/1/67167BF2-885D-4646-A61E-96A0024B52BB/Windows%2010%201803%20GP%20OS%20Certification%20Report.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/b/3/d/b3da41b6-6ebc-4a26-a581-2d2ad8d8d1ac/Windows%2010%201803%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-- [Microsoft Surface Pro 3 Common Criteria Mobile Operational Guidance](https://download.microsoft.com/download/b/e/3/be365594-daa5-4af3-a6b5-9533d61eae32/surface%20pro%203%20mobile%20operational%20guidance.docx)
-- [Windows 8.1 and Windows Phone 8.1 CC Supplemental Admin Guide](https://download.microsoft.com/download/b/0/e/b0e30225-5017-4241-ac0a-6c40bc8e6714/mobile%20operational%20guidance.docx)
+### Microsoft Windows 10 and Windows Server (Fall Creators Update, version 1709)
+Certified against the Protection Profile for General Purpose Operating Systems.
 
-**Windows 8, Windows RT, and Windows Server 2012**
+- [Security Target](https://download.microsoft.com/download/B/6/A/B6A5EC2C-6351-4FB9-8FF1-643D4BD5BE6E/Windows%2010%201709%20GP%20OS%20Security%20Target.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/5/D/2/5D26F473-0FCE-4AC4-9065-6AEC0FE5B693/Windows%2010%201709%20GP%20OS%20Administrative%20Guide.pdf)
+- [Certification Report](https://download.microsoft.com/download/2/C/2/2C20D013-0610-4047-B2FA-516819DFAE0A/Windows%2010%201709%20GP%20OS%20Certification%20Report.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/e/7/6/e7644e3c-1e59-4754-b071-aec491c71849/Windows%2010%201709%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-- [Windows 8 and Windows Server 2012](https://download.microsoft.com/download/6/0/b/60b27ded-705a-4751-8e9f-642e635c3cf3/microsoft%20windows%208%20windows%20server%202012%20common%20criteria%20supplemental%20admin%20guidance.docx)
-- [Windows 8 and Windows RT](https://download.microsoft.com/download/8/6/e/86e8c001-8556-4949-90cf-f5beac918026/microsoft%20windows%208%20microsoft%20windows%20rt%20common%20criteria%20supplemental%20admin.docx)
-- [Windows 8 and Windows Server 2012 BitLocker](https://download.microsoft.com/download/0/8/4/08468080-540b-4326-91bf-f2a33b7e1764/administrative%20guidance%20for%20software%20full%20disk%20encryption%20clients.pdf)
-- [Windows 8, Windows RT, and Windows Server 2012 IPsec VPN Client](https://download.microsoft.com/download/a/9/f/a9fd7e2d-023b-4925-a62f-58a7f1a6bd47/microsoft%20windows%208%20windows%20server%202012%20supplemental%20admin%20guidance%20ipsec%20vpn%20client.docx)
+### Microsoft Windows 10 (Creators Update, version 1703)
+Certified against the Protection Profile for General Purpose Operating Systems.
 
-**Windows 7 and Windows Server 2008 R2**
+- [Security Target](https://download.microsoft.com/download/e/8/b/e8b8c42a-a0b6-4ba1-9bdc-e704e8289697/windows%2010%20version%201703%20gp%20os%20security%20target%20-%20public%20\(january%2016,%202018\)\(final\)\(clean\).pdf)
+- [Administrative Guide](https://download.microsoft.com/download/e/9/7/e97f0c7f-e741-4657-8f79-2c0a7ca928e3/windows%2010%20cu%20gp%20os%20operational%20guidance%20\(jan%208%202017%20-%20public\).pdf)
+- [Certification Report](https://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/a/e/9/ae9a2235-e1cd-4869-964d-c8260f604367/Windows%2010%201703%20GP%20OS%20Assurance%20Activity%20Report.pdf) 
 
-- [Windows 7 and Windows Server 2008 R2 Supplemental CC Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=ee05b6d0-9939-4765-9217-63083bb94a00)
-- [Windows Server 2008 R2 Hyper-V Common Criteria Configuration Guide](https://www.microsoft.com/download/en/details.aspx?id=29308)
+### Microsoft Windows 10 (Anniversary Update, version 1607) and Windows Server 2016
+Certified against the Protection Profile for General Purpose Operating Systems.
 
-**Windows Vista and Windows Server 2008**
+- [Security Target](https://download.microsoft.com/download/f/8/c/f8c1c2a4-719c-48ae-942f-9fd3ce5b238f/windows%2010%20au%20and%20server%202016%20gp%20os%20security%20target%20-%20public%20\(december%202%202016\)%20\(clean\).docx)
+- [Administrative Guide](https://download.microsoft.com/download/b/5/2/b52e9081-05c6-4895-91a3-732bfa0eb4da/windows%2010%20au%20and%20server%202016%20gp%20os%20operational%20guidance%20\(final\).docx)
+- [Validation Report](https://download.microsoft.com/download/5/4/8/548cc06e-c671-4502-bebf-20d38e49b731/2016-36-inf-1779.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/a/5/f/a5f08a43-75f9-4433-bd77-aeb14276e587/Windows%2010%201607%20GP%20OS%20Assurance%20Activity%20Report.pdf)
 
-- [Windows Vista and Windows Server 2008 Supplemental CC Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=06166288-24c4-4c42-9daa-2b2473ddf567)
-- [Windows Server 2008 Hyper-V Role Common Criteria Administrator Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=cb19538d-9e13-4ab6-af38-8f48abfdad08)
+### Microsoft Windows 10 (version 1507) and Windows Server 2012 R2
+Certified against the Protection Profile for General Purpose Operating Systems.
 
-**Windows Server 2003 SP2 including R2, x64, and Itanium**
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_windows10.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/0/f/d/0fd33c9a-98ac-499e-882f-274f80f3d4f0/microsoft%20windows%2010%20and%20server%202012%20r2%20gp%20os%20guidance.pdf)
+- [Certification Report](https://www.commoncriteriaportal.org/files/epfiles/cr_windows10.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/7/e/5/7e5575c9-10f9-4f3d-9871-bd7cf7422e3b/Windows%2010%20(1507),%20Windows%20Server%202012%20R2%20GPOS%20Assurance%20Activity%20Report.pdf)
 
-- [Windows Server 2003 SP2 R2 Common Criteria Administrator Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=39598841-e693-4891-9234-cfd1550f3949)
-- [Windows Server 2003 SP2 R2 Common Criteria Configuration Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=4f7b6a93-0307-480f-a5af-a20268cbd7cc)
+## Archived Certified Products
 
-**Windows Server 2003 SP1(x86), x64, and IA64**
+The product releases below were certified against the cited Protection Profile and are now archived, as listed on the [Common Criteria Portal](https://www.commoncriteriaportal.org/products/index.cfm?archived=1).  The Security Target describes the product edition(s) in scope, the security functionality in the product, and the assurance measures from the Protection Profile used as part of the evaluation.  The Administrative Guide provides guidance on configuring the product to match the evaluated configuration.  The Validation Report documents the results of the evaluation by the validation team, with the Assurance Activity Report, where available, providing details on the evaluator's actions.
 
+### Microsoft Windows Server 2016, Windows Server 2012 R2, and Windows 10
+Certified against the Protection Profile for Server Virtualization. 
+
+- [Security Target](https://download.microsoft.com/download/1/c/3/1c3b5ab0-e064-4350-a31f-48312180d9b5/st_vid10823-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/d/c/4/dc40b5c8-49c2-4587-8a04-ab3b81eb6fc4/st_vid10823-agd.pdf)
+- [Validation Report](https://download.microsoft.com/download/a/3/3/a336f881-4ac9-4c79-8202-95289f86bb7a/st_vid10823-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/3/f/c/3fcc76e1-d471-4b44-9a19-29e69b6ab899/Windows%2010%20Hyper-V,%20Server%202016,%20Server%202012%20R2%20Virtualization%20Assurance%20Activity%20Report.pdf)
+
+### Microsoft Windows 10 and Windows 10 Mobile (Anniversary Update, version 1607)
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://download.microsoft.com/download/1/5/e/15eee6d3-f2a8-4441-8cb1-ce8c2ab91c24/windows%2010%20anniversary%20update%20mdf%20security%20target%20-%20public%20\(april%203%202017\).docx)
+- [Administrative Guide](https://download.microsoft.com/download/4/c/1/4c1f4ea4-2d66-4232-a0f5-925b2bc763bc/windows%2010%20au%20operational%20guidance%20\(16%20mar%202017\)\(clean\).docx)
+- [Validation Report](https://download.microsoft.com/download/f/2/f/f2f7176e-34f4-4ab0-993c-6606d207bb3c/st_vid10752-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/9/3/9/939b44a8-5755-4d4c-b020-d5e8b89690ab/Windows%2010%20and%20Windows%2010%20Mobile%201607%20MDF%20Assurance%20Activity%20Report.pdf) 
+
+### Microsoft Windows 10 (Anniversary Update, version 1607) and Windows Server 2016
+Certified against the Protection Profile for IPsec Virtual Private Network (VPN) Clients.
+
+- [Security Target](https://download.microsoft.com/download/b/f/5/bf59e430-e57b-462d-8dca-8ac3c93cfcff/windows%2010%20anniversary%20update%20ipsec%20vpn%20client%20security%20target%20-%20public%20\(december%2029%202016\)%20\(clean\).docx)
+- [Administrative Guide](https://download.microsoft.com/download/2/c/c/2cc8f929-233e-4a40-b673-57b449680984/windows%2010%20au%20and%20server%202016%20ipsec%20vpn%20client%20operational%20guidance%20\(21%20dec%202016\)%20\(public\).docx)
+- [Validation Report](https://download.microsoft.com/download/2/0/a/20a8e686-3cd9-43c4-a22a-54b552a9788a/st_vid10753-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/b/8/d/b8ddc36a-408a-4d64-a31c-d41c9c1e9d9e/Windows%2010%201607,%20Windows%20Server%202016%20IPsec%20VPN%20Client%20Assurance%20Activity%20Report.pdf)
+
+### Microsoft Windows 10 (November 2015 Update, version 1511)
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://download.microsoft.com/download/a/c/2/ac2a6ed8-4d2f-4f48-a9bf-f059d6c9af38/windows%2010%20mdf3%20security%20target%20-%20public%20\(june%2022%202016\)\(final\).docx)
+- [Administrative Guide](https://download.microsoft.com/download/3/2/c/32c6fa02-b194-478f-a0f6-0215b47d0f40/windows%2010%20mdf3%20mobile%20device%20pp%20operational%20guidance%20\(may%2027,%202016\)\(public\).docx)
+- [Validation Report](https://download.microsoft.com/download/d/c/b/dcb7097d-1b9f-4786-bb07-3c169fefb579/st_vid10715-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/1/f/1/1f12ed80-6d73-4a16-806f-d5116814bd7c/Windows%2010%20November%202015%20Update%20(1511)%20MDF%20Assurance%20Activity%20Report.pdf)
+
+### Microsoft Windows 10 and Windows 10 Mobile (version 1507)
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10677-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/2/d/c/2dce3435-9328-48e2-9813-c2559a8d39fa/microsoft%20windows%2010%20and%20windows%2010%20mobile%20guidance.pdf)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10694-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/a/1/3/a1365491-0a53-42cd-bd73-ca4067c43d86/Windows%2010,%20Windows%2010%20Mobile%20(1507)%20MDF%20Assurance%20Activity%20Report.pdf)
+
+### Microsoft Windows 10 (version 1507)
+Certified against the Protection Profile for IPsec Virtual Private Network (VPN) Clients.
+
+- [Security Target](https://download.microsoft.com/download/3/7/2/372beb03-b1ed-4bb6-9b9b-b8f43afc570d/st_vid10746-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/3/3/f/33fa01dd-b380-46e1-833f-fd85854b4022/st_vid10746-agd.pdf)
+- [Validation Report](https://download.microsoft.com/download/9/b/6/9b633763-6078-48aa-b9ba-960da2172a11/st_vid10746-vr.pdf)
+- [Assurance Activity Report](https://download.microsoft.com/download/9/3/6/93630ffb-5c06-4fea-af36-164da3e359c9/Windows%2010%20IPsec%20VPN%20Client%20Assurance%20Activity%20Report.pdf)
+
+### Windows 8.1 with Surface 3 and Windows Phone 8.1 with Lumia 635 and Lumia 830
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10635-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/b/e/3/be365594-daa5-4af3-a6b5-9533d61eae32/surface%20pro%203%20mobile%20operational%20guidance.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10635-vr.pdf)
+
+### Microsoft Surface Pro 3 and Windows 8.1
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10632-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/b/e/3/be365594-daa5-4af3-a6b5-9533d61eae32/surface%20pro%203%20mobile%20operational%20guidance.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10632-vr.pdf)
+
+### Windows 8.1 and Windows Phone 8.1
+Certified against the Protection Profile for Mobile Device Fundamentals.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10592-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/b/0/e/b0e30225-5017-4241-ac0a-6c40bc8e6714/mobile%20operational%20guidance.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10592-vr.pdf)
+
+### Windows 8 and Windows Server 2012
+Certified against the Protection Profile for General Purpose Operating Systems.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10520-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/6/0/b/60b27ded-705a-4751-8e9f-642e635c3cf3/microsoft%20windows%208%20windows%20server%202012%20common%20criteria%20supplemental%20admin%20guidance.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10520-vr.pdf)
+
+### Windows 8 and Windows RT
+Certified against the Protection Profile for General Purpose Operating Systems.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10620-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/8/6/e/86e8c001-8556-4949-90cf-f5beac918026/microsoft%20windows%208%20microsoft%20windows%20rt%20common%20criteria%20supplemental%20admin.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10620-vr.pdf)
+
+### Windows 8 and Windows Server 2012 BitLocker
+Certified against the Protection Profile for Full Disk Encryption.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10540-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/0/8/4/08468080-540b-4326-91bf-f2a33b7e1764/administrative%20guidance%20for%20software%20full%20disk%20encryption%20clients.pdf)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10540-vr.pdf)
+
+### Windows 8, Windows RT, and Windows Server 2012 IPsec VPN Client
+Certified against the Protection Profile for IPsec Virtual Private Network (VPN) Clients.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10529-st.pdf)
+- [Administrative Guide](https://download.microsoft.com/download/a/9/f/a9fd7e2d-023b-4925-a62f-58a7f1a6bd47/microsoft%20windows%208%20windows%20server%202012%20supplemental%20admin%20guidance%20ipsec%20vpn%20client.docx)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10529-vr.pdf)
+
+### Windows 7 and Windows Server 2008 R2
+Certified against the Protection Profile for General Purpose Operating Systems.
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10390-st.pdf)
+- [Administrative Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=ee05b6d0-9939-4765-9217-63083bb94a00)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10390-vr.pdf)
+
+### Microsoft Windows Server 2008 R2 Hyper-V Role
+
+- [Security Target](https://www.microsoft.com/download/en/details.aspx?id=29305)
+- [Administrative Guide](https://www.microsoft.com/download/en/details.aspx?id=29308)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/0570a_pdf.pdf)
+
+### Windows Vista and Windows Server 2008 at EAL4+
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10291-st.pdf)
+- [Administrative Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=06166288-24c4-4c42-9daa-2b2473ddf567)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10291-vr.pdf)
+
+### Windows Vista and Windows Server 2008 at EAL1
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/efs-t005_msvista_msserver2008_eal1_st_v1.0.pdf)
+- [Administrative Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=06166288-24c4-4c42-9daa-2b2473ddf567)
+- [Certification Report](https://www.commoncriteriaportal.org/files/epfiles/efs-t005_msvista_msserver2008_eal1_cr_v1.0.pdf)
+
+### Microsoft Windows Server 2008 Hyper-V Role
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/0570b_pdf.pdf)
+- [Administrative Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=cb19538d-9e13-4ab6-af38-8f48abfdad08)
+- [Certification Report](http://www.commoncriteriaportal.org:80/files/epfiles/0570a_pdf.pdf) 
+
+### Windows XP and Windows Server 2003
+
+- [Security Target - Windows Server 2003 SP2 including R2, x64, and IA64; Windows XP Professional SP2 and x64 SP2; and Windows XP Embedded SP2](https://www.commoncriteriaportal.org/files/epfiles/st_vid10184-st.pdf)
+- [Identifying Windows XP and Windows Server 2003 Common Criteria Certified Requirements for the NIST Special Publication 800-53](https://download.microsoft.com/download/a/9/6/a96d1dfc-2bd4-408d-8d93-e0ede7529691/xpws03_ccto800-53.doc)
+- [Windows Server 2003 SP2 R2 Administrator Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=39598841-e693-4891-9234-cfd1550f3949)
+- [Windows Server 2003 SP2 R2 Configuration Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=4f7b6a93-0307-480f-a5af-a20268cbd7cc)
+- [Windows Server 2003 SP1 Administrator's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=75736009-59e9-4a71-879e-cf581817b8cc)
+- [Windows Server 2003 SP1 Configuration Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=a0ad1856-beb7-4285-b47c-381e8a210c38)
 - [Windows Server 2003 with x64 Hardware Administrator's Guide](https://www.microsoft.com/downloads/details.aspx?familyid=8a26829f-c177-4b79-913a-4135fb7b96ef)
 - [Windows Server 2003 with x64 Hardware Configuration Guide](https://www.microsoft.com/downloads/details.aspx?familyid=3f9ecd0a-74dd-4d23-a4e5-d7b63fed70e8)
-
-**Windows Server 2003 SP1**
-
-- [Windows Server 2003 Administrator's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=75736009-59e9-4a71-879e-cf581817b8cc)
-- [Windows Server 2003 Configuration Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=a0ad1856-beb7-4285-b47c-381e8a210c38)
-
-**Windows XP Professional SP2 (x86) and x64 Edition**
-
-- [Windows XP Common Criteria Administrator Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=9a7f0b16-72ce-4675-aec8-58785c4e37ee)
-- [Windows XP Common Criteria Configuration Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=165da57d-f066-4ddf-9462-cbecfcd68694)
-- [Windows XP Common Criteria User Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=7c1a4761-9b9e-429c-84eb-cd7b034c5779)
+- [Windows XP Administrator Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=9a7f0b16-72ce-4675-aec8-58785c4e37ee)
+- [Windows XP Configuration Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=165da57d-f066-4ddf-9462-cbecfcd68694)
+- [Windows XP User Guide 3.0](https://www.microsoft.com/downloads/details.aspx?familyid=7c1a4761-9b9e-429c-84eb-cd7b034c5779)
 - [Windows XP Professional with x64 Hardware Administrator's Guide](https://www.microsoft.com/downloads/details.aspx?familyid=346f041e-d641-4af7-bdea-c5a3246d0431)
 - [Windows XP Professional with x64 Hardware Configuration Guide](https://www.microsoft.com/downloads/details.aspx?familyid=a7075319-cc3d-4420-a00b-8c9a7068ad54)
 - [Windows XP Professional with x64 Hardware User’s Guide](https://www.microsoft.com/downloads/details.aspx?familyid=26c49cf5-6159-4197-97ce-bf1fdfc54569)
-
-**Windows XP Professional SP2, and XP Embedded SP2**
-
 - [Windows XP Professional Administrator's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=9bcac470-a0b3-4d34-a561-fa8308c0ff60)
 - [Windows XP Professional Configuration Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=9f04915e-571a-422d-8ffa-5797051e81de)
 - [Windows XP Professional User's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=d39d0028-7093-495c-80da-2b5b29a54bd8)
-
-**Windows Server 2003 Certificate Server**
-
-- [Windows Server 2003 Certificate Server Administrator's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=445093d8-45e2-4cf6-884c-8802c1e6cb2d)
-- [Windows Server 2003 Certificate Server Configuration Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=46abc8b5-11be-4e3d-85c2-63226c3688d2)
-- [Windows Server 2003 Certificate Server User's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=74f66d84-2654-48d0-b9b5-b383d383425e)
-
-## Common Criteria Evaluation Technical Reports and Certification / Validation Reports
-
-### Information for Systems Integrators and Accreditors
-
-An Evaluation Technical Report (ETR) is a report submitted to the Common Criteria certification authority for how Windows complies with the claims made in the Security Target. A Certification / Validation Report provides the results of the evaluation by the validation team.
-
-- [Microsoft Windows 10 (November 2019 Update)](https://download.microsoft.com/download/9/f/3/9f350b73-1790-4dcb-97f7-a0e65a00b55f/Windows%2010%201909%20GP%20OS%20Certification%20Report.pdf)
-- [Microsoft Windows 10 (May 2019 Update)](https://download.microsoft.com/download/2/1/9/219909ad-2f2a-44cc-8fcb-126f28c74d36/Windows%2010%201903%20GP%20OS%20Certification%20Report.pdf)
-- [Microsoft Windows 10 (October 2018 Update)](https://download.microsoft.com/download/9/4/0/940ac551-7757-486d-9da1-7aa0300ebac0/Windows%2010%20version%201809%20GP%20OS%20Certification%20Report%20-%202018-61-INF-2795.pdf)
-- [Microsoft Windows 10 (April 2018 Update)](https://download.microsoft.com/download/6/7/1/67167BF2-885D-4646-A61E-96A0024B52BB/Windows%2010%201803%20GP%20OS%20Certification%20Report.pdf)
-- [Microsoft Windows 10 (Fall Creators Update)](https://download.microsoft.com/download/2/C/2/2C20D013-0610-4047-B2FA-516819DFAE0A/Windows%2010%201709%20GP%20OS%20Certification%20Report.pdf) 
-- [Microsoft Windows 10 (Creators Update)](https://download.microsoft.com/download/3/2/c/32cdf627-dd23-4266-90ff-2f9685fd15c0/2017-49%20inf-2218%20cr.pdf)
-- [Microsoft Windows Server 2016, Microsoft Windows Server 2012 R2, and Microsoft Windows 10 Hyper-V](https://download.microsoft.com/download/a/3/3/a336f881-4ac9-4c79-8202-95289f86bb7a/st_vid10823-vr.pdf)
-- [Microsoft Windows 10 (Anniversary Update) and Windows 10 Mobile (Anniversary Update)](https://download.microsoft.com/download/f/2/f/f2f7176e-34f4-4ab0-993c-6606d207bb3c/st_vid10752-vr.pdf)
-- [Microsoft Windows 10 (Anniversary Update) and Windows Server 2016](https://download.microsoft.com/download/5/4/8/548cc06e-c671-4502-bebf-20d38e49b731/2016-36-inf-1779.pdf)
-- [Windows 10 (Anniversary Update) and Windows Server 2016 IPsec VPN Client](https://download.microsoft.com/download/2/0/a/20a8e686-3cd9-43c4-a22a-54b552a9788a/st_vid10753-vr.pdf)
-- [Microsoft Windows 10 IPsec VPN Client](https://download.microsoft.com/download/9/b/6/9b633763-6078-48aa-b9ba-960da2172a11/st_vid10746-vr.pdf)
-- [Microsoft Windows 10 November 2015 Update with Surface Book](https://download.microsoft.com/download/d/c/b/dcb7097d-1b9f-4786-bb07-3c169fefb579/st_vid10715-vr.pdf)
-- [Microsoft Windows 10 Mobile with Lumia 950, 950 XL, 550, 635, and Windows 10 with Surface Pro 4](https://www.niap-ccevs.org/st/st_vid10694-vr.pdf)
-- [Windows 10 and Windows Server 2012 R2](https://www.commoncriteriaportal.org/files/epfiles/cr_windows10.pdf)
-- [Windows 10](https://www.niap-ccevs.org/st/st_vid10677-vr.pdf)
-- [Windows 8.1 with Surface 3 and Windows Phone 8.1 with Lumia 635 and Lumia 830](https://www.niap-ccevs.org/st/st_vid10635-vr.pdf)
-- [Microsoft Surface Pro 3 and Windows 8.1](https://www.niap-ccevs.org/st/st_vid10632-vr.pdf)
-- [Windows 8.1 and Windows Phone 8.1](https://www.niap-ccevs.org/st/st_vid10592-vr.pdf)
-- [Windows 8 and Windows Server 2012](https://www.niap-ccevs.org/st/st_vid10520-vr.pdf)
-- [Windows 8 and Windows RT](https://www.niap-ccevs.org/st/st_vid10620-vr.pdf)
-- [Windows 8 and Windows Server 2012 BitLocker](https://www.commoncriteriaportal.org/files/epfiles/st_vid10540-vr.pdf)
-- [Windows 8, Windows RT, and Windows Server 2012 IPsec VPN Client](https://www.commoncriteriaportal.org/files/epfiles/st_vid10529-vr.pdf)
-- [Windows 7 and Windows Server 2008 R2 Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10390-vr.pdf)
-- [Windows Vista and Windows Server 2008 Validation Report at EAL4+](https://www.commoncriteriaportal.org/files/epfiles/st_vid10291-vr.pdf)
-- [Windows Server 2008 Hyper-V Role Certification Report](https://www.commoncriteriaportal.org/files/epfiles/0570a_pdf.pdf)
-- [Windows Vista and Windows Server 2008 Certification Report at EAL1](https://www.commoncriteriaportal.org/files/epfiles/efs-t005_msvista_msserver2008_eal1_cr_v1.0.pdf)
 - [Windows XP / Windows Server 2003 with x64 Hardware ETR](https://www.microsoft.com/downloads/details.aspx?familyid=6e8d98f9-25b9-4c85-9bd9-24d91ea3c9ef)
 - [Windows XP / Windows Server 2003 with x64 Hardware ETR, Part II](https://www.microsoft.com/downloads/details.aspx?familyid=0c35e7d8-9c56-4686-b902-d5ffb9915658)
 - [Windows Server 2003 SP2 including R2, Standard, Enterprise, Datacenter, x64, and Itanium Editions Validation Report](https://www.commoncriteriaportal.org/files/epfiles/20080303_st_vid10184-vr.pdf)
@@ -175,10 +243,17 @@ An Evaluation Technical Report (ETR) is a report submitted to the Common Criteri
 - [Windows XP Embedded SP2 Validation Report](https://www.commoncriteriaportal.org/files/epfiles/20080303_st_vid10184-vr.pdf)
 - [Windows XP and Windows Server 2003 ETR](https://www.microsoft.com/downloads/details.aspx?familyid=63cf2a1e-f578-4bb5-9245-d411f0f64265)
 - [Windows XP and Windows Server 2003 Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid9506-vr.pdf)
-- [Windows Server 2003 Certificate Server ETR](https://www.microsoft.com/downloads/details.aspx?familyid=a594e77f-dcbb-4787-9d68-e4689e60a314)
-- [Windows Server 2003 Certificate Server Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid9507-vr.pdf)
-- [Microsoft Windows Rights Management Services (RMS) 1.0 SP2 Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10224-vr.pdf)
 
-## Other Common Criteria Related Documents
+### Windows Server 2003 Certificate Server
 
-- [Identifying Windows XP and Windows Server 2003 Common Criteria Certified Requirements for the NIST Special Publication 800-53](https://download.microsoft.com/download/a/9/6/a96d1dfc-2bd4-408d-8d93-e0ede7529691/xpws03_ccto800-53.doc)
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid9507-st.pdf)
+- [Administrator's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=445093d8-45e2-4cf6-884c-8802c1e6cb2d)
+- [Configuration Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=46abc8b5-11be-4e3d-85c2-63226c3688d2)
+- [User's Guide](https://www.microsoft.com/downloads/en/details.aspx?familyid=74f66d84-2654-48d0-b9b5-b383d383425e)
+- [Evaluation Technical Report](https://www.microsoft.com/downloads/details.aspx?familyid=a594e77f-dcbb-4787-9d68-e4689e60a314)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid9507-vr.pdf)
+
+### Windows Rights Management Services
+
+- [Security Target](https://www.commoncriteriaportal.org/files/epfiles/st_vid10224-st.pdf)
+- [Validation Report](https://www.commoncriteriaportal.org/files/epfiles/st_vid10224-vr.pdf)


### PR DESCRIPTION
I am an external consultant working with MS FTE Mike Grimm (MGrimm) on Common Criteria certifications.  We are refreshing this topic with the following changes:
- Reorganized the topic by product release (e.g., list all documents for the Windows 10 1909 certification together in a group)
- Added links to downloadable Assurance Activity Reports where available
- Fixed numerous broken links to NIAP resources

Please follow up with me or MGrimm with questions or concerns.  Thanks!