### PR TITLE
Removing of Applies to

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-antivirus/configure-server-exclusions-microsoft-defender-antivirus.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/configure-server-exclusions-microsoft-defender-antivirus.md
@@ -18,10 +18,6 @@ ms.custom: nextgen
 
 # Configure Microsoft Defender Antivirus exclusions on Windows Server
 
-**Applies to:**
-
-- [Microsoft Defender Advanced Threat Protection (Microsoft Defender ATP)](https://go.microsoft.com/fwlink/p/?linkid=2069559)
-
 Microsoft Defender Antivirus on Windows Server 2016 and 2019 automatically enrolls you in certain exclusions, as defined by your specified server role. See the [list of automatic exclusions](#list-of-automatic-exclusions) (in this article). These exclusions do not appear in the standard exclusion lists that are shown in the [Windows Security app](microsoft-defender-security-center-antivirus.md#exclusions).
 
 > [!NOTE]


### PR DESCRIPTION
As the applies to portion is linking to the commercial differences among Windows 10 and doesn't fit with the article so it has been removed to make document clear. 

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/7106