### PR TITLE
Fix registry path to DoNotConnectToWindowsUpdateInternetLocations

### DIFF
--- a/windows/deployment/update/waas-manage-updates-wsus.md
+++ b/windows/deployment/update/waas-manage-updates-wsus.md
@@ -84,7 +84,7 @@ When using WSUS to manage updates on Windows client devices, start by configurin
    ![Example of UI](images/waas-wsus-fig5.png)
    
    >[!IMPORTANT]
-   > Use Regedit.exe to check that the following key is not enabled, because it can break Windows Store connectivity: Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdateDoNotConnectToWindowsUpdateInternetLocations
+   > Use Regedit.exe to check that the following key is not enabled, because it can break Windows Store connectivity: Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DoNotConnectToWindowsUpdateInternetLocations
     
    > [!NOTE]
    > There are three other settings for automatic update download and installation dates and times. This is simply the option this example uses. For more examples of how to control automatic updates and other related policies, see [Configure Automatic Updates by Using Group Policy](https://technet.microsoft.com/library/cc720539%28v=ws.10%29.aspx). 


### PR DESCRIPTION
It was missing a \ between `WindowsUpdate` and `DoNotConnectToWindowsUpdateInternetLocations`