### PR TITLE
Simple typo fix

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/live-response-command-examples.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/live-response-command-examples.md
@@ -155,7 +155,7 @@ registry HKEY_CURRENT_USER\Console
 
 ```
 # Show information about a specific registry value
-registry HKEY_CURRENT_USER\Console\\ScreenBufferSize
+registry HKEY_CURRENT_USER\Console\ScreenBufferSize
 ```
 
 


### PR DESCRIPTION
Remove an extraneous backslash.