### PR TITLE
remove Infineon from list of firmware TPMs

### DIFF
--- a/windows/deployment/windows-autopilot/windows-autopilot-requirements.md
+++ b/windows/deployment/windows-autopilot/windows-autopilot-requirements.md
@@ -95,7 +95,6 @@ If the Microsoft Store is not accessible, the Autopilot process will still conti
   <br>Intel- https://ekop.intel.com/ekcertservice 
   <br>Qualcomm- https://ekcert.spserv.microsoft.com/EKCertificate/GetEKCertificate/v1
   <br>AMD- https://ftpm.amd.com/pki/aia
-  <br>Infineon- https://pki.infineon.com
 </table>
 
 ## Licensing requirements


### PR DESCRIPTION
The text mentions Firmware TPMs for which Windows needs to be able to fetch EK certificates during Autopilot deployment. Infineon does not produce firmware TPMs and EK certificates for Infineon TPMs do not need to be fetched from an online service.