### PR TITLE
Event Forwarding: 1 word typo removal

### DIFF
--- a/windows/security/threat-protection/use-windows-event-forwarding-to-assist-in-intrusion-detection.md
+++ b/windows/security/threat-protection/use-windows-event-forwarding-to-assist-in-intrusion-detection.md
@@ -24,8 +24,7 @@ Learn about an approach to collect events from devices in your organization. Thi
 
 Windows Event Forwarding (WEF) reads any operational or administrative event log on a device in your organization and forwards the events you choose to a Windows Event Collector (WEC) server.
 
-To accomplish this, there are two different of subscriptions published to client devices - the Baseline subscription and the suspect subscription. The Baseline subscription enrolls all devices in your organization, and a Suspect subscription only includes devices that have been added by you. The
-Suspect subscription collects additional events to help build context for system activity and can quickly be updated to accommodate new events and/or scenarios as needed without impacting baseline operations.
+To accomplish this, there are two different subscriptions published to client devices - the Baseline subscription and the suspect subscription. The Baseline subscription enrolls all devices in your organization, and a Suspect subscription only includes devices that have been added by you. The Suspect subscription collects additional events to help build context for system activity and can quickly be updated to accommodate new events and/or scenarios as needed without impacting baseline operations.
 
 This implementation helps differentiate where events are ultimately stored. Baseline events can be sent to devices with online analytical capability, such as Security Event Manager (SEM), while also sending events to a MapReduce system, such as HDInsight or Hadoop, for long-term storage and deeper analysis. Events from the Suspect subscription are sent directly to a MapReduce system due to volume and lower signal/noise ratio, they are largely used for host forensic analysis.
 


### PR DESCRIPTION
1 word typo removal: "there are two different **of** subscriptions published"

Thanks to @CLEVELAND2024 for reporting the typo and asking for correction.

Closes #8361