### PR TITLE
Defender SmartScreen: typo correction & URL update

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-smartscreen/microsoft-defender-smartscreen-overview.md
+++ b/windows/security/threat-protection/microsoft-defender-smartscreen/microsoft-defender-smartscreen-overview.md
@@ -67,12 +67,12 @@ When submitting Microsoft Defender SmartScreen products, make sure to select **M
 ## Viewing Microsoft Defender SmartScreen anti-phishing events
 
 > [!NOTE]
-> No Smartscreen events will be logged when using  Microsoft Edge version 77 or later.
+> No SmartScreen events will be logged when using  Microsoft Edge version 77 or later.
 
-When Microsoft Defender SmartScreen warns or blocks a user from a website, it's logged as [Event 1035 - Anti-Phishing](https://technet.microsoft.com/scriptcenter/dd565657(v=msdn.10).aspx).
+When Microsoft Defender SmartScreen warns or blocks a user from a website, it's logged as [Event 1035 - Anti-Phishing](https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/compatibility/dd565657(v=vs.85)).
 
 ## Viewing Windows event logs for Microsoft Defender SmartScreen
-Microsoft Defender SmartScreen events appear in the Microsoft-Windows-SmartScreen/Debug login Event Viewer.
+Microsoft Defender SmartScreen events appear in the Microsoft-Windows-SmartScreen/Debug log, in the Event Viewer.
 
 Windows event log for SmartScreen is disabled by default, users can use Event Viewer UI to enable the log or use the command line to enable it:
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #8665 (**Correction To Microsoft Defender SmartScreen "login", replace with "log in"**), there is a typo where the phrase "Debug log in Event Viewer" has lost its required spacing between "log" and "in".

Thanks to @secdev-01 for finding and reporting this typo.

**Changes proposed:**

- change "Debug login Event Viewer" to "Debug log, in the Event Viewer"

- the URL to the [Event 1035 - Anti-Phishing] page has been changed to reflect its permanent redirect from https://technet.microsoft.com/scriptcenter/dd565657(v=msdn.10).aspx to https://docs.microsoft.com/previous-versions/windows/internet-explorer/ie-developer/compatibility/dd565657(v=vs.85)

- "Smartscreen" adjusted to use the same type of CamelCase as its other occurrences, SmartScreen.

**Ticket closure or reference:**

Closes #8665