### PR TITLE
Removed paragraph about Autopilot self-deploying mode

### DIFF
--- a/windows/whats-new/ltsc/whats-new-windows-10-2019.md
+++ b/windows/whats-new/ltsc/whats-new-windows-10-2019.md
@@ -259,17 +259,6 @@ Using Intune, Autopilot now enables locking the device during provisioning durin
 
 You can also apply an Autopilot deployment profile to your devices using Microsoft Store for Business. When people in your organization run the out-of-box experience on the device, the profile configures Windows based on the Autopilot deployment profile you applied to the device. For more information, see [Manage Windows device deployment with Windows Autopilot Deployment](https://docs.microsoft.com/microsoft-store/add-profile-to-devices).
 
-#### Windows Autopilot self-deploying mode
-
-Windows Autopilot self-deploying mode enables a zero touch device provisioning experience. Simply power on the device, plug it into the Ethernet, and the device is fully configured automatically by Windows Autopilot. 
-
-This self-deploying capability removes the current need to have an end user interact by pressing the “Next” button during the deployment process. 
-
-You can utilize Windows Autopilot self-deploying mode to register the device to an AAD tenant, enroll in your organization’s MDM provider, and provision policies and applications, all with no user authentication or user interaction required. 
-
-To learn more about Autopilot self-deploying mode and to see step-by-step instructions to perform such a deployment, [Windows Autopilot self-deploying mode](https://docs.microsoft.com/windows/deployment/windows-autopilot/self-deploying). 
-
-
 #### Autopilot Reset	
 
 IT Pros can use Autopilot Reset to quickly remove personal files, apps, and settings. A custom login screen is available from the lock screen that enables you to apply original settings and management enrollment (Azure Active Directory and device management) so that devices are returned to a fully configured, known, IT-approved state and ready to use. For more information, see [Reset devices with Autopilot Reset](https://docs.microsoft.com/education/windows/autopilot-reset).


### PR DESCRIPTION
Autopilot self-deploying mode is NOT supported on LTSC 2019 (1809) as this is below the minimum OS requirement of 1903, as per https://docs.microsoft.com/en-us/mem/autopilot/self-deploying#requirements:~:text=.%20Since%20Windows%2010%20Enterprise%202019,on%20Windows%2010%20Enterprise%202019%20LTSC

Hence removing all mention of self-deploying mode as it's N/A for LTSC 2019