### PR TITLE
Update minimum-requirements.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
@@ -97,7 +97,7 @@ The hardware requirements for Microsoft Defender ATP on devices are the same for
 > [!NOTE]
 > Machines running mobile versions of Windows are not supported.
 >
-> Virtual Machines running Windows 10 Enterprise 2016 LTSC (which is based on Windows 10, version 1607) may encounter performance issues if run on non-Microsoft virtualization platforms.
+> Virtual Machines running Windows 10 Enterprise 2016 LTSB (which is based on Windows 10, version 1607) may encounter performance issues if run on non-Microsoft virtualization platforms.
 >
 > For virtual environments, we recommend using Windows 10 Enterprise LTSC 2019 (which is based on Windows 10, version 1809) or later.
 


### PR DESCRIPTION
fixed minor typo.
"Windows 10 Enterprise 2016 LTSB edition" - LTSC naming convection started with 2019 version. reference:
https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet