### PR TITLE
Update policy-csp-localpoliciessecurityoptions.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-localpoliciessecurityoptions.md
+++ b/windows/client-management/mdm/policy-csp-localpoliciessecurityoptions.md
@@ -1373,6 +1373,8 @@ Default: No message.
 
 Value type is string. Supported operations are Add, Get, Replace, and Delete.
 
+NOTE: When targeting this policy to a device the initial login at OOBE may hang. To prevent the initial OOBE login from hanging you must also disable the First Login Animation: https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-csp-windowslogon#windowslogon-enablefirstlogonanimation 
+
 <!--/Description-->
 <!--RegistryMapped-->
 GP Info:  
@@ -1435,6 +1437,8 @@ This security setting allows the specification of a title to appear in the title
 Default: No message.
 
 Value type is string. Supported operations are Add, Get, Replace, and Delete.
+
+NOTE: When targeting this policy to a device the initial login at OOBE may hang. To prevent the initial OOBE login from hanging you must also disable the First Login Animation: https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-csp-windowslogon#windowslogon-enablefirstlogonanimation 
 
 <!--/Description-->
 <!--RegistryMapped-->


### PR DESCRIPTION
We have a bug filed for the behavior however what I am looking to add is like one of the purple note boxes for each of the settings so that if a user chooses to target the device with these policy's they also need to disable the First Login Animation or their OOBE login will hang.