### PR TITLE
Update kernel-dma-protection-for-thunderbolt.md

### DIFF
--- a/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
+++ b/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
@@ -84,7 +84,7 @@ Beginning with Windows 10 version 1809, you can use Security Center to check if 
 1. Launch MSINFO32.exe in a command prompt, or in the Windows search bar.
 2. Check the value of **Kernel DMA Protection**.
    ![Kernel DMA protection in System Information](bitlocker/images/kernel-dma-protection.png)
-3. If the current state of **Kernel DMA Protection** is OFF and **Virtualization Technology in Firmware** is NO:
+3. If the current state of **Kernel DMA Protection** is OFF and **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is NOT shown (this means Virtualization technology in Firmware is disabled):
    - Reboot into BIOS settings
    - Turn on Intel Virtualization Technology.
    - Turn on Intel Virtualization Technology for I/O (VT-d). In Windows 10 version 1803, only Intel VT-d is supported. Other platforms can use DMA attack mitigations described in [BitLocker countermeasures](bitlocker/bitlocker-countermeasures.md).

--- a/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
+++ b/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
@@ -84,11 +84,15 @@ Beginning with Windows 10 version 1809, you can use Security Center to check if 
 1. Launch MSINFO32.exe in a command prompt, or in the Windows search bar.
 2. Check the value of **Kernel DMA Protection**.
    ![Kernel DMA protection in System Information](bitlocker/images/kernel-dma-protection.png)
-3. If the current state of **Kernel DMA Protection** is OFF and **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is NOT shown (this means Virtualization technology in Firmware is disabled):
+3. If the current state of **Kernel DMA Protection** is OFF and **Hyper-V - Virtualization Enabled in Firmware** is NO:
    - Reboot into BIOS settings
    - Turn on Intel Virtualization Technology.
    - Turn on Intel Virtualization Technology for I/O (VT-d). In Windows 10 version 1803, only Intel VT-d is supported. Other platforms can use DMA attack mitigations described in [BitLocker countermeasures](bitlocker/bitlocker-countermeasures.md).
    - Reboot system into Windows 10.
+
+>[!NOTE]
+> **Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES.
+
 4. If the state of **Kernel DMA Protection** remains Off, then the system does not support this feature. 
 
 For systems that do not support Kernel DMA Protection, please refer to the [BitLocker countermeasures](bitlocker/bitlocker-countermeasures.md) or [Thunderbolt™ 3 and Security on Microsoft Windows® 10 Operating system](https://thunderbolttechnology.net/security/Thunderbolt%203%20and%20Security.pdf) for other means of DMA protection.


### PR DESCRIPTION
The item of "Virtualization technology in Firmware" doesn't exist in msinfo32.exe. So, it should be replaced with **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is NOT shown (this means Virtualization technology in Firmware is disabled).