### PR TITLE
Hybrid WHfB: MarkDown code format, whitespace, typos

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -143,7 +143,7 @@ If your AD FS farm is not already configured for Device Authentication (you can 
 3. On the pop-up window click **Yes**.
 
 > [!NOTE]
-> If your AD FS service is configured to use a GMSA account, enter the account name in the format "domain\accountname$"
+> If your AD FS service is configured to use a GMSA account, enter the account name in the format "domain\accountname$".
 
 ![Device Registration](images/hybridct/device3.png)
 

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -204,7 +204,7 @@ To ensure AD DS objects and containers are in the correct state for write back o
 
 Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format.
 
-The above command creates the following objects for device write back to AD DS, if they do not exist already, and allows access to the specified AD connector account name
+The above command creates the following objects for device write back to AD DS, if they do not exist already, and allows access to the specified AD connector account name:
 
 - RegisteredDevices container in the AD domain partition
 - Device Registration Service container and object under Configuration --> Services --> Device Registration Configuration

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -97,7 +97,7 @@ Sign in to the domain controller hosting the schema master operational role usin
 > If you installed Azure AD Connect prior to upgrading the schema, you will need to re-run the Azure AD Connect installation and refresh the on-premises AD schema to ensure the synchronization rule for msDS-KeyCredentialLink is configured.
 
 
-### Setup Active Directory Federation Services
+### Set up Active Directory Federation Services
 
 If you are new to AD FS and federation services, you should review [Understanding Key AD FS Concepts](https://docs.microsoft.com/windows-server/identity/ad-fs/technical-reference/understanding-key-ad-fs-concepts) to prior to designing and deploying your federation service.
 Review the [AD FS Design guide](https://docs.microsoft.com/windows-server/identity/ad-fs/design/ad-fs-design-guide-in-windows-server-2012-r2) to plan your federation service.

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -58,7 +58,7 @@ To do this, follow the **Configure device settings** steps under [Setting up Azu
 
 ## Configure Active Directory to support Azure device synchronization
 
-Azure Active Directory is now configured for device registration. Next, you need to configure the on-premises Active Directory to support synchronizing hybrid Azure AD joined devices. Begin with upgrading the Active Directory Schema
+Azure Active Directory is now configured for device registration. Next, you need to configure the on-premises Active Directory to support synchronizing hybrid Azure AD joined devices. Begin with upgrading the Active Directory Schema.
 
 ### Upgrading Active Directory to the Windows Server 2016 or later Schema
 
@@ -135,11 +135,11 @@ If your AD FS farm is not already configured for Device Authentication (you can 
 
 2. On your AD FS primary server, ensure you are logged in as AD DS user with enterprise administrator privileges and open an elevated Windows PowerShell prompt. Then, run the following commands:
 
-   ```powershell
-   Import-module activedirectory
+   ```PowerShell
+   Import-module activedirectory`
    Initialize-ADDeviceRegistration -ServiceAccountName "<your service account>"
    ```
-   
+
 3. On the pop-up window click **Yes**.
 
 > [!NOTE]
@@ -165,7 +165,7 @@ If you plan to use Windows 10 domain join (with automatic registration to Azure 
 
 1. Open Windows PowerShell and execute the following:
 
-   ```powershell
+   ```PowerShell
    Import-Module -Name "C:\Program Files\Microsoft Azure Active Directory Connect\AdPrep\AdSyncPrep.psm1"
    ```
 
@@ -176,16 +176,16 @@ If you plan to use Windows 10 domain join (with automatic registration to Azure 
 
 2. Provide your Azure AD global administrator credentials
 
-   ```powershell
-   $aadAdminCred = Get-Credential`
-   ```
+   ```PowerShell
+   $aadAdminCred = Get-Credential
+  ```
 
 ![Device Registration](images/hybridct/device7.png)
 
 3. Run the following PowerShell command
 
-   ```powershell
-   Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred
+   ```PowerShell
+   Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred`
    ```
 
 Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory.
@@ -198,8 +198,8 @@ To ensure AD DS objects and containers are in the correct state for write back o
 
 1. Open Windows PowerShell and execute the following:
 
-   ```powershell
-   Initialize-ADSyncDeviceWriteBack -DomainName <AD DS domain name> -AdConnectorAccount [AD connector account name]`
+   ```PowerShell
+   Initialize-ADSyncDeviceWriteBack -DomainName <AD DS domain name> -AdConnectorAccount [AD connector account name]
    ```
 
 Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format
@@ -266,6 +266,7 @@ The definition helps you to verify whether the values are present or if you need
 
 **`http://schemas.microsoft.com/ws/2012/01/accounttype`** - This claim must contain a value of **DJ**, which identifies the device as a domain-joined computer. In AD FS, you can add an issuance transform rule that looks like this:
 
+    ```aspx
     @RuleName = "Issue account type for domain-joined computers"
     c:[
         Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
@@ -276,11 +277,13 @@ The definition helps you to verify whether the values are present or if you need
         Type = "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value = "DJ"
     );
+    ```
 
 #### Issue objectGUID of the computer account on-premises
 
 **`http://schemas.microsoft.com/identity/claims/onpremobjectguid`** - This claim must contain the **objectGUID** value of the on-premises computer account. In AD FS, you can add an issuance transform rule that looks like this:
 
+    ```aspx
     @RuleName = "Issue object GUID for domain-joined computers"
     c1:[
         Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
@@ -298,11 +301,13 @@ The definition helps you to verify whether the values are present or if you need
         query = ";objectguid;{0}",
         param = c2.Value
     );
+    ```
 
 #### Issue objectSID of the computer account on-premises
 
 **`http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid`** - This claim must contain the **objectSid** value of the on-premises computer account. In AD FS, you can add an issuance transform rule that looks like this:
 
+    ```aspx
     @RuleName = "Issue objectSID for domain-joined computers"
     c1:[
         Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
@@ -315,11 +320,13 @@ The definition helps you to verify whether the values are present or if you need
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(claim = c2);
+    ```
 
 #### Issue issuerID for computer when multiple verified domain names in Azure AD
 
 **`http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid`** - This claim must contain the Uniform Resource Identifier (URI) of any of the verified domain names that connect with the on-premises federation service (AD FS or 3rd party) issuing the token. In AD FS, you can add issuance transform rules that look like the ones below in that specific order after the ones above. Please note that one rule to explicitly issue the rule for users is necessary. In the rules below, a first rule identifying user vs. computer authentication is added.
 
+    ```aspx
     @RuleName = "Issue account type with the value User when it is not a computer"
 
     NOT EXISTS(
@@ -361,6 +368,7 @@ The definition helps you to verify whether the values are present or if you need
         Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
         Value = "http://<verified-domain-name>/adfs/services/trust/"
     );
+    ```
 
 
 In the claim above,
@@ -375,6 +383,7 @@ To get a list of your verified company domains, you can use the [Get-MsolDomain]
 
 **`http://schemas.microsoft.com/LiveID/Federation/2008/05/ImmutableID`** - This claim must contain a valid value for computers. In AD FS, you can create an issuance transform rule as follows:
 
+    ```aspx
     @RuleName = "Issue ImmutableID for computers"
     c1:[
         Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
@@ -392,11 +401,13 @@ To get a list of your verified company domains, you can use the [Get-MsolDomain]
         query = ";objectguid;{0}",
         param = c2.Value
     );
+    ```
 
 #### Helper script to create the AD FS issuance transform rules
 
 The following script helps you with the creation of the issuance transform rules described above.
 
+    ```aspx
     $multipleVerifiedDomainNames = $false
     $immutableIDAlreadyIssuedforUsers = $false
     $oneOfVerifiedDomainNames = 'example.com'   # Replace example.com with one of your verified domains
@@ -515,6 +526,7 @@ The following script helps you with the creation of the issuance transform rules
     $crSet = New-ADFSClaimRuleSet -ClaimRule $updatedRules
 
     Set-AdfsRelyingPartyTrust -TargetIdentifier urn:federation:MicrosoftOnline -IssuanceTransformRules $crSet.ClaimRulesString
+    ```
 
 
 #### Remarks
@@ -523,10 +535,19 @@ The following script helps you with the creation of the issuance transform rules
 
 - If you have multiple verified domain names (as shown in the Azure AD portal or via the Get-MsolDomains cmdlet), set the value of **$multipleVerifiedDomainNames** in the script to **$true**. Also make sure that you remove any existing issuerID claim that might have been created by Azure AD Connect or via other means. Here is an example for this rule:
 
-```
-c:[Type == "http://schemas.xmlsoap.org/claims/UPN"]
-=> issue(Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", Value = regexreplace(c.Value, ".+@(?<domain>.+)",  "http://${domain}/adfs/services/trust/"));
-```
+    ```aspx
+    c:[
+        Type == "http://schemas.xmlsoap.org/claims/UPN"
+    ]
+    => issue(
+        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
+        Value = regexreplace(
+        c.Value,
+        ".+@(?<domain>.+)",
+        "http://${domain}/adfs/services/trust/"
+        )
+    );
+    ```
 
 - If you have already issued an **ImmutableID** claim  for user accounts, set the value of **$immutableIDAlreadyIssuedforUsers** in the script to **$true**.
 
@@ -534,13 +555,13 @@ c:[Type == "http://schemas.xmlsoap.org/claims/UPN"]
 
 Using an elevated PowerShell command window, configure AD FS policy by executing the following command
 
-```powershell
+```PowerShell
 Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAuthenticationMethod SignedToken
 ```
 
 #### Check your configuration
 
-For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work:
+For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work
 
 - object of type ms-DS-DeviceContainer at CN=RegisteredDevices,DC=&lt;domain&gt;
     - read access to the AD FS service account

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -99,7 +99,7 @@ Sign in to the domain controller hosting the schema master operational role usin
 
 ### Set up Active Directory Federation Services
 
-If you are new to AD FS and federation services, you should review [Understanding Key AD FS Concepts](https://docs.microsoft.com/windows-server/identity/ad-fs/technical-reference/understanding-key-ad-fs-concepts) to prior to designing and deploying your federation service.
+If you are new to AD FS and federation services, you should review [Understanding Key AD FS Concepts](https://docs.microsoft.com/windows-server/identity/ad-fs/technical-reference/understanding-key-ad-fs-concepts) prior to designing and deploying your federation service.
 Review the [AD FS Design guide](https://docs.microsoft.com/windows-server/identity/ad-fs/design/ad-fs-design-guide-in-windows-server-2012-r2) to plan your federation service.
 
 Once you have your AD FS design ready, review [Deploying a Federation Server farm](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/deploying-a-federation-server-farm) to configure AD FS in your environment.

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -85,7 +85,7 @@ Windows Hello for Business uses asymmetric keys as user credentials (rather than
 
 Manually updating Active Directory uses the command-line utility **adprep.exe** located at **\<drive>:\support\adprep** on the Windows Server 2016 or later DVD or ISO. Before running adprep.exe, you must identify the domain controller hosting the schema master role.
 
-Sign-in to the domain controller hosting the schema master operational role using enterprise administrator equivalent credentials.
+Sign in to the domain controller hosting the schema master operational role using enterprise administrator equivalent credentials.
 
 1. Open an elevated command prompt.
 2. Type `cd /d x:\support\adprep` where *x* is the drive letter of the DVD or mounted ISO.

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -136,7 +136,7 @@ If your AD FS farm is not already configured for Device Authentication (you can 
 2. On your AD FS primary server, ensure you are logged in as AD DS user with enterprise administrator privileges and open an elevated Windows PowerShell prompt. Then, run the following commands:
 
    ```PowerShell
-   Import-module activedirectory`
+   Import-module activedirectory
    Initialize-ADDeviceRegistration -ServiceAccountName "<your service account>"
    ```
 
@@ -178,14 +178,14 @@ If you plan to use Windows 10 domain join (with automatic registration to Azure 
 
    ```PowerShell
    $aadAdminCred = Get-Credential
-  ```
+   ```
 
 ![Device Registration](images/hybridct/device7.png)
 
 3. Run the following PowerShell command
 
    ```PowerShell
-   Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred`
+   Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred
    ```
 
 Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory.
@@ -561,7 +561,7 @@ Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAut
 
 #### Check your configuration
 
-For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work
+For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work:
 
 - object of type ms-DS-DeviceContainer at CN=RegisteredDevices,DC=&lt;domain&gt;
     - read access to the AD FS service account

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -107,7 +107,7 @@ Once you have your AD FS design ready, review [Deploying a Federation Server far
 > [!IMPORTANT]
 > During your AD FS deployment, skip the **Configure a federation server with Device Registration Service** and the **Configure Corporate DNS for the Federation Service and DRS** procedures.
 
-The AD FS farm used with Windows Hello for Business must be Windows Server 2016 with minimum update of [KB4088889 (14393.2155)](https://support.microsoft.com/help/4088889). If your AD FS farm is not running the AD FS role with updates from Windows Server 2016, then read [Upgrading to AD FS in Windows Server 2016](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server-2016)
+The AD FS farm used with Windows Hello for Business must be Windows Server 2016 with minimum update of [KB4088889 (14393.2155)](https://support.microsoft.com/help/4088889). If your AD FS farm is not running the AD FS role with updates from Windows Server 2016, then read [Upgrading to AD FS in Windows Server 2016](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server-2016).
 
 #### ADFS Web Proxy
 

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -14,25 +14,27 @@ ms.collection: M365-identity-device-management
 ms.topic: article
 localizationpriority: medium
 ms.date: 08/18/2018
-ms.reviewer: 
+ms.reviewer:
 ---
+
 # Configure Device Registration for Hybrid Windows Hello for Business
 
 **Applies to**
--  Windows 10, version 1703 or later
--  Hybrid deployment
--  Certificate trust
+- Windows 10, version 1703 or later
+- Hybrid deployment
+- Certificate trust
 
 
-Your environment is federated and you are ready to configure device registration for your hybrid environment. Hybrid Windows Hello for Business deployment needs device registration and device write-back to enable proper device authentication.  
+Your environment is federated and you are ready to configure device registration for your hybrid environment. Hybrid Windows Hello for Business deployment needs device registration and device write-back to enable proper device authentication.
 
 > [!IMPORTANT]
-> If your environment is not federated, review the [New Installation baseline](hello-hybrid-cert-new-install.md) section of this deployment document to learn how to federate your environment for your Windows Hello for Business deployment. 
+> If your environment is not federated, review the [New Installation baseline](hello-hybrid-cert-new-install.md) section of this deployment document to learn how to federate your environment for your Windows Hello for Business deployment.
 
->[!TIP]
->Refer to the [Tutorial: Configure hybrid Azure Active Directory join for federated domains](https://docs.microsoft.com/azure/active-directory/devices/hybrid-azuread-join-federated-domains) to learn more about setting up Azure Active Directory Connect for a simplified join flow for Azure AD device registration.
+> [!TIP]
+> Refer to the [Tutorial: Configure hybrid Azure Active Directory join for federated domains](https://docs.microsoft.com/azure/active-directory/devices/hybrid-azuread-join-federated-domains) to learn more about setting up Azure Active Directory Connect for a simplified join flow for Azure AD device registration.
 
-Use this three-phased approach for configuring device registration.
+Use this three-phased approach for configuring device registration:
+
 1. [Configure devices to register in Azure](#configure-azure-for-device-registration)
 2. [Synchronize devices to on-premises Active Directory](#configure-active-directory-to-support-azure-device-synchronization)
 3. [Configure AD FS to use cloud devices](#configure-ad-fs-to-use-azure-registered-devices)
@@ -45,148 +47,171 @@ Use this three-phased approach for configuring device registration.
 >
 > You can learn about this and more by reading [Introduction to Device Management in Azure Active Directory.](https://docs.microsoft.com/azure/active-directory/device-management-introduction)
 
->[!IMPORTANT]
+> [!IMPORTANT]
 > To use hybrid identity with Azure Active Directory and device WriteBack features, you must use the built-in GUI with the [latest updates for ADConnect](https://www.microsoft.com/download/details.aspx?id=47594).
 
 ## Configure Azure for Device Registration
-Begin configuring device registration to support Hybrid Windows Hello for Business by configuring device registration capabilities in Azure AD. 
 
-To do this, follow the **Configure device settings** steps under [Setting up Azure AD Join in your organization](https://azure.microsoft.com/documentation/articles/active-directory-azureadjoin-setup/)  
+Begin configuring device registration to support Hybrid Windows Hello for Business by configuring device registration capabilities in Azure AD.
+
+To do this, follow the **Configure device settings** steps under [Setting up Azure AD Join in your organization](https://azure.microsoft.com/documentation/articles/active-directory-azureadjoin-setup/)
 
 ## Configure Active Directory to support Azure device synchronization
 
-Azure Active Directory is now configured for device registration. Next, you need to configure the on-premises Active Directory to support synchronizing hybrid Azure AD joined devices. Begin with upgrading the Active Directory Schema 
+Azure Active Directory is now configured for device registration. Next, you need to configure the on-premises Active Directory to support synchronizing hybrid Azure AD joined devices. Begin with upgrading the Active Directory Schema
 
-### Upgrading Active Directory to the Windows Server 2016 or later Schema 
+### Upgrading Active Directory to the Windows Server 2016 or later Schema
 
-To use Windows Hello for Business with Hybrid Azure AD joined devices, you must first upgrade your Active Directory schema to Windows Server 2016 or later. 
+To use Windows Hello for Business with Hybrid Azure AD joined devices, you must first upgrade your Active Directory schema to Windows Server 2016 or later.
 
 > [!IMPORTANT]
 > If you already have a Windows Server 2016 or later domain controller in your forest, you can skip **Upgrading Active Directory to the Windows Server 2016 or later Schema** (this section).
 
 #### Identify the schema role domain controller
 
-To locate the schema master role holder, open and command prompt and type:
+To locate the schema master role holder, open a command prompt and type:
 
-```Netdom query fsmo | findstr -i schema```
+```
+Netdom query fsmo | findstr -i schema
+```
 
 ![Netdom example output](images/hello-cmd-netdom.png)
 
-The command should return the name of the domain controller where you need to run adprep.exe.  Update the schema locally on the domain controller hosting the Schema master role.
+The command should return the name of the domain controller where you need to run adprep.exe. Update the schema locally on the domain controller hosting the Schema master role.
 
 #### Updating the Schema
 
-Windows Hello for Business uses asymmetric keys as user credentials (rather than passwords).  During enrollment, the public key is registered in an attribute on the user object in Active Directory.  The schema update adds this new attribute to Active Directory.  
+Windows Hello for Business uses asymmetric keys as user credentials (rather than passwords). During enrollment, the public key is registered in an attribute on the user object in Active Directory. The schema update adds this new attribute to Active Directory.
 
-Manually updating Active Directory uses the command-line utility **adprep.exe** located at **\<drive>:\support\adprep** on the Windows Server 2016 or later DVD or ISO.  Before running adprep.exe, you must identify the domain controller hosting the schema master role.
+Manually updating Active Directory uses the command-line utility **adprep.exe** located at **\<drive>:\support\adprep** on the Windows Server 2016 or later DVD or ISO. Before running adprep.exe, you must identify the domain controller hosting the schema master role.
 
 Sign-in to the domain controller hosting the schema master operational role using enterprise administrator equivalent credentials.
 
-1.  Open an elevated command prompt.
-2.  Type ```cd /d x:\support\adprep``` where *x* is the drive letter of the DVD or mounted ISO.
-3.  To update the schema, type ```adprep /forestprep```.
-4.  Read the Adprep Warning.  Type the letter **C*** and press **Enter** to update the schema.
-5.  Close the Command Prompt and sign-out.
+1. Open an elevated command prompt.
+2. Type `cd /d x:\support\adprep` where *x* is the drive letter of the DVD or mounted ISO.
+3. To update the schema, type `adprep /forestprep` .
+4. Read the Adprep Warning. Type the letter **C*** and press **Enter** to update the schema.
+5. Close the Command Prompt and sign out.
 
 > [!NOTE]
 > If you installed Azure AD Connect prior to upgrading the schema, you will need to re-run the Azure AD Connect installation and refresh the on-premises AD schema to ensure the synchronization rule for msDS-KeyCredentialLink is configured.
 
 
 ### Setup Active Directory Federation Services
+
 If you are new to AD FS and federation services, you should review [Understanding Key AD FS Concepts](https://docs.microsoft.com/windows-server/identity/ad-fs/technical-reference/understanding-key-ad-fs-concepts) to prior to designing and deploying your federation service.
 Review the [AD FS Design guide](https://docs.microsoft.com/windows-server/identity/ad-fs/design/ad-fs-design-guide-in-windows-server-2012-r2) to plan your federation service.
 
 Once you have your AD FS design ready, review [Deploying a Federation Server farm](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/deploying-a-federation-server-farm) to configure AD FS in your environment.
+
 > [!IMPORTANT]
-> During your AD FS deployment, skip the **Configure a federation server with Device Registration Service** and the **Configure Corporate DNS for the Federation Service and DRS** procedures.      
+> During your AD FS deployment, skip the **Configure a federation server with Device Registration Service** and the **Configure Corporate DNS for the Federation Service and DRS** procedures.
 
-The AD FS farm used with Windows Hello for Business must be Windows Server 2016 with minimum update of [KB4088889 (14393.2155)](https://support.microsoft.com/help/4088889).  If your AD FS farm is not running the AD FS role with updates from Windows Server 2016, then read [Upgrading to AD FS in Windows Server 2016](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server-2016)
+The AD FS farm used with Windows Hello for Business must be Windows Server 2016 with minimum update of [KB4088889 (14393.2155)](https://support.microsoft.com/help/4088889). If your AD FS farm is not running the AD FS role with updates from Windows Server 2016, then read [Upgrading to AD FS in Windows Server 2016](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/upgrading-to-ad-fs-in-windows-server-2016)
 
-#### ADFS Web Proxy ###
+#### ADFS Web Proxy
+
 Federation server proxies are computers that run AD FS software that have been configured manually to act in the proxy role. You can use federation server proxies in your organization to provide intermediary services between an Internet client and a federation server that is behind a firewall on your corporate network.
 Use the [Setting of a Federation Proxy](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/checklist--setting-up-a-federation-server-proxy) checklist to configure AD FS proxy servers in your environment.
 
 ### Deploy Azure AD Connect
-Next, you need to synchronize the on-premises Active Directory with Azure Active Directory.  To do this, first review the [Integrating on-prem directories with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect) and [hardware and prerequisites](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect-prerequisites) needed and then [download the software](https://go.microsoft.com/fwlink/?LinkId=615771).
 
-When you are ready to install, follow the **Configuring federation with AD FS** section of [Custom installation of Azure AD Connect](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect-get-started-custom).  Select the **Federation with AD FS** option on the **User sign-in** page.  At the **AD FS Farm** page, select the use an existing option and click **Next**.  
+Next, you need to synchronize the on-premises Active Directory with Azure Active Directory. To do this, first review the [Integrating on-prem directories with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect) and [hardware and prerequisites](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect-prerequisites) needed and then [download the software](https://go.microsoft.com/fwlink/?LinkId=615771).
 
-### Create AD objects for AD FS Device Authentication  
-If your AD FS farm is not already configured for Device Authentication (you can see this in the AD FS Management console under Service -> Device Registration), use the following steps to create the correct AD DS objects and configuration.  
+When you are ready to install, follow the **Configuring federation with AD FS** section of [Custom installation of Azure AD Connect](https://docs.microsoft.com/azure/active-directory/connect/active-directory-aadconnect-get-started-custom). Select the **Federation with AD FS** option on the **User sign-in** page. At the **AD FS Farm** page, select the use an existing option and click **Next**.
+
+### Create AD objects for AD FS Device Authentication
+
+If your AD FS farm is not already configured for Device Authentication (you can see this in the AD FS Management console under Service -> Device Registration), use the following steps to create the correct AD DS objects and configuration.
 
 ![Device Registration](images/hybridct/device1.png)
 
 > [!NOTE]
-> The below commands require Active Directory administration tools, so if your federation server is not also a domain controller, first install the tools using step 1 below.  Otherwise you can skip step 1.  
+> The below commands require Active Directory administration tools, so if your federation server is not also a domain controller, first install the tools using step 1 below. Otherwise you can skip step 1.
 
-1.  Run the **Add Roles & Features** wizard and select feature **Remote Server Administration Tools** -> **Role Administration Tools** -> **AD DS and AD LDS Tools** -> Choose both the **Active Directory module for Windows PowerShell** and the **AD DS Tools**.
+1. Run the **Add Roles & Features** wizard and select feature **Remote Server Administration Tools** -> **Role Administration Tools** -> **AD DS and AD LDS Tools** -> Choose both the **Active Directory module for Windows PowerShell** and the **AD DS Tools**.
 
 ![Device Registration](images/hybridct/device2.png)
 
-2. On your AD FS primary server, ensure you are logged in as AD DS user with enterprise administrator privileges and open an elevated Windows PowerShell prompt.  Then, run the following commands:  
+2. On your AD FS primary server, ensure you are logged in as AD DS user with enterprise administrator privileges and open an elevated Windows PowerShell prompt. Then, run the following commands:
 
-   `Import-module activedirectory`  
-   `PS C:\> Initialize-ADDeviceRegistration -ServiceAccountName "<your service account>"` 
+   ```powershell
+   Import-module activedirectory
+   Initialize-ADDeviceRegistration -ServiceAccountName "<your service account>"
+   ```
+   
 3. On the pop-up window click **Yes**.
 
 > [!NOTE]
 > If your AD FS service is configured to use a GMSA account, enter the account name in the format "domain\accountname$"
 
-![Device Registration](images/hybridct/device3.png)  
+![Device Registration](images/hybridct/device3.png)
 
-The above PSH creates the following objects:  
+The above PSH creates the following objects:
 
-- RegisteredDevices container under the AD domain partition  
-- Device Registration Service container and object under Configuration --> Services --> Device Registration Configuration  
-- Device Registration Service DKM container and object under Configuration --> Services --> Device Registration Configuration  
+- RegisteredDevices container under the AD domain partition
+- Device Registration Service container and object under Configuration --> Services --> Device Registration Configuration
+- Device Registration Service DKM container and object under Configuration --> Services --> Device Registration Configuration
 
-![Device Registration](images/hybridct/device4.png)  
+![Device Registration](images/hybridct/device4.png)
 
 4. Once this is done, you will see a successful completion message.
 
-![Device Registration](images/hybridct/device5.png) 
+![Device Registration](images/hybridct/device5.png)
 
-### Create Service Connection Point (SCP) in Active Directory  
-If you plan to use Windows 10 domain join (with automatic registration to Azure AD) as described here, execute the following commands to create a service connection point in AD DS  
-1.  Open Windows PowerShell and execute the following:
+### Create Service Connection Point (SCP) in Active Directory
 
-    `PS C:>Import-Module -Name "C:\Program Files\Microsoft Azure Active Directory Connect\AdPrep\AdSyncPrep.psm1"` 
+If you plan to use Windows 10 domain join (with automatic registration to Azure AD) as described here, execute the following commands to create a service connection point in AD DS:
+
+1. Open Windows PowerShell and execute the following:
+
+   ```powershell
+   Import-Module -Name "C:\Program Files\Microsoft Azure Active Directory Connect\AdPrep\AdSyncPrep.psm1"
+   ```
 
 > [!NOTE]
-> If necessary, copy the AdSyncPrep.psm1 file from your Azure AD Connect server.  This file is located in Program Files\Microsoft Azure Active Directory Connect\AdPrep
+> If necessary, copy the AdSyncPrep.psm1 file from your Azure AD Connect server. This file is located in Program Files\Microsoft Azure Active Directory Connect\AdPrep .
 
-![Device Registration](images/hybridct/device6.png)   
+![Device Registration](images/hybridct/device6.png)
 
-2. Provide your Azure AD global administrator credentials  
+2. Provide your Azure AD global administrator credentials
 
-    `PS C:>$aadAdminCred = Get-Credential`
+   ```powershell
+   $aadAdminCred = Get-Credential`
+   ```
 
-![Device Registration](images/hybridct/device7.png) 
+![Device Registration](images/hybridct/device7.png)
 
-3. Run the following PowerShell command 
+3. Run the following PowerShell command
 
-   `PS C:>Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred` 
+   ```powershell
+   Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred
+   ```
 
 Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory.
 
-The above commands enable Windows 10 clients to find the correct Azure AD domain to join by creating the serviceConnectionpoint object in AD DS.  
+The above commands enable Windows 10 clients to find the correct Azure AD domain to join by creating the serviceConnectionpoint object in AD DS.
 
-### Prepare AD for Device Write Back   
+### Prepare AD for Device Write Back
+
 To ensure AD DS objects and containers are in the correct state for write back of devices from Azure AD, do the following.
 
-1.  Open Windows PowerShell and execute the following:  
+1. Open Windows PowerShell and execute the following:
 
-    `PS C:>Initialize-ADSyncDeviceWriteBack -DomainName <AD DS domain name> -AdConnectorAccount [AD connector account name]` 
+   ```powershell
+   Initialize-ADSyncDeviceWriteBack -DomainName <AD DS domain name> -AdConnectorAccount [AD connector account name]`
+   ```
 
-Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format  
+Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format
 
-The above command creates the following objects for device write back to AD DS, if they do not exist already, and allows access to the specified AD connector account name  
+The above command creates the following objects for device write back to AD DS, if they do not exist already, and allows access to the specified AD connector account name
 
-- RegisteredDevices container in the AD domain partition  
-- Device Registration Service container and object under Configuration --> Services --> Device Registration Configuration  
+- RegisteredDevices container in the AD domain partition
+- Device Registration Service container and object under Configuration --> Services --> Device Registration Configuration
 
-### Enable Device Write Back in Azure AD Connect  
-If you have not done so before, enable device write back in Azure AD Connect by running the wizard a second time and selecting **"Customize Synchronization Options"**, then checking the box for device write back and selecting the forest in which you have run the above cmdlets  
+### Enable Device Write Back in Azure AD Connect
+
+If you have not done so before, enable device write back in Azure AD Connect by running the wizard a second time and selecting **"Customize Synchronization Options"**, then checking the box for device write back and selecting the forest in which you have run the above cmdlets
 
 ## Configure AD FS to use Azure registered devices
 
@@ -197,12 +222,15 @@ In a federated Azure AD configuration, devices rely on Active Directory Federati
 Windows current devices authenticate using Integrated Windows Authentication to an active WS-Trust endpoint (either 1.3 or 2005 versions) hosted by the on-premises federation service.
 
 When you're using AD FS, you need to enable the following WS-Trust endpoints:
-`/adfs/services/trust/2005/windowstransport` 
-`/adfs/services/trust/13/windowstransport` 
-`/adfs/services/trust/2005/usernamemixed`
-`/adfs/services/trust/13/usernamemixed`
-`/adfs/services/trust/2005/certificatemixed`
-`/adfs/services/trust/13/certificatemixed`
+
+```
+/adfs/services/trust/2005/windowstransport
+/adfs/services/trust/13/windowstransport
+/adfs/services/trust/2005/usernamemixed
+/adfs/services/trust/13/usernamemixed
+/adfs/services/trust/2005/certificatemixed
+/adfs/services/trust/13/certificatemixed
+```
 
 > [!WARNING]
 > Both **adfs/services/trust/2005/windowstransport** and **adfs/services/trust/13/windowstransport** should be enabled as intranet facing endpoints only and must NOT be exposed as extranet facing endpoints through the Web Application Proxy. To learn more on how to disable WS-Trust Windows endpoints, see [Disable WS-Trust Windows endpoints on the proxy](https://docs.microsoft.com/windows-server/identity/ad-fs/deployment/best-practices-securing-ad-fs#disable-ws-trust-windows-endpoints-on-the-proxy-ie-from-extranet). You can see what endpoints are enabled through the AD FS management console under **Service** > **Endpoints**.
@@ -240,12 +268,12 @@ The definition helps you to verify whether the values are present or if you need
 
     @RuleName = "Issue account type for domain-joined computers"
     c:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value = "DJ"
     );
 
@@ -255,19 +283,19 @@ The definition helps you to verify whether the values are present or if you need
 
     @RuleName = "Issue object GUID for domain-joined computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        store = "Active Directory", 
-        types = ("http://schemas.microsoft.com/identity/claims/onpremobjectguid"), 
-        query = ";objectguid;{0}", 
+        store = "Active Directory",
+        types = ("http://schemas.microsoft.com/identity/claims/onpremobjectguid"),
+        query = ";objectguid;{0}",
         param = c2.Value
     );
 
@@ -277,13 +305,13 @@ The definition helps you to verify whether the values are present or if you need
 
     @RuleName = "Issue objectSID for domain-joined computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(claim = c2);
@@ -296,12 +324,12 @@ The definition helps you to verify whether the values are present or if you need
 
     NOT EXISTS(
     [
-        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value == "DJ"
     ]
     )
     => add(
-        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value = "User"
     );
 
@@ -309,28 +337,28 @@ The definition helps you to verify whether the values are present or if you need
     c1:[
         Type == "http://schemas.xmlsoap.org/claims/UPN"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value == "User"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", 
+        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
         Value = regexreplace(
-        c1.Value, 
-        ".+@(?<domain>.+)", 
+        c1.Value,
+        ".+@(?<domain>.+)",
         "http://${domain}/adfs/services/trust/"
         )
     );
 
     @RuleName = "Issue issuerID for domain-joined computers"
     c:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", 
+        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
         Value = "http://<verified-domain-name>/adfs/services/trust/"
     );
 
@@ -340,8 +368,8 @@ In the claim above,
 - `$<domain>` is the AD FS service URL
 - `<verified-domain-name>` is a placeholder you need to replace with one of your verified domain names in Azure AD
 
-For more details about verified domain names, see [Add a custom domain name to Azure Active Directory](https://docs.microsoft.com/azure/active-directory/active-directory-add-domain).  
-To get a list of your verified company domains, you can use the [Get-MsolDomain](https://docs.microsoft.com/powershell/module/msonline/get-msoldomain?view=azureadps-1.0) cmdlet. 
+For more details about verified domain names, see [Add a custom domain name to Azure Active Directory](https://docs.microsoft.com/azure/active-directory/active-directory-add-domain).
+To get a list of your verified company domains, you can use the [Get-MsolDomain](https://docs.microsoft.com/powershell/module/msonline/get-msoldomain?view=azureadps-1.0) cmdlet.
 
 #### Issue ImmutableID for computer when one for users exist (e.g. alternate login ID is set)
 
@@ -349,19 +377,19 @@ To get a list of your verified company domains, you can use the [Get-MsolDomain]
 
     @RuleName = "Issue ImmutableID for computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
-    ] 
-    && 
+    ]
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        store = "Active Directory", 
-        types = ("http://schemas.microsoft.com/LiveID/Federation/2008/05/ImmutableID"), 
-        query = ";objectguid;{0}", 
+        store = "Active Directory",
+        types = ("http://schemas.microsoft.com/LiveID/Federation/2008/05/ImmutableID"),
+        query = ";objectguid;{0}",
         param = c2.Value
     );
 
@@ -375,42 +403,42 @@ The following script helps you with the creation of the issuance transform rules
 
     $rule1 = '@RuleName = "Issue account type for domain-joined computers"
     c:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value = "DJ"
     );'
 
     $rule2 = '@RuleName = "Issue object GUID for domain-joined computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        store = "Active Directory", 
-        types = ("http://schemas.microsoft.com/identity/claims/onpremobjectguid"), 
-        query = ";objectguid;{0}", 
+        store = "Active Directory",
+        types = ("http://schemas.microsoft.com/identity/claims/onpremobjectguid"),
+        query = ";objectguid;{0}",
         param = c2.Value
     );'
 
     $rule3 = '@RuleName = "Issue objectSID for domain-joined computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(claim = c2);'
@@ -420,12 +448,12 @@ The following script helps you with the creation of the issuance transform rules
     $rule4 = '@RuleName = "Issue account type with the value User when it is not a computer"
     NOT EXISTS(
     [
-        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value == "DJ"
     ]
     )
     => add(
-        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type = "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value = "User"
     );
 
@@ -433,28 +461,28 @@ The following script helps you with the creation of the issuance transform rules
     c1:[
         Type == "http://schemas.xmlsoap.org/claims/UPN"
     ]
-    && 
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype", 
+        Type == "http://schemas.microsoft.com/ws/2012/01/accounttype",
         Value == "User"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", 
+        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
         Value = regexreplace(
-        c1.Value, 
-        ".+@(?<domain>.+)", 
+        c1.Value,
+        ".+@(?<domain>.+)",
         "http://${domain}/adfs/services/trust/"
         )
     );
 
     @RuleName = "Issue issuerID for domain-joined computers"
     c:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", 
+        Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid",
         Value = "http://' + $oneOfVerifiedDomainNames + '/adfs/services/trust/"
     );'
     }
@@ -463,64 +491,67 @@ The following script helps you with the creation of the issuance transform rules
     if ($immutableIDAlreadyIssuedforUsers -eq $true) {
     $rule5 = '@RuleName = "Issue ImmutableID for computers"
     c1:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid", 
-        Value =~ "-515$", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid",
+        Value =~ "-515$",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
-    ] 
-    && 
+    ]
+    &&
     c2:[
-        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", 
+        Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname",
         Issuer =~ "^(AD AUTHORITY|SELF AUTHORITY|LOCAL AUTHORITY)$"
     ]
     => issue(
-        store = "Active Directory", 
-        types = ("http://schemas.microsoft.com/LiveID/Federation/2008/05/ImmutableID"), 
-        query = ";objectguid;{0}", 
+        store = "Active Directory",
+        types = ("http://schemas.microsoft.com/LiveID/Federation/2008/05/ImmutableID"),
+        query = ";objectguid;{0}",
         param = c2.Value
     );'
     }
 
-    $existingRules = (Get-ADFSRelyingPartyTrust -Identifier urn:federation:MicrosoftOnline).IssuanceTransformRules 
+    $existingRules = (Get-ADFSRelyingPartyTrust -Identifier urn:federation:MicrosoftOnline).IssuanceTransformRules
 
     $updatedRules = $existingRules + $rule1 + $rule2 + $rule3 + $rule4 + $rule5
 
-    $crSet = New-ADFSClaimRuleSet -ClaimRule $updatedRules 
+    $crSet = New-ADFSClaimRuleSet -ClaimRule $updatedRules
 
-    Set-AdfsRelyingPartyTrust -TargetIdentifier urn:federation:MicrosoftOnline -IssuanceTransformRules $crSet.ClaimRulesString 
+    Set-AdfsRelyingPartyTrust -TargetIdentifier urn:federation:MicrosoftOnline -IssuanceTransformRules $crSet.ClaimRulesString
 
 
-#### Remarks 
+#### Remarks
 
 - This script appends the rules to the existing rules. Do not run the script twice because the set of rules would be added twice. Make sure that no corresponding rules exist for these claims (under the corresponding conditions) before running the script again.
 
-- If you have multiple verified domain names (as shown in the Azure AD portal or via the Get-MsolDomains cmdlet), set the value of **$multipleVerifiedDomainNames** in the script to **$true**. Also make sure that you remove any existing issuerid claim that might have been created by Azure AD Connect or via other means. Here is an example for this rule:
+- If you have multiple verified domain names (as shown in the Azure AD portal or via the Get-MsolDomains cmdlet), set the value of **$multipleVerifiedDomainNames** in the script to **$true**. Also make sure that you remove any existing issuerID claim that might have been created by Azure AD Connect or via other means. Here is an example for this rule:
 
-
-~~~
-    c:[Type == "http://schemas.xmlsoap.org/claims/UPN"]
-    => issue(Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", Value = regexreplace(c.Value, ".+@(?<domain>.+)",  "http://${domain}/adfs/services/trust/")); 
-~~~
+```
+c:[Type == "http://schemas.xmlsoap.org/claims/UPN"]
+=> issue(Type = "http://schemas.microsoft.com/ws/2008/06/identity/claims/issuerid", Value = regexreplace(c.Value, ".+@(?<domain>.+)",  "http://${domain}/adfs/services/trust/"));
+```
 
 - If you have already issued an **ImmutableID** claim  for user accounts, set the value of **$immutableIDAlreadyIssuedforUsers** in the script to **$true**.
 
-#### Configure Device Authentication in AD FS  
-Using an elevated PowerShell command window, configure AD FS policy by executing the following command  
+#### Configure Device Authentication in AD FS
 
-`PS C:>Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAuthenticationMethod SignedToken` 
+Using an elevated PowerShell command window, configure AD FS policy by executing the following command
 
-#### Check your configuration  
-For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work
+```powershell
+Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAuthenticationMethod SignedToken
+```
 
-- object of type ms-DS-DeviceContainer at CN=RegisteredDevices,DC=&lt;domain&gt;        
-    - read access to the AD FS service account   
+#### Check your configuration
+
+For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work:
+
+- object of type ms-DS-DeviceContainer at CN=RegisteredDevices,DC=&lt;domain&gt;
+    - read access to the AD FS service account
     - read/write access to the Azure AD Connect sync AD connector account
 - Container CN=Device Registration Configuration,CN=Services,CN=Configuration,DC=&lt;domain&gt;
 - Container Device Registration Service DKM under the above container
 
-![Device Registration](images/hybridct/device8.png) 
+![Device Registration](images/hybridct/device8.png)
 
-- object of type serviceConnectionpoint at CN=&lt;guid&gt;, CN=Device Registration Configuration,CN=Services,CN=Configuration,DC=&lt;domain&gt;  
-  - read/write access to the specified AD connector account name on the new object 
+- object of type serviceConnectionpoint at CN=&lt;guid&gt;, CN=Device Registration Configuration,CN=Services,CN=Configuration,DC=&lt;domain&gt;
+  - read/write access to the specified AD connector account name on the new object
 - object of type msDS-DeviceRegistrationServiceContainer at CN=Device Registration Services,CN=Device Registration Configuration,CN=Services,CN=Configuration,DC=&lt;domain&gt;
 - object of type msDS-DeviceRegistrationService in the above container
 
@@ -531,6 +562,7 @@ For your reference, below is a comprehensive list of the AD DS devices, containe
 <hr>
 
 ## Follow the Windows Hello for Business hybrid certificate trust deployment guide
+
 1. [Overview](hello-hybrid-cert-trust.md)
 2. [Prerequisites](hello-hybrid-cert-trust-prereqs.md)
 3. [New Installation Baseline](hello-hybrid-cert-new-install.md)

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -54,7 +54,7 @@ Use this three-phased approach for configuring device registration:
 
 Begin configuring device registration to support Hybrid Windows Hello for Business by configuring device registration capabilities in Azure AD.
 
-To do this, follow the **Configure device settings** steps under [Setting up Azure AD Join in your organization](https://azure.microsoft.com/documentation/articles/active-directory-azureadjoin-setup/)
+To do this, follow the **Configure device settings** steps under [Setting up Azure AD Join in your organization](https://azure.microsoft.com/documentation/articles/active-directory-azureadjoin-setup/).
 
 ## Configure Active Directory to support Azure device synchronization
 

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -202,7 +202,7 @@ To ensure AD DS objects and containers are in the correct state for write back o
    Initialize-ADSyncDeviceWriteBack -DomainName <AD DS domain name> -AdConnectorAccount [AD connector account name]
    ```
 
-Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format
+Where the [AD connector account name] is the name of the account you configured in Azure AD Connect when adding your on-premises AD DS directory in domain\accountname format.
 
 The above command creates the following objects for device write back to AD DS, if they do not exist already, and allows access to the specified AD connector account name
 

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -561,7 +561,7 @@ Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAut
 
 #### Check your configuration
 
-For your reference, below is a comprehensive list of the AD DS devices, containers and permissions required for device write-back and authentication to work:
+For your reference, below is a comprehensive list of the AD DS devices, containers, and permissions required for device write-back and authentication to work:
 
 - object of type ms-DS-DeviceContainer at CN=RegisteredDevices,DC=&lt;domain&gt;
     - read access to the AD FS service account

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -553,7 +553,7 @@ The following script helps you with the creation of the issuance transform rules
 
 #### Configure Device Authentication in AD FS
 
-Using an elevated PowerShell command window, configure AD FS policy by executing the following command
+Using an elevated PowerShell command window, configure AD FS policy by executing the following command:
 
 ```PowerShell
 Set-AdfsGlobalAuthenticationPolicy -DeviceAuthenticationEnabled $true -DeviceAuthenticationMethod SignedToken

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -182,7 +182,7 @@ If you plan to use Windows 10 domain join (with automatic registration to Azure 
 
 ![Device Registration](images/hybridct/device7.png)
 
-3. Run the following PowerShell command
+3. Run the following PowerShell command:
 
    ```PowerShell
    Initialize-ADSyncDomainJoinedComputerSync -AdConnectorAccount [AD connector account name] -AzureADCredentials $aadAdminCred

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -174,7 +174,7 @@ If you plan to use Windows 10 domain join (with automatic registration to Azure 
 
 ![Device Registration](images/hybridct/device6.png)
 
-2. Provide your Azure AD global administrator credentials
+2. Provide your Azure AD global administrator credentials.
 
    ```PowerShell
    $aadAdminCred = Get-Credential

--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-trust-devreg.md
@@ -211,7 +211,7 @@ The above command creates the following objects for device write back to AD DS, 
 
 ### Enable Device Write Back in Azure AD Connect
 
-If you have not done so before, enable device write back in Azure AD Connect by running the wizard a second time and selecting **"Customize Synchronization Options"**, then checking the box for device write back and selecting the forest in which you have run the above cmdlets
+If you have not done so before, enable device write back in Azure AD Connect by running the wizard a second time and selecting **"Customize Synchronization Options"**, then checking the box for device write back and selecting the forest in which you have run the above cmdlets.
 
 ## Configure AD FS to use Azure registered devices
 


### PR DESCRIPTION
**Description:**

As mentioned in PR #8595, I noticed quite a few formatting issues in this document, both for MarkDown code block formatting and whitespace usage (or lack thereof).

Since the PR was focused on a quite specific topic update, the PR author did not want additional changes added. I therefore submit a list of my own improvements.

**Changes proposed:**

- add MarkDown code block syntax highlighting language `aspx` for the schema scripts (might be asp.net or XML)
- reformat and wrap the example script for removing any existing issuerID claim (Remarks section)
- add proper MarkDown code blocks around separate command lines and important lists
- add PowerShell syntax highlighting to PS MarkDown code blocks
- remove PowerShell command prompt for command copying (current codestyle)
- remove redundant ending ### in the heading "#### ADFS Web Proxy ###"
- typo correction: replace "and" with "a" in "open and command prompt"
- add missing colon at the end of introductory sentences

**Whitespace changes:**

- add missing blank lines between section headings (H2/H3/H4) and their text paragraphs
- remove any blank space at the end of lines (whitespace cleanup)
- standardize number list spacing to a single blank (MarkDown standard)

**Ticket closure or reference:**

Ref. #8595