### PR TITLE
Client Management/MDM: URL & text correction

### DIFF
--- a/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/mdm/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -7,20 +7,20 @@ ms.prod: w10
 ms.technology: windows
 author: manikadhiman
 ms.date:
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ---
 
 # Enroll a Windows 10 device automatically using Group Policy
 
-Starting in Windows 10, version 1709, you can use a Group Policy to trigger auto-enrollment to MDM for Active Directory (AD) domain-joined devices. 
+Starting in Windows 10, version 1709, you can use a Group Policy to trigger auto-enrollment to MDM for Active Directory (AD) domain-joined devices.
 
 The enrollment into Intune is triggered by a group policy created on your local AD and happens without any user interaction. This means you can automatically mass-enroll a large number of domain-joined corporate devices into Microsoft Intune. The enrollment process starts in the background once you sign in to the device with your Azure AD account.
 
 Requirements:
 - AD-joined PC running Windows 10, version 1709 or later
-- The enterprise has configured a mobile device management (MDM) service  
-- The enterprise AD must be [registered with Azure Active Directory (Azure AD)](azure-active-directory-integration-with-mdm.md)
+- The enterprise has configured a mobile device management (MDM) service
+- The on-premises AD must be [integrated with Azure AD (via Azure AD Connect)](https://docs.microsoft.com/azure/architecture/reference-architectures/identity/azure-ad)
 - The device should not already be enrolled in Intune using the classic agents (devices managed using agents will fail enrollment with `error 0x80180026`)
 - The minimum Windows Server version requirement is based on the Hybrid Azure AD join requirement. See [How to plan your hybrid Azure Active Directory join implementation](https://docs.microsoft.com/azure/active-directory/devices/hybrid-azuread-join-plan) for more information.
 
@@ -33,7 +33,7 @@ Requirements:
 The auto-enrollment relies on the presence of an MDM service and the Azure Active Directory registration for the PC. Starting in Windows 10, version 1607, once the enterprise has registered its AD with Azure AD, a Windows PC that is domain joined is automatically Azure AD–registered.
 
 > [!NOTE]
-> In Windows 10, version 1709, the enrollment protocol was updated to check whether the device is domain-joined. For details, see [\[MS-MDE2\]: Mobile Device Enrollment Protocol Version 2](https://msdn.microsoft.com/library/mt221945.aspx). For examples, see section 4.3.1 RequestSecurityToken of the MS-MDE2 protocol documentation. 
+> In Windows 10, version 1709, the enrollment protocol was updated to check whether the device is domain-joined. For details, see [\[MS-MDE2\]: Mobile Device Enrollment Protocol Version 2](https://msdn.microsoft.com/library/mt221945.aspx). For examples, see section 4.3.1 RequestSecurityToken of the MS-MDE2 protocol documentation.
 
 When the auto-enrollment Group Policy is enabled, a task is created in the background that initiates the MDM enrollment. The task will use the existing MDM service configuration from the Azure Active Directory information of the user. If multi-factor authentication is required, the user will get a prompt to complete the authentication. Once the enrollment is configured, the user can check the status in the Settings page.
 
@@ -42,13 +42,13 @@ In Windows 10, version 1709 or later, when the same policy is configured in GP a
 For this policy to work, you must verify that the MDM service provider allows the GP triggered MDM enrollment for domain joined devices.
 
 ## Verify auto-enrollment requirements and settings
-To ensure that the auto-enrollment feature is working as expected, you must verify that various requirements and settings are configured correctly. 
+To ensure that the auto-enrollment feature is working as expected, you must verify that various requirements and settings are configured correctly.
 The following steps demonstrate required settings using the Intune service:
 1. Verify that the user who is going to enroll the device has a valid Intune license.
 
     ![Intune license verification](images/auto-enrollment-intune-license-verification.png)
 
-2. Verify that auto-enrollment is activated for those users who are going to enroll the devices into Intune. For additional details, see [Azure AD and Microsoft Intune: Automatic MDM enrollment in the new Portal](https://docs.microsoft.com/windows/client-management/mdm/azure-ad-and-microsoft-intune-automatic-mdm-enrollment-in-the-new-portal). 
+2. Verify that auto-enrollment is activated for those users who are going to enroll the devices into Intune. For additional details, see [Azure AD and Microsoft Intune: Automatic MDM enrollment in the new Portal](https://docs.microsoft.com/windows/client-management/mdm/azure-ad-and-microsoft-intune-automatic-mdm-enrollment-in-the-new-portal).
 
     ![Auto-enrollment activation verification](images/auto-enrollment-activation-verification.png)
 
@@ -80,7 +80,7 @@ The following steps demonstrate required settings using the Intune service:
 
     ![Mobility setting MDM intune](images/auto-enrollment-microsoft-intune-setting.png)
 
-7. Verify that the *Enable Automatic MDM enrollment using default Azure AD credentials* group policy (**Local Group Policy Editor > Computer Configuration > Policies > Administrative Templates > Windows Components > MDM**) is properly deployed to all devices which should be enrolled into Intune. 
+7. Verify that the *Enable Automatic MDM enrollment using default Azure AD credentials* group policy (**Local Group Policy Editor > Computer Configuration > Policies > Administrative Templates > Windows Components > MDM**) is properly deployed to all devices which should be enrolled into Intune.
 You may contact your domain administrators to verify if the group policy has been deployed successfully.
 
 8. Verify that the device is not enrolled with the old Intune client used on the Intune Silverlight Portal (this is the Intune portal used before the Azure portal).
@@ -95,12 +95,12 @@ This procedure is only for illustration purposes to show how the new auto-enroll
 
 Requirements:
 - AD-joined PC running Windows 10, version 1709 or later
-- Enterprise has MDM service already configured 
+- Enterprise has MDM service already configured
 - Enterprise AD must be registered with Azure AD
 
 1. Run GPEdit.msc
 
-    Click Start, then in the text box type gpedit. 
+    Click Start, then in the text box type gpedit.
 
     ![GPEdit desktop app search result](images/autoenrollment-gpedit.png)
 
@@ -110,7 +110,7 @@ Requirements:
 
    ![MDM policies](images/autoenrollment-mdm-policies.png)
 
-4. Double-click **Enable automatic MDM enrollment using default Azure AD credentials** (previously called **Auto MDM Enrollment with AAD Token** in Windows 10, version 1709). For ADMX files in Windows 10, version 1903 and later, select **User Credential** as the Selected Credential Type to use. 
+4. Double-click **Enable automatic MDM enrollment using default Azure AD credentials** (previously called **Auto MDM Enrollment with AAD Token** in Windows 10, version 1709). For ADMX files in Windows 10, version 1903 and later, select **User Credential** as the Selected Credential Type to use.
 
    > [!NOTE]
    > **Device Credential** Credential Type will also work, however, it is not yet supported for MDM solutions (including Intune). We don't recommend using this option until support is announced.
@@ -120,11 +120,11 @@ Requirements:
 5. Click **Enable**, and select **User Credential** from the dropdown **Select Credential Type to Use**, then click **OK**.
 
     > [!NOTE]
-    > In Windows 10, version 1903, the MDM.admx file was updated to include an option to select which credential is used to enroll the device. **Device Credential** is a new option that will only have an effect on clients that have installed Windows 10, version 1903 or later. 
-    > The default behavior for older releases is to revert to **User Credential**. 
-    > **Device Credential** is not supported for enrollment type when you have a ConfigMgr Agent on your device. 
+    > In Windows 10, version 1903, the MDM.admx file was updated to include an option to select which credential is used to enroll the device. **Device Credential** is a new option that will only have an effect on clients that have installed Windows 10, version 1903 or later.
+    > The default behavior for older releases is to revert to **User Credential**.
+    > **Device Credential** is not supported for enrollment type when you have a ConfigMgr Agent on your device.
 
-    When a group policy refresh occurs on the client, a task is created and scheduled to run every 5 minutes for the duration of one day. The task is called " Schedule created by enrollment client for automatically enrolling in MDM from AAD." 
+    When a group policy refresh occurs on the client, a task is created and scheduled to run every 5 minutes for the duration of one day. The task is called " Schedule created by enrollment client for automatically enrolling in MDM from AAD."
 
     To see the scheduled task, launch the [Task Scheduler app](#task-scheduler-app).
 
@@ -153,11 +153,11 @@ Requirements:
 
 2. Under **Best match**, click **Task Scheduler** to launch it.
 
-3. In **Task Scheduler Library**, open **Microsoft > Windows** , then click **EnterpriseMgmt**. 
+3. In **Task Scheduler Library**, open **Microsoft > Windows** , then click **EnterpriseMgmt**.
 
     ![Auto-enrollment scheduled task](images/autoenrollment-scheduled-task.png)
 
-    To see the result of the task, move the scroll bar to the right to see the **Last Run Result**. Note that **0x80180026** is a failure message (MENROLL\_E_DEVICE\_MANAGEMENT_BLOCKED). You can see the logs in the **History** tab. 
+    To see the result of the task, move the scroll bar to the right to see the **Last Run Result**. Note that **0x80180026** is a failure message (MENROLL\_E_DEVICE\_MANAGEMENT_BLOCKED). You can see the logs in the **History** tab.
 
     If the device enrollment is blocked, your IT admin may have enabled the **Disable MDM Enrollment** policy. Note that the GPEdit console does not reflect the status of policies set by your IT admin on your device. It is only used by the user to set policies.
 
@@ -172,39 +172,39 @@ Requirements:
 > [!IMPORTANT]
 > If you do not see the policy, it may be because you don't have the ADMX for Windows 10, version 1803, version 1809, or version 1903 installed. To fix the issue, use the following procedures. Note that the latest MDM.admx is backwards compatible.
 
-1. Download:  
-  
+1. Download:
+
    - 1803 --> [Administrative Templates (.admx) for Windows 10 April 2018 Update (1803)](https://www.microsoft.com/download/details.aspx?id=56880)
-     
+
    - 1809 --> [Administrative Templates (.admx) for Windows 10 October 2018 Update (1809)](https://www.microsoft.com/download/details.aspx?id=57576)
-     
+
    - 1903 --> [Administrative Templates (.admx) for Windows 10 May 2019 Update (1903)](https://www.microsoft.com/download/details.aspx?id=58495)
-   
+
    - 1909 --> [Administrative Templates (.admx) for Windows 10 November 2019 Update (1909)](
 https://www.microsoft.com/download/confirmation.aspx?id=1005915)
-   
+
    - 2004 --> [Administrative Templates (.admx) for Windows 10 May 2020 Update (2004)](https://www.microsoft.com/download/confirmation.aspx?id=101445)
-     
+
 2. Install the package on the Domain Controller.
-  
+
 3. Navigate, depending on the version to the folder:
-  
+
    - 1803 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 April 2018 Update (1803) v2**
-     
+
    - 1809 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 October 2018 Update (1809) v2**
-     
+
    - 1903 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2019 Update (1903) v3**
-   
+
    - 1909 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 November 2019 Update (1909)**
-    
-   - 2004 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2020 Update (2004)**     
-     
+
+   - 2004 --> **C:\Program Files (x86)\Microsoft Group Policy\Windows 10 May 2020 Update (2004)**
+
 4. Rename the extracted Policy Definitions folder to **PolicyDefinitions**.
-  
-5. Copy PolicyDefinitions folder to **C:\Windows\SYSVOL\domain\Policies**. 
-  
+
+5. Copy PolicyDefinitions folder to **C:\Windows\SYSVOL\domain\Policies**.
+
    If this folder does not exist, then be aware that you will be switching to a [central policy store](https://support.microsoft.com/help/3087759/how-to-create-and-manage-the-central-store-for-group-policy-administra) for your entire domain.
-     
+
 6. Restart the Domain Controller for the policy to be available.
 
 This procedure will work for any future version as well.
@@ -218,7 +218,7 @@ This procedure will work for any future version as well.
 4. Filter using Security Groups.
 
 ## Troubleshoot auto-enrollment of devices
-Investigate the log file if you have issues even after performing all the mandatory verification steps. The first log file to investigate is the event log on the target Windows 10 device. 
+Investigate the log file if you have issues even after performing all the mandatory verification steps. The first log file to investigate is the event log on the target Windows 10 device.
 
 To collect Event Viewer logs:
 
@@ -254,12 +254,12 @@ To collect Event Viewer logs:
 
     Note that the task scheduler log displays event ID 102 (task completed) regardless of the auto-enrollment success or failure. This means that the task scheduler log is only useful to confirm if the auto-enrollment task is triggered or not. It does not indicate the success or failure of auto-enrollment.
 
-    If you cannot see from the log that task Schedule created by enrollment client for automatically enrolling in MDM from AAD is initiated, there is possibly issue with the group policy. Immediately run the command `gpupdate /force` in command prompt to get the GPO applied. If this still does not help, further troubleshooting on the Active Directory is required. 
+    If you cannot see from the log that task Schedule created by enrollment client for automatically enrolling in MDM from AAD is initiated, there is possibly issue with the group policy. Immediately run the command `gpupdate /force` in command prompt to get the GPO applied. If this still does not help, further troubleshooting on the Active Directory is required.
     One frequently seen error is related to some outdated enrollment entries in the registry on the target client device (**HKLM > Software > Microsoft > Enrollments**). If a device has been enrolled (can be any MDM solution and not only Intune), some enrollment information added into the registry is seen:
 
     ![Outdated enrollment entries](images/auto-enrollment-outdated-enrollment-entries.png)
 
-    By default, these entries are removed when the device is un-enrolled, but occasionally the registry key remains even after un-enrollment. In this case, `gpupdate /force` fails to initiate the auto-enrollment task and error code 2149056522 is displayed in the **Applications and Services Logs > Microsoft > Windows > Task Scheduler > Operational** event log file under event ID 7016. 
+    By default, these entries are removed when the device is un-enrolled, but occasionally the registry key remains even after un-enrollment. In this case, `gpupdate /force` fails to initiate the auto-enrollment task and error code 2149056522 is displayed in the **Applications and Services Logs > Microsoft > Windows > Task Scheduler > Operational** event log file under event ID 7016.
     A resolution to this issue is to remove the registry key manually. If you do not know which registry key to remove, go for the key which displays most entries as the screenshot above. All other keys will display fewer entries as shown in the following screenshot:
 
     ![Manually deleted entries](images/auto-enrollment-activation-verification-less-entries.png)


### PR DESCRIPTION
**Description:**

As outlined in issue ticket #8682 (**3rd bullet point in Requirements section is confusing, and linked page is unrelated to the link's text**), "The linked page contains basically no information about registering your "enterprise AD" with Azure AD. Instead, that page is a somewhat convoluted set of sections that are sort of unrelated to anything specific."

Thanks to Jeremy T. Bradshaw (@JeremyTBradshaw) for identifying and reporting this issue.

**Changes proposed:**

- change the MDM page link URL to a more precise Azure AD page link
- change the 3rd bullet point text to refer to the new page link

**Whitespace changes:**

- remove end-of-line redundant whitespace (blanks)

**Ticket closure or reference:**

Closes #8682