### PR TITLE
Comma missing in example

### DIFF
--- a/windows/security/information-protection/windows-information-protection/create-wip-policy-using-intune-azure.md
+++ b/windows/security/information-protection/windows-information-protection/create-wip-policy-using-intune-azure.md
@@ -456,7 +456,7 @@ contoso.sharepoint.com,contoso.internalproxy1.com|contoso.visualstudio.com,conto
 Value format without proxy:
 
 ```code
-contoso.sharepoint.com|contoso.visualstudio.com
+contoso.sharepoint.com,|contoso.visualstudio.com,|contoso.onedrive.com
 ```
 
 ### Protected domains


### PR DESCRIPTION
As mentioned in the document that if we are adding a URL without proxy we need to add "," just before the "|". Added this in the documents example section. 

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/7134