### PR TITLE
Update manual config to include full census sync

### DIFF
--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -80,10 +80,10 @@ Many Windows and Microsoft services are required to ensure that not only the dev
 
 ## Run a full Census sync
 
-Census is a service that runs on a regular cadence on Windows machines. A number of key device attributes, like what OS Edition is installed on the device, are included in the Census payload. However, to save network load and system resources, data that tends to be more static (like OS Edition) is sent around once per week rather than on every daily run. Because of this, these attributes can take longer to appear in Update Compliance unless a full Census sync is initiated. The Update Compliance Configuration Script does this. 
+Census is a service that runs on a regular schedule on Windows devices. A number of key device attributes, like what opearting system edition is installed on the device, are included in the Census payload. However, to save network load and system resources, data that tends to be more static (like edition) is sent approximately once per week rather than on every daily run. Because of this, these attributes can take longer to appear in Update Compliance unless you start a full Census sync. The Update Compliance Configuration Script does this. 
 
-A full Census sync is accomplished by adding a new registry value to Census's path. When this registry value is added, Census's configuration is overridden to force a full sync. It is recommended that this registry value is enabled, Census is manually invoked, and then the registry value is disabled to allow Census to operate normally. The steps to accomplish this are below:
+A full Census sync adds a new registry value to Census's path. When this registry value is added, Census's configuration is overridden to force a full sync. For Census to work normally, this registry value should be enabled, Census should be started manually, and then the registry value should be disabled. Follow these steps:
 
-1. For every device you are manually configuring for Update Compliance, add or modify the registry key located at **HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Census** to include a new **DWORD value** named **FullSync** and set to 1. 
-2. Run devicecensus.exe with administrator privileges on every device. devicecensus.exe is located in the System32 folder. No additional run parameters are required. 
-3. After devicecensus.exe has run, the FullSync value can be removed or set to 0. 
+1. For every device you are manually configuring for Update Compliance, add or modify the registry key located at **HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Census** to include a new **DWORD value** named **FullSync** and set to **1**. 
+2. Run Devicecensus.exe with administrator privileges on every device. Devicecensus.exe is in the System32 folder. No additional run parameters are required. 
+3. After Devicecensus.exe has run, the **FullSync** registry value can be removed or set to **0**. 

--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -85,5 +85,5 @@ Census is a service that runs on a regular cadence on Windows machines. A number
 A full Census sync is accomplished by adding a new registry value to Census's path. When this registry value is added, Census's configuration is overridden to force a full sync. It is recommended that this registry value is enabled, Census is manually invoked, and then the registry value is disabled to allow Census to operate normally. The steps to accomplish this are below:
 
 1. For every device you are manually configuring for Update Compliance, add or modify the registry key located at **HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Census** to include a new **DWORD value** named **FullSync** and set to 1. 
-2. Run devicecensus.exe with administrator priviledges on every device. devicecensus.exe is located in the System32 folder. No additional parameters are required. 
-3. After devicecensus.exe has run, the FullSync value can be removed or set back to 0. 
+2. Run devicecensus.exe with administrator privileges on every device. devicecensus.exe is located in the System32 folder. No additional run parameters are required. 
+3. After devicecensus.exe has run, the FullSync value can be removed or set to 0. 

--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -17,13 +17,14 @@ ms.topic: article
 
 # Manually Configuring Devices for Update Compliance
 
-There are a number of requirements to consider when manually configuring Update Compliance. These can potentially change with newer versions of Windows 10. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) will be updated when any configuration requirements change so only a redeployment of the script will be required.
+There are a number of requirements to consider when manually configuring devices for Update Compliance. These can potentially change with newer versions of Windows 10. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) will be updated when any configuration requirements change so only a redeployment of the script will be required.
 
 The requirements are separated into different categories:
 
 1. Ensuring the [**required policies**](#required-policies) for Update Compliance are correctly configured.
 2. Devices in every network topography needs to send data to the [**required endpoints**](#required-endpoints) for Update Compliance, for example both devices in main and satellite offices, which may have different network configurations.
 3. Ensure [**Required Windows services**](#required-services) are running or are scheduled to run. It is recommended all Microsoft and Windows services are set to their out-of-box defaults to ensure proper functionality.
+4. [**Run a full Census sync**](#run-a-full-census-sync) on new devices to ensure that all necessary data points are collected.
 
 ## Required policies
 
@@ -75,3 +76,14 @@ To enable data sharing between devices, your network, and Microsoft's Diagnostic
 ## Required services
 
 Many Windows and Microsoft services are required to ensure that not only the device can function, but Update Compliance can see device data. It is recommended that you allow all default services from the out-of-box experience to remain running. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) checks whether the majority of these services are running or are allowed to run automatically.
+
+
+## Run a full Census sync
+
+Census is a service that runs on a regular cadence on Windows machines. A number of key device attributes, like what OS Edition is installed on the device, are included in the Census payload. However, to save network load and system resources, data that tends to be more static (like OS Edition) is sent around once per week rather than on every daily run. Because of this, these attributes can take longer to appear in Update Compliance unless a full Census sync is initiated. The Update Compliance Configuration Script does this. 
+
+A full Census sync is accomplished by adding a new registry value to Census's path. When this registry value is added, Census's configuration is overridden to force a full sync. It is recommended that this registry value is enabled, Census is manually invoked, and then the registry value is disabled to allow Census to operate normally. The steps to accomplish this are below:
+
+1. For every device you are manually configuring for Update Compliance, add or modify the registry key located at **HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Census** to include a new **DWORD value** named **FullSync** and set to 1. 
+2. Run devicecensus.exe with administrator priviledges on every device. devicecensus.exe is located in the System32 folder. No additional parameters are required. 
+3. After devicecensus.exe has run, the FullSync value can be removed or set back to 0. 


### PR DESCRIPTION
Incidents have been popping up wherein customers are experiencing issues with missing fields. This is partially due to Census not fully syncing those fields on every run, only once per week. The config script has always invoked a full Census sync. This is being added as it has been observed many customers simply manually configure devices for Update Compliance.