### PR TITLE
Update respond-file-alerts.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/respond-file-alerts.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/respond-file-alerts.md
@@ -139,7 +139,7 @@ You can prevent further propagation of an attack in your organization by banning
 
 >[!IMPORTANT]
 >
->- This feature is available if your organization uses Microsoft Defender Antivirus and Cloud–based protection is enabled. For more information, see [Manage cloud–based protection](../microsoft-defender-antivirus/deploy-manage-report-microsoft-defender-antivirus.md).
+>- This feature is available if your organization uses Microsoft Defender Antivirus and Cloud–delivered protection is enabled. For more information, see [Manage cloud–delivered protection](../microsoft-defender-antivirus/deploy-manage-report-microsoft-defender-antivirus.md).
 >
 >- The Antimalware client version must be 4.18.1901.x or later.
 >- This feature is designed to prevent suspected malware (or potentially malicious files) from being downloaded from the web. It currently supports portable executable (PE) files, including _.exe_ and _.dll_ files. The coverage will be extended over time.


### PR DESCRIPTION
Text says "Cloud-based protection..." but the in-product UI and other docs refer to it as "Cloud-delivered protection...". Updating text to standardize.

The preview version of the article also seems to have the "Cloud-based protection..." wording under the new "Download quarantined files" section but I don't seem to have access to the preview version.