### PR TITLE
added directions that the CMD must also be copied for MDATP non-persistent VDI if you want one entry

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/configure-endpoints-vdi.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-endpoints-vdi.md
@@ -70,7 +70,7 @@ The following steps will guide you through onboarding VDI devices and will highl
 
 3. The following step is only applicable if you're implementing a single entry for each device: <br>
     **For single entry for each device**:<br>
-        a. From the `WindowsDefenderATPOnboardingPackage`, copy the `Onboard-NonPersistentMachine.ps1` file to `golden/master` image to the path `C:\WINDOWS\System32\GroupPolicy\Machine\Scripts\Startup`. <br>
+        a. From the `WindowsDefenderATPOnboardingPackage`, copy the `Onboard-NonPersistentMachine.ps1` and `WindowsDefenderATPOnboardingScript.cmd` file to `golden/master` image to the path `C:\WINDOWS\System32\GroupPolicy\Machine\Scripts\Startup`. <br>
 
     >[!NOTE]
     >If you don't see the `C:\WINDOWS\System32\GroupPolicy\Machine\Scripts\Startup` folder, it might be hidden. You'll need to choose the **Show hidden files and folders** option from file explorer.


### PR DESCRIPTION
added directions that the CMD must also be copied when you only want a single entry since the .ps1 requires the cmd. This is unclear in the current documentation