### PR TITLE
Update AppLocker CSP warning

### DIFF
--- a/windows/client-management/mdm/applocker-csp.md
+++ b/windows/client-management/mdm/applocker-csp.md
@@ -35,7 +35,7 @@ Defines restrictions for applications.
 > Delete/unenrollment is not properly supported unless Grouping values are unique across enrollments. If multiple enrollments use the same Grouping value, then unenrollment will not work as expected since there are duplicate URIs that get deleted by the resource manager. To prevent this problem, the Grouping value should include some randomness. The best practice is to use a randomly generated GUID. However, there is no requirement on the exact value of the node.
 
 > [!NOTE]
-> Deploying policies via the AppLocker CSP will force a reboot during OOBE.
+> The AppLocker CSP will schedule a reboot when a policy is applied or a deletion occurs using the AppLocker/ApplicationLaunchRestrictions/Grouping/CodeIntegrity/Policy URI.
 
 Additional information:
 


### PR DESCRIPTION
Previously indicated reboots were only scheduled during OOBE, but this is not the case