### PR TITLE
Windows/Troubleshooting: Link URL & format update

### DIFF
--- a/windows/client-management/windows-10-support-solutions.md
+++ b/windows/client-management/windows-10-support-solutions.md
@@ -131,4 +131,4 @@ This section contains advanced troubleshooting topics and links to help you reso
 
 ## Other Resources
 
-### [Troubleshooting Windows Server components](https://docs.microsoft.com/windows-server/troubleshoot/windows-server-support-solutions)
+- [Troubleshooting Windows Server components](https://docs.microsoft.com/windows-server/troubleshoot/windows-server-troubleshooting)


### PR DESCRIPTION
As pointed out in issue ticket #8119, the last link of the page returns a 404 error.
The parent page https://docs.microsoft.com/windows-server/ has been changed since that incorrectly formatted link was added.

Old 404 URL: https://docs.microsoft.com/en-us/windows-server/troubleshoot/windows-server-support-solutions
Proposed new URL: https://docs.microsoft.com/windows-server/troubleshoot/windows-server-troubleshooting

Thanks to rossmpersonal for pointing out the 404 error.

Closes #8119