### PR TITLE
Format of resolution for "The TPM is locked out."

### DIFF
--- a/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
+++ b/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
@@ -39,7 +39,9 @@ To resolve this issue, follow these steps:
 1. Open an elevated PowerShell window and run the following script:
 
    ```ps
-   $Tpm = Get-WmiObject -class Win32_Tpm -namespace "root\CIMv2\Security\MicrosoftTpm" $ConfirmationStatus = $Tpm.GetPhysicalPresenceConfirmationStatus(22).ConfirmationStatus if($ConfirmationStatus -ne 4) {$Tpm.SetPhysicalPresenceRequest(22)}
+   $Tpm = Get-WmiObject -class Win32_Tpm -namespace "root\CIMv2\Security\MicrosoftTpm"
+   $ConfirmationStatus = $Tpm.GetPhysicalPresenceConfirmationStatus(22).ConfirmationStatus
+   if($ConfirmationStatus -ne 4) {$Tpm.SetPhysicalPresenceRequest(22)}
    ```
 
 1. Restart the computer. If you are prompted at the restart screen, press F12 to agree.


### PR DESCRIPTION
The resolution for the "The TPM is locked out." issue was missing newline characters in the PowerShell commands. This change adds newline characters between the commands so that the command is easier to run.