### PR TITLE
Typo correction: spell NTLM correctly (not NTML)

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/behavioral-blocking-containment.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/behavioral-blocking-containment.md
@@ -90,7 +90,7 @@ While the attack was detected and stopped, alerts, such as an "initial access al
 
 This example shows how behavior-based device learning models in the cloud add new layers of protection against attacks, even after they have started running.
 
-### Example 2: NTML relay - Juicy Potato malware variant
+### Example 2: NTLM relay - Juicy Potato malware variant
 
 As described in the recent blog post, [Behavioral blocking and containment: Transforming optics into protection](https://www.microsoft.com/security/blog/2020/03/09/behavioral-blocking-and-containment-transforming-optics-into-protection), in January 2020, Microsoft Defender ATP detected a privilege escalation activity on a device in an organization. An alert called “Possible privilege escalation using NTLM relay” was triggered.
 


### PR DESCRIPTION
Switch the letter ordering of the word "NTLM" in the Example 2 subheading so it becomes correct:

- old spelling "**Example 2: NTML relay - Juicy Potato malware variant**"
- new spelling: "Example 2: **NTLM** relay - Juicy Potato malware variant"

Closes #8081