### PR TITLE
Update trusted-platform-module-services-group-policy-settings.md

### DIFF
--- a/windows/security/information-protection/tpm/trusted-platform-module-services-group-policy-settings.md
+++ b/windows/security/information-protection/tpm/trusted-platform-module-services-group-policy-settings.md
@@ -41,7 +41,7 @@ This policy setting configured which TPM authorization values are stored in the 
 |--------------|---------------|---------|-----------------|-----------------|------------------|
 | OwnerAuthAdmin | StorageOwnerAuth | Create SRK | No      | Yes             | Yes              |
 | OwnerAuthEndorsement | EndorsementAuth | Create or use EK (1.2 only: Create AIK) | No  | Yes  | Yes   |
-| OwnerAuthFull | LockoutAuth  | Reset/change Dictionary Attack Protection | No | No | No   |
+| OwnerAuthFull | LockoutAuth  | Reset/change Dictionary Attack Protection | No | No | Yes   |
 
 There are three TPM owner authentication settings that are managed by the Windows operating system. You can choose a value of **Full**, **Delegate**, or **None**.
 


### PR DESCRIPTION
Fix description of OwnerAuthFull for OsManagedAuthLevel = Full.  
The OwnerAuthFull is retained when OsManagedAuthLevel==4.