### PR TITLE
Update mac-schedule-scan-atp.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-schedule-scan-atp.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-schedule-scan-atp.md
@@ -36,8 +36,8 @@ While you can start a threat scan at any time with Microsoft Defender ATP, your 
         <key>ProgramArguments</key>
         <array>
             <string>sh</string>
-            <string>-c<string>
-            <string>/usr/local/bin/mdatp --scan --quick<string>
+            <string>-c</string>
+            <string>/usr/local/bin/mdatp --scan --quick</string>
         </array>
         <key>RunAtLoad</key>
         <true/>


### PR DESCRIPTION
The sample .plist is missing the slash ("/") char on some of the end tags.