### PR TITLE
Update microsoft-defender-atp-android.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-android.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-android.md
@@ -27,8 +27,6 @@ ms.topic: conceptual
 > 
 > As with any pre-release solution, remember to exercise caution when determining the target population for your deployments.
 > 
-> If you have preview features turned on in the Microsoft Defender Security Center, you should be able to access the Android onboarding page immediately. If you have not yet opted into previews, we encourage you to [turn on preview features](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/preview) in the Microsoft Defender Security Center today. 
-
 This topic describes how to install, configure, update, and use Microsoft Defender ATP for Android.
 
 > [!CAUTION]
@@ -86,8 +84,8 @@ For more information, see [Deploy Microsoft Defender ATP for Android with Micros
 
 
 > [!NOTE]
-> During public preview, instructions to deploy Microsoft Defender ATP for Android on Intune enrolled Android devices are different across Device Administrator and Android Enterprise entrollment modes. <br>
-> **When Microsoft Defender ATP for Android reaches General Availability (GA), the app will be available on Google Play.**
+> **Microsoft Defender ATP for Android is available on Google Play now.**
+You can connect to Google Play from Intune directly to deploy app across Device Administrator and Android Enterprise entrollment modes. 
 
 ## How to Configure Microsoft Defender ATP for Android
 


### PR DESCRIPTION
1. Deleted below, to stop users from visiting security center onboarding page. As User can download the page from Google Play directly
If you have preview features turned on in the Microsoft Defender Security Center, you should be able to access the Android onboarding page immediately. If you have not yet opted into previews, we encourage you to turn on preview features in the Microsoft Defender Security Center today. 

2. Updated below note to announce that app is now available in Googla Play 
 **Microsoft Defender ATP for Android is available on Google Play now.**
You can connect to Google Play from Intune directly to deploy app across Device Administrator and Android Enterprise entrollment modes.