### PR TITLE
Update scheduled-catch-up-scans-microsoft-defender-antivirus.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-antivirus/scheduled-catch-up-scans-microsoft-defender-antivirus.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/scheduled-catch-up-scans-microsoft-defender-antivirus.md
@@ -12,7 +12,7 @@ ms.localizationpriority: medium
 author: denisebmsft
 ms.author: deniseb
 ms.custom: nextgen
-ms.date: 12/10/2018
+ms.date: 07/22/2020
 ms.reviewer: 
 manager: dansimp
 ---
@@ -71,7 +71,7 @@ Scheduled scans will run at the day and time you specify. You can use Group Poli
 >[!NOTE]
 >If a computer is unplugged and running on battery during a scheduled full scan, the scheduled scan will stop with event 1002, which states that the scan stopped before completion. Microsoft Defender Antivirus will run a full scan at the next scheduled time.
 
-**Use Group Policy to schedule scans:**
+### Use Group Policy to schedule scans
 
 Location | Setting | Description | Default setting (if not configured)
 ---|---|---|---
@@ -80,7 +80,7 @@ Scan | Specify the day of the week to run a scheduled scan | Specify the day (or
 Scan | Specify the time of day to run a scheduled scan | Specify the number of minutes after midnight (for example, enter **60** for 1 am). | 2 am
 Root | Randomize scheduled task times |In Microsoft Defender Antivirus: Randomize the start time of the scan to any interval from 0 to 4 hours. <br>In FEP/SCEP: randomize to any interval plus or minus 30 minutes. This can be useful in VM or VDI deployments. | Enabled
 
-**Use PowerShell cmdlets to schedule scans:**
+### Use PowerShell cmdlets to schedule scans
 
 Use the following cmdlets:
 
@@ -94,7 +94,7 @@ Set-MpPreference -RandomizeScheduleTaskTimes
 
 See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](use-powershell-cmdlets-microsoft-defender-antivirus.md) and [Defender cmdlets](https://technet.microsoft.com/itpro/powershell/windows/defender/index) for more information on how to use PowerShell with Microsoft Defender Antivirus.
 
-**Use Windows Management Instruction (WMI) to schedule scans:**
+### Use Windows Management Instruction (WMI) to schedule scans
 
 Use the [**Set** method of the **MSFT_MpPreference**](https://msdn.microsoft.com/library/dn455323(v=vs.85).aspx) class for the following properties:
 
@@ -109,20 +109,20 @@ See the following for more information and allowed parameters:
 
 
 
-## tart scheduled scans only when the endpoint is not in use
+## Start scheduled scans only when the endpoint is not in use
 
 You can set the scheduled scan to only occur when the endpoint is turned on but not in use with Group Policy, PowerShell, or WMI.
 
 > [!NOTE]
 > These scans will not honor the CPU throttling configuration and take full advantage of the resources available to complete the scan as fast as possible.
 
-**Use Group Policy to schedule scans**
+### Use Group Policy to schedule scans
 
 Location | Setting | Description | Default setting (if not configured)
 ---|---|---|---
 Scan | Start the scheduled scan only when computer is on but not in use | Scheduled scans will not run, unless the computer is on but not in use | Enabled
 
-**Use PowerShell cmdlets:**
+### Use PowerShell cmdlets
 
 Use the following cmdlets:
 
@@ -132,7 +132,7 @@ Set-MpPreference -ScanOnlyIfIdleEnabled
 
 See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](use-powershell-cmdlets-microsoft-defender-antivirus.md) and [Defender cmdlets](https://technet.microsoft.com/itpro/powershell/windows/defender/index) for more information on how to use PowerShell with Microsoft Defender Antivirus.
 
-**Use Windows Management Instruction (WMI):**
+### Use Windows Management Instruction (WMI)
 
 Use the [**Set** method of the **MSFT_MpPreference**](https://msdn.microsoft.com/library/dn455323(v=vs.85).aspx) class for the following properties:
 
@@ -149,15 +149,14 @@ See the following for more information and allowed parameters:
 
 Some threats may require a full scan to complete their removal and remediation. You can schedule when these scans should occur with Group Policy, PowerShell, or WMI.
 
-
-**Use Group Policy to schedule remediation-required scans**
+### Use Group Policy to schedule remediation-required scans
 
 Location | Setting | Description | Default setting (if not configured)
 ---|---|---|---
 Remediation | Specify the day of the week to run a scheduled full scan to complete remediation | Specify the day (or never) to run a scan. | Never
 Remediation | Specify the time of day to run a scheduled full scan to complete remediation | Specify the number of minutes after midnight (for example, enter **60** for 1 am) | 2 am
 
-**Use PowerShell cmdlets:**
+### Use PowerShell cmdlets
 
 Use the following cmdlets:
 
@@ -168,7 +167,7 @@ Set-MpPreference -RemediationScheduleTime
 
 See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](use-powershell-cmdlets-microsoft-defender-antivirus.md) and [Defender cmdlets](https://technet.microsoft.com/itpro/powershell/windows/defender/index) for more information on how to use PowerShell with Microsoft Defender Antivirus.
 
-**Use Windows Management Instruction (WMI):**
+### Use Windows Management Instruction (WMI)
 
 Use the [**Set** method of the **MSFT_MpPreference**](https://msdn.microsoft.com/library/dn455323(v=vs.85).aspx) class for the following properties:
 
@@ -188,14 +187,14 @@ See the following for more information and allowed parameters:
 You can enable a daily quick scan that can be run in addition to your other scheduled scans with Group Policy, PowerShell, or WMI.
 
 
-**Use Group Policy to schedule daily scans:**
+### Use Group Policy to schedule daily scans
 
 Location | Setting | Description | Default setting (if not configured)
 ---|---|---|---
 Scan | Specify the interval to run quick scans per day | Specify how many hours should elapse before the next quick scan. For example, to run every two hours, enter **2**, for once a day, enter **24**. Enter **0** to never run a daily quick scan. | Never
 Scan | Specify the time for a daily quick scan | Specify the number of minutes after midnight (for example, enter **60** for 1 am) | 2 am
 
-**Use PowerShell cmdlets to schedule daily scans:**
+### Use PowerShell cmdlets to schedule daily scans
 
 Use the following cmdlets:
 
@@ -205,7 +204,7 @@ Set-MpPreference -ScanScheduleQuickTime
 
 See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](use-powershell-cmdlets-microsoft-defender-antivirus.md) and [Defender cmdlets](https://technet.microsoft.com/itpro/powershell/windows/defender/index) for more information on how to use PowerShell with Microsoft Defender Antivirus.
 
-**Use Windows Management Instruction (WMI) to schedule daily scans:**
+### Use Windows Management Instruction (WMI) to schedule daily scans
 
 Use the [**Set** method of the **MSFT_MpPreference**](https://msdn.microsoft.com/library/dn455323(v=vs.85).aspx) class for the following properties:
 
@@ -222,15 +221,11 @@ See the following for more information and allowed parameters:
 
 You can force a scan to occur after every [protection update](manage-protection-updates-microsoft-defender-antivirus.md) with Group Policy.
 
-**Use Group Policy to schedule scans after protection updates**
+### Use Group Policy to schedule scans after protection updates
 
 Location | Setting | Description | Default setting (if not configured)
 ---|---|---|---
 Signature updates | Turn on scan after Security intelligence update | A scan will occur immediately after a new protection update is downloaded | Enabled
-
-
-
-
 
 ## Related topics
 

--- a/windows/security/threat-protection/microsoft-defender-antivirus/scheduled-catch-up-scans-microsoft-defender-antivirus.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/scheduled-catch-up-scans-microsoft-defender-antivirus.md
@@ -109,9 +109,12 @@ See the following for more information and allowed parameters:
 
 
 
-## Start scheduled scans only when the endpoint is not in use
+## tart scheduled scans only when the endpoint is not in use
 
 You can set the scheduled scan to only occur when the endpoint is turned on but not in use with Group Policy, PowerShell, or WMI.
+
+> [!NOTE]
+> These scans will not honor the CPU throttling configuration and take full advantage of the resources available to complete the scan as fast as possible.
 
 **Use Group Policy to schedule scans**
 


### PR DESCRIPTION
added the below note under "Start scheduled scans only when the endpoint is not in use":
These scans will not honor the CPU throttling configuration and take full advantage of the resources available to complete the scan as fast as possible.