### PR TITLE
Adding iOS section, fixing double "for", updating name to "macOS"

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
@@ -42,38 +42,38 @@ non-Windows platforms, enabling them to get a full picture of what's happening
 in their environment, which empowers them to more quickly assess and respond to
 threats.
 
-## Microsoft Defender for Endpoint for Mac 
+## Microsoft Defender for Endpoint on macOS 
 
-Microsoft Defender for Endpoint for Mac offers antivirus and endpoint detection and response (EDR) capabilities for the three
+Microsoft Defender for Endpoint on macOS offers antivirus and endpoint detection and response (EDR) capabilities for the three
 latest released versions of macOS. Customers can deploy and manage the solution
 through Microsoft Endpoint Manager and Jamf. Just like with Microsoft Office
 applications on macOS, Microsoft Auto Update is used to manage Microsoft
-Defender for Endpoint for Mac updates. For information about the key features and
+Defender for Endpoint on Mac updates. For information about the key features and
 benefits, read our
 [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-atp/bg-p/MicrosoftDefenderATPBlog/label-name/macOS).
 
-For more details on how to get started, visit the Defender for Endpoint for Mac
+For more details on how to get started, visit the Defender for Endpoint on macOS
 [documentation](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-mac).
 
-## Microsoft Defender for Endpoint for Linux
+## Microsoft Defender for Endpoint on Linux
 
-Microsoft Defender for Endpoint for Linux offers preventative (AV) capabilities for Linux
+Microsoft Defender for Endpoint on Linux offers preventative (AV) capabilities for Linux
 servers. This includes a full command line experience to configure and manage
 the agent, initiate scans, and manage threats. We support recent versions of the
 six most common Linux Server distributions: RHEL 7.2+, CentOS Linux 7.2+, Ubuntu
 16 LTS, or higher LTS, SLES 12+, Debian 9+, and Oracle Linux 7.2. Microsoft
-Defender for Endpoint for Linux can be deployed and configured using Puppet, Ansible, or
+Defender for Endpoint on Linux can be deployed and configured using Puppet, Ansible, or
 using your existing Linux configuration management tool. For information about
 the key features and benefits, read our
 [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-atp/bg-p/MicrosoftDefenderATPBlog/label-name/Linux).
 
-For more details on how to get started, visit the Microsoft Defender for Endpoint for
+For more details on how to get started, visit the Microsoft Defender for Endpoint on
 Linux
 [documentation](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-linux).
 
-## Microsoft Defender for Endpoint for Android
+## Microsoft Defender for Endpoint on Android
 
-Microsoft Defender for Endpoint for Android is our mobile threat defense solution for
+Microsoft Defender for Endpoint on Android is our mobile threat defense solution for
 devices running Android 6.0 and higher. Both Android Enterprise (Work Profile)
 and Device Administrator modes are supported. On Android, we offer web
 protection, which includes anti-phishing, blocking of unsafe connections, and
@@ -83,11 +83,20 @@ through integration with Microsoft Endpoint Manager and Conditional Access. For
 information about the key features and benefits, read our
 [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-atp/bg-p/MicrosoftDefenderATPBlog/label-name/Android).
 
-For more details on how to get started, visit the Microsoft Defender for Endpoint for
+For more details on how to get started, visit the Microsoft Defender for Endpoint on
 Android
 [documentation](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-android).
 
+## Microsoft Defender for Endpoint on iOS
 
+Microsoft Defender for Endpoint on iOS is our mobile threat defense solution for devices
+running iOS 11.0 and higher. Both Supervised and Unsupervised devices are supported. 
+On iOS, we offer web protection which includes anti-phishing, blocking of unsafe connections, and 
+setting of custom indicators. For more information about the key features and benefits, 
+read our [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-for-endpoint/bg-p/MicrosoftDefenderATPBlog/label-name/iOS). 
+
+For more details on how to get started, visit the Microsoft Defender for Endpoint 
+on iOS [documentation](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-ios).
 
 ## Licensing requirements 
 
@@ -95,7 +104,7 @@ Eligible Licensed Users may use Microsoft Defender for Endpoint on up to five co
 devices. Microsoft Defender for Endpoint is also available for purchase from a Cloud
 Solution Provider (CSP).
 
-Customers can obtain Microsoft Defender for Endpoint for Mac through a standalone
+Customers can obtain Microsoft Defender for Endpoint on macOS through a standalone
 Microsoft Defender for Endpoint license, as part of Microsoft 365 A5/E5, or Microsoft 365
 Security.
 

--- a/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
@@ -96,7 +96,7 @@ setting custom indicators. For more information about the key features and benef
 read our [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-for-endpoint/bg-p/MicrosoftDefenderATPBlog/label-name/iOS). 
 
 For more details on how to get started, visit the Microsoft Defender for Endpoint 
-on iOS [documentation](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-ios).
+on iOS [documentation](https://docs.microsoft.com/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-atp-ios).
 
 ## Licensing requirements 
 

--- a/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/non-windows.md
@@ -91,8 +91,8 @@ Android
 
 Microsoft Defender for Endpoint on iOS is our mobile threat defense solution for devices
 running iOS 11.0 and higher. Both Supervised and Unsupervised devices are supported. 
-On iOS, we offer web protection which includes anti-phishing, blocking of unsafe connections, and 
-setting of custom indicators. For more information about the key features and benefits, 
+On iOS, we offer web protection which includes anti-phishing, blocking unsafe connections, and 
+setting custom indicators. For more information about the key features and benefits, 
 read our [announcements](https://techcommunity.microsoft.com/t5/microsoft-defender-for-endpoint/bg-p/MicrosoftDefenderATPBlog/label-name/iOS). 
 
 For more details on how to get started, visit the Microsoft Defender for Endpoint 


### PR DESCRIPTION
Added section on Microsoft Defender for Endpoint on iOS now that iOS is in public preview and soon to be GA. Also updated each section titles to remove the second "for" in the title after "for Endpoint". Did the same in the first sentence of each section. Changed "for" to "on" ex: Microsoft Defender for Endpoint on macOS.

Updated "Mac" to "macOS" to refer to the OS name and not the device name.