### PR TITLE
Typo correction & metadata description update

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-install-with-intune.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-install-with-intune.md
@@ -1,6 +1,6 @@
 ---
 title: Intune-based deployment for Microsoft Defender ATP for Mac
-description: Install Microsoft Defender ATP for Mac, using Microsoft Intune.
+description: Install Microsoft Defender for Endpoint for Mac, using Microsoft Intune.
 keywords: microsoft, defender, atp, mac, installation, deploy, uninstallation, intune, jamf, macos, catalina, mojave, high sierra
 search.product: eADQiWindows 10XVcnh
 search.appverid: met150
@@ -42,7 +42,7 @@ This topic describes how to deploy Microsoft Defender for Endpoint for Mac throu
 
 ## Prerequisites and system requirements
 
-Before you get started, see [the main MIcrosoft Defender for EndpointP for Mac page](microsoft-defender-atp-mac.md) for a description of prerequisites and system requirements for the current software version.
+Before you get started, see [the main Microsoft Defender for Endpoint for Mac page](microsoft-defender-atp-mac.md) for a description of prerequisites and system requirements for the current software version.
 
 ## Overview
 


### PR DESCRIPTION
**Description:**

As reported in issue ticket #8669 (**Check Grammar**), there is a typo in the following sentence:

> Before you get started, see the main MIcrosoft Defender for EndpointP for Mac page for a description of prerequisites and system requirements for the current software version.

The word "EndpointP" has received an unneeded letter at the end, sometime just before commit https://github.com/MicrosoftDocs/windows-itpro-docs/commit/5eb8d432da413dd0447b14e1b6763dc73dae3758 .

***

Edit: At the same time as the unneeded letter was added, the letter ` i ` in "Microsoft" got capitalized as well, so there were 2 undocumented changes in commit https://github.com/MicrosoftDocs/windows-itpro-docs/commit/5eb8d432da413dd0447b14e1b6763dc73dae3758 (not sure how it could happen without GitHub marking those changes in that commit). Both typos will be corrected by this PR.

***

Thanks to @matambanadzo for noticing and reporting this typo.

**Additional change:** 
The metadata description (name) text is now updated from
- Install Microsoft Defender ATP for Mac, using Microsoft Intune.
 -- to --
- Install Microsoft Defender for Endpoint for Mac, using Microsoft Intune.

**Ticket closure or reference:**

Closes #8669