### PR TITLE
Update kernel-dma-protection-for-thunderbolt.md

### DIFF
--- a/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
+++ b/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
@@ -91,7 +91,7 @@ Beginning with Windows 10 version 1809, you can use Security Center to check if 
    - Reboot system into Windows 10.
 
 >[!NOTE]
-> **Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES.
+> **Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES and the **Hyper-V** Windows feature is enabled. Enabling both is needed to enable **Kernel DMA Protection** even when the firmware has the flag of "ACPI Kernel DMA Protection Indicators" described in [Kernel DMA Protection (Memory Access Protection) for OEMs](https://docs.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-kernel-dma-protection).
 
 4. If the state of **Kernel DMA Protection** remains Off, then the system does not support this feature. 
 

--- a/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
+++ b/windows/security/information-protection/kernel-dma-protection-for-thunderbolt.md
@@ -91,7 +91,7 @@ Beginning with Windows 10 version 1809, you can use Security Center to check if 
    - Reboot system into Windows 10.
 
 >[!NOTE]
-> **Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES and the **Hyper-V** Windows feature is enabled. Enabling both is needed to enable **Kernel DMA Protection** even when the firmware has the flag of "ACPI Kernel DMA Protection Indicators" described in [Kernel DMA Protection (Memory Access Protection) for OEMs](https://docs.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-kernel-dma-protection).
+> **Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES and the **Hyper-V** Windows feature is enabled. Enabling both is needed to enable **Kernel DMA Protection** even when the firmware has the flag of "ACPI Kernel DMA Protection Indicators" described in [Kernel DMA Protection (Memory Access Protection) for OEMs](https://docs.microsoft.com/windows-hardware/design/device-experiences/oem-kernel-dma-protection).
 
 4. If the state of **Kernel DMA Protection** remains Off, then the system does not support this feature. 
 


### PR DESCRIPTION
Changed Note to "**Hyper-V - Virtualization Enabled in Firmware** is NOT shown when **A hypervisor has been detected. Features required for Hyper-V will not be displayed.** is shown because this means that **Hyper-V - Virtualization Enabled in Firmware** is YES and the **Hyper-V** Windows feature is enabled. Enabling both is needed to enable **Kernel DMA Protection** even when the firmware has the flag of "ACPI Kernel DMA Protection Indicators" described in [Kernel DMA Protection (Memory Access Protection) for OEMs](https://docs.microsoft.com/en-us/windows-hardware/design/device-experiences/oem-kernel-dma-protection)."