### PR TITLE
Updating MSA warning documentation

### DIFF
--- a/windows/client-management/mdm/policy-csp-update.md
+++ b/windows/client-management/mdm/policy-csp-update.md
@@ -14,8 +14,6 @@ manager: dansimp
 
 # Policy CSP - Update
 
-> [!NOTE]
-> If the MSA service is disabled, Windows Update will no longer offer feature updates to devices running Windows 10 1709 or higher. See [Feature updates are not being offered while other updates are](https://docs.microsoft.com/windows/deployment/update/windows-update-troubleshooting#feature-updates-are-not-being-offered-while-other-updates-are).
 
 <hr/>
 

--- a/windows/deployment/update/windows-update-troubleshooting.md
+++ b/windows/deployment/update/windows-update-troubleshooting.md
@@ -62,7 +62,7 @@ The Settings UI is talking to the Update Orchestrator service which in turn is t
    - Windows Update 
 
 ## Feature updates are not being offered while other updates are
-On computers running Windows 10 1709 through Windows 10 version 1803 and [configured to update from Windows Update](#BKMK_DCAT) (including WUfB scenarios) servicing and definition updates are being installed successfully, but feature updates are never offered.
+Devices running Windows 10, version 1709 through Windows 10, version 1803 that are [configured to update from Windows Update](#BKMK_DCAT) (including Windows Update for Business scenarios) are able to install servicing and definition updates but are never offered feature updates.
 
 Checking the WindowsUpdate.log reveals the following error:
 ```console

--- a/windows/deployment/update/windows-update-troubleshooting.md
+++ b/windows/deployment/update/windows-update-troubleshooting.md
@@ -62,7 +62,7 @@ The Settings UI is talking to the Update Orchestrator service which in turn is t
    - Windows Update 
 
 ## Feature updates are not being offered while other updates are
-On computers running [Windows 10 1709 or higher](#BKMK_DCAT) configured to update from Windows Update (usually WUfB scenario) servicing and definition updates are being installed successfully, but feature updates are never offered.
+On computers running Windows 10 1709 through Windows 10 version 1803 and [configured to update from Windows Update](#BKMK_DCAT) (including WUfB scenarios) servicing and definition updates are being installed successfully, but feature updates are never offered.
 
 Checking the WindowsUpdate.log reveals the following error:
 ```console


### PR DESCRIPTION
Removing top-level warning-banner for MSA as this has been fixed for a number of releases and only applies to Windows 10 versions 1703, 1709, and 1803.