### PR TITLE
Item is missing from proxy/firewall requirements

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/configure-proxy-internet.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/configure-proxy-internet.md
@@ -140,7 +140,8 @@ The information below list the proxy and firewall configuration information requ
 |------|---------|--------|--------|   
 |*.ods.opinsights.azure.com |Port 443 |Outbound|Yes |  
 |*.oms.opinsights.azure.com |Port 443 |Outbound|Yes |  
-|*.blob.core.windows.net |Port 443 |Outbound|Yes |  
+|*.blob.core.windows.net |Port 443 |Outbound|Yes |
+|*.azure-automation.net |Port 443 |Outbound|Yes |  
 
 
 > [!NOTE]


### PR DESCRIPTION
Should be the same as this link (missing *.azure-automation.net).  The *.azure-automation.net url is also called out and checked in the defender for endpoint connectivity analyzer.
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/log-analytics-agent#firewall-requirements