### PR TITLE
OCSP as alternative to CDP

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-key-trust-prereqs.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-key-trust-prereqs.md
@@ -67,7 +67,7 @@ Key trust deployments do not need client issued certificates for on-premises aut
 
 The minimum required Enterprise certificate authority that can be used with Windows Hello for Business is Windows Server 2012, but you can also use a third-party Enterprise certification authority. The requirements for the domain controller certificate are shown below. For more details, see [Requirements for domain controller certificates from a third-party CA](https://support.microsoft.com/help/291010/requirements-for-domain-controller-certificates-from-a-third-party-ca).
 
-* The certificate must have a Certificate Revocation List (CRL) distribution point extension that points to a valid CRL.
+* The certificate must have a Certificate Revocation List (CRL) distribution point extension that points to a valid CRL, or an Authority Information Access (AIA) extension that points to an Online Certificate Status Protocol (OCSP) responder.
 * The certificate Subject section should contain the directory path of the server object (the distinguished name).
 * The certificate Key Usage section must contain Digital Signature and Key Encipherment.
 * Optionally, the certificate Basic Constraints section should contain: [Subject Type=End Entity, Path Length Constraint=None].


### PR DESCRIPTION
A revocation check for the certificate must be possible, but it is not important that it is a CRL check. An OCSP check is valid as well.

This is the same as in any other place in Windows where certificates are checked.