### PR TITLE
remove policy

### DIFF
--- a/windows/client-management/mdm/policies-in-policy-csp-supported-by-hololens2.md
+++ b/windows/client-management/mdm/policies-in-policy-csp-supported-by-hololens2.md
@@ -86,7 +86,6 @@ ms.date: 10/08/2020
 - [Search/AllowSearchToUseLocation](policy-csp-search.md#search-allowsearchtouselocation)
 - [Security/AllowAddProvisioningPackage](policy-csp-security.md#security-allowaddprovisioningpackage)
 - [Security/AllowRemoveProvisioningPackage](policy-csp-security.md#security-allowremoveprovisioningpackage)
-- [Security/RequireDeviceEncryption](policy-csp-security.md#security-requiredeviceencryption)
 - [Settings/AllowDateTime](policy-csp-settings.md#settings-allowdatetime)
 - [Settings/AllowVPN](policy-csp-settings.md#settings-allowvpn)
 - [Speech/AllowSpeechModelUpdate](policy-csp-speech.md#speech-allowspeechmodelupdate)


### PR DESCRIPTION
Bitlocker is enabled by default on HoloLens 2. No need to enable it via CSP policy.

https://github.com/MicrosoftDocs/windows-itpro-docs/issues/8438