### PR TITLE
Update link to Intune content for managing web protection on Android

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/android-configure.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/android-configure.md
@@ -43,7 +43,7 @@ Microsoft Defender ATP for Android enables admins to configure custom indicators
 ## Configure web protection
 Microsoft Defender ATP for Android allows IT Administrators the ability to configure the web protection feature. This capability is available within the Microsoft Endpoint Manager Admin center.
 
-For more information, see [Configure web protection on devices that run Android](https://docs.microsoft.com/mem/intune/protect/advanced-threat-protection#configure-web-protection-on-devices-that-run-android).
+For more information, see [Configure web protection on devices that run Android](https://docs.microsoft.com/mem/intune/protect/advanced-threat-protection-manage-android).
 
 ## Related topics
 - [Overview of Microsoft Defender ATP for Android](microsoft-defender-atp-android.md)


### PR DESCRIPTION
The Intune MD ATP doc was restructured into multiple articles on 7/24.  I've updated the only link that I could locate that needs a new destination. The previous page remains valid links that don't bookmark to what was a subsection of the article:  intune/protect/advanced-threat-protection.md