### PR TITLE
Properly show which Windows 10 Client SKUs Credential Guard applies to

### DIFF
--- a/windows/security/identity-protection/credential-guard/credential-guard-manage.md
+++ b/windows/security/identity-protection/credential-guard/credential-guard-manage.md
@@ -21,7 +21,8 @@ ms.custom:
 # Manage Windows Defender Credential Guard
 
 **Applies to**
--   Windows 10
+-   Windows 10 <=1903 Enterprise and Education SKUs
+-   Windows 10 >=1909
 -   Windows Server 2016
 -   Windows Server 2019
 


### PR DESCRIPTION
It might still be that Window 10 >=1909 Home is excluded. I have no system to test this.

Edit: (Device) Guard was also available on Windows 10 S 1708: https://twitter.com/dwizzzleMSFT/status/899781973371113473

Might close Issue #7900