### PR TITLE
Policy CSP/Update: place important blob below list

### DIFF
--- a/windows/client-management/mdm/policy-csp-update.md
+++ b/windows/client-management/mdm/policy-csp-update.md
@@ -7,7 +7,7 @@ ms.prod: w10
 ms.technology: windows
 author: manikadhiman
 ms.localizationpriority: medium
-ms.date: 10/21/2020
+ms.date: 11/03/2020
 ms.reviewer: 
 manager: dansimp
 ---

--- a/windows/client-management/mdm/policy-csp-update.md
+++ b/windows/client-management/mdm/policy-csp-update.md
@@ -461,11 +461,6 @@ Enables the IT admin to manage automatic update behavior to scan, download, and 
 
 Supported operations are Get and Replace.
 
-
-> [!IMPORTANT]
-> This option should be used only for systems under regulatory compliance, as you will not get security updates as well.
- 
-
 If the policy is not configured, end-users get the default behavior (Auto install and restart).
 
 <!--/Description-->
@@ -487,6 +482,11 @@ The following list shows the supported values:
 -   3 – Auto install and restart at a specified time. The IT specifies the installation day and time. If no day and time are specified, the default is 3 AM daily. Automatic installation happens at this time and device restart happens after a 15-minute countdown. If the user is logged in when Windows is ready to restart, the user can interrupt the 15-minute countdown to delay the restart.
 -   4 – Auto install and restart without end-user control. Updates are downloaded automatically on non-metered networks and installed during "Automatic Maintenance" when the device is not in use and is not running on battery power. If automatic maintenance is unable to install updates for two days, Windows Update will install updates right away. If a restart is required, then the device is automatically restarted when the device is not actively being used. This setting option also sets the end-user control panel to read-only.
 -   5 – Turn off automatic updates.
+
+
+> [!IMPORTANT]
+> This option should be used only for systems under regulatory compliance, as you will not get security updates as well.
+
 
 <!--/SupportedValues-->
 <!--/Policy-->


### PR DESCRIPTION
**Description:**

As reported in issue ticket #8580 (**The position of the "Important" section of Update/AllowAutoUpdate is incorrect. (Update/AllowAutoUpdate の「Important」セクションの位置が正しくありません)**), the current placement of the important Note blob does not make it clear enough which of the details it is referring to.

Placing the important note blob directly beneath bullet list point 5, which the important blob is referring to, makes it much more clear.

Thanks to 新宅 伸啓 (@ShintakuNobuhiro) for reporting this clarification issue.

**Proposed change:**
- move the important blob from its current location to directly after bullet list point 5, which the note refers to.

**Ticket closure or reference:**

Closes #8580