### PR TITLE
Update waas-delivery-optimization-reference.md

### DIFF
--- a/windows/deployment/update/waas-delivery-optimization-reference.md
+++ b/windows/deployment/update/waas-delivery-optimization-reference.md
@@ -247,9 +247,9 @@ This policy allows you to specify how your client(s) can discover Delivery Optim
 - 1 = DHCP Option 235.
 - 2 = DHCP Option 235 Force.
 
-with either option, the client will query DHCP Option ID 235 and use the returned value as the Cache Server Hostname. Option 2 overrides the Cache Server Hostname policy, if set.
+With either option, the client will query DHCP Option ID 235 and use the returned value as the Cache Server Hostname. Option 2 overrides the Cache Server Hostname policy, if set.
 
-Set this policy to designate one or more Delivery Optimization in Network Cache servers through a custom DHCP Option. Specify the custom DHCP option on your server as text type. You can add one or more value either fully qualified domain names (FQDN) or IP addresses. To add multiple values, separate each FQDN or IP address by commas.
+Set this policy to designate one or more Delivery Optimization in Network Cache servers through a custom DHCP Option. Specify the custom DHCP option on your server as *text* type. You can add one or more values as either fully qualified domain names (FQDN) or IP addresses. To add multiple values, separate each FQDN or IP address with commas.
 
 > [!NOTE]
 > If you format the DHCP Option ID incorrectly, the client will fall back to the Cache Server Hostname policy value if that value has been set.

--- a/windows/deployment/update/waas-delivery-optimization-reference.md
+++ b/windows/deployment/update/waas-delivery-optimization-reference.md
@@ -249,7 +249,7 @@ This policy allows you to specify how your client(s) can discover Delivery Optim
 
 with either option, the client will query DHCP Option ID 235 and use the returned value as the Cache Server Hostname. Option 2 overrides the Cache Server Hostname policy, if set.
 
-Set this policy to designate one or more Delivery Optimization in Network Cache servers through a custom DHCP Option. You can add one or more value either fully qualified domain names (FQDN) or IP addresses. To add multiple values, separate each FQDN or IP address by commas.
+Set this policy to designate one or more Delivery Optimization in Network Cache servers through a custom DHCP Option. Specify the custom DHCP option on your server as text type. You can add one or more value either fully qualified domain names (FQDN) or IP addresses. To add multiple values, separate each FQDN or IP address by commas.
 
 > [!NOTE]
 > If you format the DHCP Option ID incorrectly, the client will fall back to the Cache Server Hostname policy value if that value has been set.


### PR DESCRIPTION
Adding clarification for customer to add as type = text on their DHCP custom option.  DO client expects a string when processing the DHCP option.