### PR TITLE
Update block-untrusted-fonts-in-enterprise.md

### DIFF
--- a/windows/security/threat-protection/block-untrusted-fonts-in-enterprise.md
+++ b/windows/security/threat-protection/block-untrusted-fonts-in-enterprise.md
@@ -2,7 +2,7 @@
 title: Block untrusted fonts in an enterprise (Windows 10)
 description: To help protect your company from attacks which may originate from untrusted or attacker controlled font files, we’ve created the Blocking Untrusted Fonts feature.
 ms.assetid: a3354c8e-4208-4be6-bc19-56a572c361b4
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 keywords: font blocking, untrusted font blocking, block fonts, untrusted fonts
 ms.prod: w10
@@ -19,9 +19,9 @@ ms.localizationpriority: medium
 
 **Applies to:**
 
--   Windows 10
+- Windows 10
 
->Learn more about what features and functionality are supported in each Windows edition at [Compare Windows 10 Editions](https://www.microsoft.com/WindowsForBusiness/Compare).
+> Learn more about what features and functionality are supported in each Windows edition at [Compare Windows 10 Editions](https://www.microsoft.com/WindowsForBusiness/Compare).
 
 To help protect your company from attacks which may originate from untrusted or attacker controlled font files, we’ve created the Blocking Untrusted Fonts feature. Using this feature, you can turn on a global setting that stops your employees from loading untrusted fonts processed using the Graphics Device Interface (GDI) onto your network. Untrusted fonts are any font installed outside of the `%windir%/Fonts` directory. Blocking untrusted fonts helps prevent both remote (web-based or email-based) and local EOP attacks that can happen during the font file-parsing process.
 
@@ -31,24 +31,24 @@ Blocking untrusted fonts helps improve your network and employee protection agai
 ## How does this feature work?
 There are 3 ways to use this feature:
 
--   **On.** Helps stop any font processed using GDI from loading outside of the `%windir%/Fonts` directory. It also turns on event logging.
+- **On.** Helps stop any font processed using GDI from loading outside of the `%windir%/Fonts` directory. It also turns on event logging.
 
--   **Audit.** Turns on event logging, but doesn’t block fonts from loading, regardless of location. The name of the apps that use untrusted fonts appear in your event log.<p>**Note**<br>If you aren’t quite ready to deploy this feature into your organization, you can run it in Audit mode to see if not loading untrusted fonts causes any usability or compatibility issues.
+- **Audit.** Turns on event logging, but doesn’t block fonts from loading, regardless of location. The name of the apps that use untrusted fonts appear in your event log.<p>**Note**<br>If you aren’t quite ready to deploy this feature into your organization, you can run it in Audit mode to see if not loading untrusted fonts causes any usability or compatibility issues.
 
--   **Exclude apps to load untrusted fonts.** You can exclude specific apps, allowing them to load untrusted fonts, even while this feature is turned on. For instructions, see [Fix apps having problems because of blocked fonts](#fix-apps-having-problems-because-of-blocked-fonts).
+- **Exclude apps to load untrusted fonts.** You can exclude specific apps, allowing them to load untrusted fonts, even while this feature is turned on. For instructions, see [Fix apps having problems because of blocked fonts](#fix-apps-having-problems-because-of-blocked-fonts).
 
 ## Potential reductions in functionality
 After you turn this feature on, your employees might experience reduced functionality when:
 
--   Sending a print job to a remote printer server that uses this feature and where the spooler process hasn’t been specifically excluded. In this situation, any fonts that aren’t already available in the server’s %windir%/Fonts folder won’t be used.
+- Sending a print job to a remote printer server that uses this feature and where the spooler process hasn’t been specifically excluded. In this situation, any fonts that aren’t already available in the server’s %windir%/Fonts folder won’t be used.
 
--   Printing using fonts provided by the installed printer’s graphics .dll file, outside of the %windir%/Fonts folder. For more information, see [Introduction to Printer Graphics DLLs](https://go.microsoft.com/fwlink/p/?LinkId=522302).
+- Printing using fonts provided by the installed printer’s graphics .dll file, outside of the %windir%/Fonts folder. For more information, see [Introduction to Printer Graphics DLLs](https://go.microsoft.com/fwlink/p/?LinkId=522302).
 
--   Using first or third-party apps that use memory-based fonts.
+- Using first or third-party apps that use memory-based fonts.
 
--   Using Internet Explorer to look at websites that use embedded fonts. In this situation, the feature blocks the embedded font, causing the website to use a default font. However, not all fonts have all of the characters, so the website might render differently.
+- Using Internet Explorer to look at websites that use embedded fonts. In this situation, the feature blocks the embedded font, causing the website to use a default font. However, not all fonts have all of the characters, so the website might render differently.
 
--   Using desktop Office to look at documents with embedded fonts. In this situation, content shows up using a default font picked by Office.
+- Using desktop Office to look at documents with embedded fonts. In this situation, content shows up using a default font picked by Office.
 
 ## Turn on and use the Blocking Untrusted Fonts feature
 Use Group Policy or the registry to turn this feature on, off, or to use audit mode.
@@ -58,7 +58,7 @@ Use Group Policy or the registry to turn this feature on, off, or to use audit m
 
 2. Click **Enabled** to turn the feature on, and then click one of the following **Migitation Options**:
 
-    - **Block untrusted fonts and log events.** Turns the feature on, blocking untrusted fonts and logging installation attempts to the event log. 
+    - **Block untrusted fonts and log events.** Turns the feature on, blocking untrusted fonts and logging installation attempts to the event log.
 
     - **Do not block untrusted fonts.** Turns the feature on, but doesn't block untrusted fonts nor does it log installation attempts to the event log.
 
@@ -73,9 +73,9 @@ To turn this feature on, off, or to use audit mode:
 
 2. If the **MitigationOptions** key isn't there, right-click and add a new **QWORD (64-bit) Value**, renaming it to **MitigationOptions**.
 
-3. Right click on the **MitigationOptions** key, and then click **Modify**. 
+3. Right click on the **MitigationOptions** key, and then click **Modify**.
 
-    The **Edit QWORD (64-bit) Value** box opens.
+   The **Edit QWORD (64-bit) Value** box opens.
 
 4. Make sure the **Base** option is **Hexadecimal**, and then update the **Value data**, making sure you keep your existing value, like in the important note below:
 
@@ -85,8 +85,8 @@ To turn this feature on, off, or to use audit mode:
 
    - **To audit with this feature.** Type **3000000000000**.
 
-     >[!Important]
-     >Your existing **MitigationOptions** values should be saved during your update. For example, if the current value is *1000*, your updated value should be *1000000001000*. 
+     > [!Important]
+     > Your existing **MitigationOptions** values should be saved during your update. For example, if the current value is *1000*, your updated value should be *1000000001000*.
 
 5. Restart your computer.
 
@@ -104,27 +104,27 @@ After you turn this feature on, or start using Audit mode, you can look at your 
     FontType: Memory<br>
     FontPath:<br>
     Blocked: true
-    
-    >[!NOTE]
-    >Because the **FontType** is *Memory*, there’s no associated **FontPath**.
+
+    > [!NOTE]
+    > Because the **FontType** is *Memory*, there’s no associated **FontPath**.
 
     **Event Example 2 - Winlogon**<br>
     Winlogon.exe attempted loading a font that is restricted by font-loading policy.<br>
     FontType: File<br>
     FontPath: `\??\C:\PROGRAM FILES (X86)\COMMON FILES\MICROSOFT SHARED\EQUATION\MTEXTRA.TTF`<br>
     Blocked: true
-    
-    >[!NOTE]
-    >Because the **FontType** is *File*, there’s also an associated **FontPath**.
+
+    > [!NOTE]
+    > Because the **FontType** is *File*, there’s also an associated **FontPath**.
 
     **Event Example 3 - Internet Explorer running in Audit mode**<br>
     Iexplore.exe attempted loading a font that is restricted by font-loading policy.<br>
     FontType: Memory<br>
     FontPath:<br>
     Blocked: false
-    
-    >[!NOTE]
-    >In Audit mode, the problem is recorded, but the font isn’t blocked.
+
+    > [!NOTE]
+    > In Audit mode, the problem is recorded, but the font isn’t blocked.
 
 ## Fix apps having problems because of blocked fonts
 Your company may still need apps that are having problems because of blocked fonts, so we suggest that you first run this feature in Audit mode to determine which fonts are causing the problems.
@@ -133,21 +133,15 @@ After you figure out the problematic fonts, you can try to fix your apps in 2 wa
 
 **To fix your apps by installing the problematic fonts (recommended)**
 
--   On each computer with the app installed, right-click on the font name and click **Install**.<p>The font should automatically install into your `%windir%/Fonts` directory. If it doesn’t, you’ll need to manually copy the font files into the **Fonts** directory and run the installation from there.
+- On each computer with the app installed, right-click on the font name and click **Install**.<p>The font should automatically install into your `%windir%/Fonts` directory. If it doesn’t, you’ll need to manually copy the font files into the **Fonts** directory and run the installation from there.
 
 **To fix your apps by excluding processes**
 
-1.  On each computer with the app installed, open regedit.exe and go to `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<process_image_name>`.<br><br>For example, if you want to exclude Microsoft Word processes, you’d use `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Winword.exe`.
+1. On each computer with the app installed, open regedit.exe and go to `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\<process_image_name>`.<br><br>For example, if you want to exclude Microsoft Word processes, you’d use `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Winword.exe`.
 
-2.  Add any additional processes that need to be excluded here, and then turn the Blocking untrusted fonts feature on, using the steps in the [Turn on and use the Blocking Untrusted Fonts feature](#turn-on-and-use-the-blocking-untrusted-fonts-feature) section of this topic.
+2. Add any additional processes that need to be excluded here, and then turn the Blocking untrusted fonts feature on, using the steps in the [Turn on and use the Blocking Untrusted Fonts feature](#turn-on-and-use-the-blocking-untrusted-fonts-feature) section of this topic.
 
- 
+
 ## Related content
 
-- [Dropping the “Untrusted Font Blocking” setting](https://blogs.technet.microsoft.com/secguide/2017/06/15/dropping-the-untrusted-font-blocking-setting/)
- 
-
-
-
-
-
+- [Dropping the “Untrusted Font Blocking” setting](https://techcommunity.microsoft.com/t5/microsoft-security-baselines/dropping-the-quot-untrusted-font-blocking-quot-setting/ba-p/701068/)


### PR DESCRIPTION
**Description:**

As reported in issue ticket #8687 (**Dead link to Dropping the “Untrusted Font Blocking” setting**), the outdated link to blogs.technet.microsoft.com just leads to a 404 error and no proper redirect to the existing article.

Thanks to @KalleOlaviNiemitalo for noticing, reporting the issue and suggesting the link to the correct page.

**Proposed change:**

- replace the blogs.technet.microsoft.com URL with a working techcommunity.microsoft.com URL

**Whitespace changes:**

- add missing MarkDown indent marker compatibility spacing
- normalize bullet point list spacing (from 3 down to 1)
- remove any end-of-line blank space
- remove redundant blank lines at the end of the document

**Ticket closure or reference:**

Closes #8687