### PR TITLE
Specify Expected Behavior for Username/Password Setting

### DIFF
--- a/windows/client-management/mdm/accounts-csp.md
+++ b/windows/client-management/mdm/accounts-csp.md
@@ -52,6 +52,7 @@ This node specifies the username for a new local user account.  This setting can
 This node specifies the password for a new local user account.  This setting can be managed remotely. 
 
 Supported operation is Add.
+GET operation is not supported.  This setting will report as failed when deployed from the Endpoint Manager.
 
 <a href="" id="users-username-localusergroup"></a>**Users/_UserName_/LocalUserGroup**  
 This optional node specifies the local user group that a local user account should be joined to.  If the node is not set, the new local user account is joined just to the Standard Users group.  Set the value to 2 for Administrators group. This setting can be managed remotely.


### PR DESCRIPTION
As an Intune SE, we receive a lot of cases for this OMA-URI setting. Customers use it to create a local admin account for Intune enrolled devices but it always reports as failed.
By including this information, we can set the expectation and prevent future cases.