### PR TITLE
Added mfc40.dll to recommended block list

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -88,6 +88,7 @@ Unless your use scenarios explicitly require them, Microsoft recommends that you
 |Lasse Trolle Borup | Langkjaer Cyber Defence |
 |Jimmy Bayne | @bohops |
 |Philip Tsukerman | @PhilipTsukerman |
+|Brock Mammen| |
 
 <br />
 

--- a/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
+++ b/windows/security/threat-protection/windows-defender-application-control/microsoft-recommended-block-rules.md
@@ -158,6 +158,7 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   <Deny ID="ID_DENY_KILL" FriendlyName="kill.exe" FileName="kill.exe" MinimumFileVersion="65535.65535.65535.65535" />
   <Deny ID="ID_DENY_LXRUN" FriendlyName="lxrun.exe" FileName="lxrun.exe" MinimumFileVersion="65535.65535.65535.65535"/> 
   <Deny ID="ID_DENY_LXSS" FriendlyName="LxssManager.dll" FileName="LxssManager.dll" MinimumFileVersion="65535.65535.65535.65535"/>
+  <Deny ID="ID_DENY_MFC40" FriendlyName="mfc40.dll" FileName="mfc40.dll" MinimumFileVersion="65535.65535.65535.65535"/> 
   <Deny ID="ID_DENY_MS_BUILD" FriendlyName="Microsoft.Build.dll" FileName="Microsoft.Build.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
   <Deny ID="ID_DENY_MS_BUILD_FMWK" FriendlyName="Microsoft.Build.Framework.dll" FileName="Microsoft.Build.Framework.dll" MinimumFileVersion="65535.65535.65535.65535" /> 
   <Deny ID="ID_DENY_MWFC" FriendlyName="Microsoft.Workflow.Compiler.exe" FileName="Microsoft.Workflow.Compiler.exe" MinimumFileVersion="65535.65535.65535.65535" /> 
@@ -896,6 +897,7 @@ Pick the correct version of each .dll for the Windows release you plan to suppor
   <FileRuleRef RuleID="ID_DENY_KILL"/>
   <FileRuleRef RuleID="ID_DENY_LXSS"/> 
   <FileRuleRef RuleID="ID_DENY_LXRUN"/> 
+  <FileRuleRef RuleID="ID_DENY_MFC40"/>
   <FileRuleRef RuleID="ID_DENY_MS_BUILD" /> 
   <FileRuleRef RuleID="ID_DENY_MS_BUILD_FMWK" /> 
   <FileRuleRef RuleID="ID_DENY_MWFC" /> 


### PR DESCRIPTION
Adding mfc40.dll by filename block to the recommended WDAC block list per case 60080. Validated the policy compiles according to the schema by running ConvertFrom-CIPolicy cmdlet. 