### PR TITLE
DLP depends on RTP

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
@@ -91,6 +91,8 @@ If you uninstall the other product, and choose to use Microsoft Defender Antivir
 > [!WARNING]
 > You should not attempt to disable, stop, or modify any of the associated services used by Microsoft Defender Antivirus, Microsoft Defender ATP, or the Windows Security app. This includes the *wscsvc*, *SecurityHealthService*, *MsSense*, *Sense*, *WinDefend*, or *MsMpEng* services and process. Manually modifying these services can cause severe instability on your endpoints and open your network to infections and attacks. It can also cause problems when using third-party antivirus apps and how their information is displayed in the [Windows Security app](microsoft-defender-security-center-antivirus.md).
 
+> [!IMPORTANT]
+> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus Real-time protection feature will be enabled even when Microsoft Defender Antivirus is running in Passive mode. Endpoint DLP depends on Real-time protection (RTP) to operate.
 
 ## Related topics
 

--- a/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
@@ -13,7 +13,7 @@ ms.author: deniseb
 ms.custom: nextgen
 ms.reviewer:
 manager: dansimp
-ms.date: 08/26/2020
+ms.date: 09/28/2020
 ---
 
 # Microsoft Defender Antivirus compatibility
@@ -92,7 +92,7 @@ If you uninstall the other product, and choose to use Microsoft Defender Antivir
 > You should not attempt to disable, stop, or modify any of the associated services used by Microsoft Defender Antivirus, Microsoft Defender ATP, or the Windows Security app. This includes the *wscsvc*, *SecurityHealthService*, *MsSense*, *Sense*, *WinDefend*, or *MsMpEng* services and process. Manually modifying these services can cause severe instability on your endpoints and open your network to infections and attacks. It can also cause problems when using third-party antivirus apps and how their information is displayed in the [Windows Security app](microsoft-defender-security-center-antivirus.md).
 
 > [!IMPORTANT]
-> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus Real-time protection will be enabled even when Microsoft Defender Antivirus is running in Passive mode. Endpoint DLP depends on Real-time protection (RTP) to operate.
+> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus real-time protection is enabled even when Microsoft Defender Antivirus is running in passive mode. Endpoint DLP depends on real-time protection to operate.
 
 ## Related topics
 

--- a/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/microsoft-defender-antivirus-compatibility.md
@@ -92,7 +92,7 @@ If you uninstall the other product, and choose to use Microsoft Defender Antivir
 > You should not attempt to disable, stop, or modify any of the associated services used by Microsoft Defender Antivirus, Microsoft Defender ATP, or the Windows Security app. This includes the *wscsvc*, *SecurityHealthService*, *MsSense*, *Sense*, *WinDefend*, or *MsMpEng* services and process. Manually modifying these services can cause severe instability on your endpoints and open your network to infections and attacks. It can also cause problems when using third-party antivirus apps and how their information is displayed in the [Windows Security app](microsoft-defender-security-center-antivirus.md).
 
 > [!IMPORTANT]
-> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus Real-time protection feature will be enabled even when Microsoft Defender Antivirus is running in Passive mode. Endpoint DLP depends on Real-time protection (RTP) to operate.
+> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus Real-time protection will be enabled even when Microsoft Defender Antivirus is running in Passive mode. Endpoint DLP depends on Real-time protection (RTP) to operate.
 
 ## Related topics
 


### PR DESCRIPTION
When using DLP, RTP will be enabled even in Passive mode.

> [!IMPORTANT]
> If you are using [Microsoft endpoint data loss prevention (Endpoint DLP)](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/information-protection-in-windows-overview), Microsoft Defender Antivirus Real-time protection feature will be enabled even when Microsoft Defender Antivirus is running in Passive mode. Endpoint DLP depends on Real-time protection (RTP) to operate.