### PR TITLE
clarifying behavior on network shares

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-antivirus/configure-advanced-scan-types-microsoft-defender-antivirus.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/configure-advanced-scan-types-microsoft-defender-antivirus.md
@@ -59,8 +59,8 @@ Specify the level of subfolders within an archive folder to scan | Scan > Specif
  Specify the maximum size (in kilobytes) of archive files that should be scanned. The default, **0**, applies no limit | Scan > Specify the maximum size of archive files to be scanned | No limit | Not available
  Configure low CPU priority for scheduled scans | Scan > Configure low CPU priority for scheduled scans | Disabled | Not available
  
->[!NOTE]
->If real-time protection is enabled, files are scanned before they are accessed and executed. The scanning scope includes all files, including those on mounted removable devices such as USB drives.
+> [!NOTE]
+> If real-time protection is turned on, files are scanned before they are accessed and executed. The scanning scope includes all files, including files on mounted removable media, such as USB drives. If the device performing the scan has real-time protection or on-access protection turned on, the scan will also include network shares.
 
 ## Use PowerShell to configure scanning options
 


### PR DESCRIPTION
I'm an internal contributor. I had a request to update this page because there was customer confusion about what turning on network sharing does and doesn't do.

> In the Note:  If real-time protection is enabled, files are scanned before they are accessed and executed. The scanning scope includes all files, including those on mounted removable devices such as USB drives.
>
> https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/configure-advanced-scan-types-microsoft-defender-antivirus
>
> We need to ensure we also mention that files on network shares will also be scanned when executed from a machine that has RTP/on access  enabled.  Customers are under the impression that with network scanning turned off, we will not scan anything on a network share ever.