### PR TITLE
Added missing final steps

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-sysext-policies.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-sysext-policies.md
@@ -279,3 +279,5 @@ To deploy this custom configuration profile:
 
     ![System extension in Intune screenshot](images/mac-system-extension-intune.png)
 
+5. In the `Assignments` tab, assign this profile to **All Users & All devices**.
+6. Review and create this configuration profile.


### PR DESCRIPTION
The steps for deploying the custom configuration profile did not finish as the previous section did, by explaining how the configuration profile should be assigned.
I have added identical steps to the Systems Extension Policy before it.