### PR TITLE
MarkDown syntax highlighting, whitespace cleanup

### DIFF
--- a/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
+++ b/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
@@ -1,5 +1,5 @@
 ---
-title: BitLocker cannot encrypt a drive known TPM issues 
+title: BitLocker cannot encrypt a drive known TPM issues
 description: Provides guidance for troubleshooting known issues that may prevent BitLocker Drive Encryption from encrypting a drive, and that you can attribute to the TPM
 ms.reviewer: kaushika
 ms.technology: windows
@@ -15,7 +15,6 @@ ms.topic: troubleshooting
 ms.date: 10/18/2019
 ms.custom: bitlocker
 ---
-
 
 # BitLocker cannot encrypt a drive: known TPM issues
 
@@ -38,7 +37,7 @@ To resolve this issue, follow these steps:
 
 1. Open an elevated PowerShell window and run the following script:
 
-   ```ps
+   ```powershell
    $Tpm = Get-WmiObject -class Win32_Tpm -namespace "root\CIMv2\Security\MicrosoftTpm"
    $ConfirmationStatus = $Tpm.GetPhysicalPresenceConfirmationStatus(22).ConfirmationStatus
    if($ConfirmationStatus -ne 4) {$Tpm.SetPhysicalPresenceRequest(22)}
@@ -69,7 +68,7 @@ To resolve this issue, disable and re-enable the TPM. To do this, follow these s
 If you still cannot prepare the TPM, clear the existing TPM keys. To do this, follow the instructions in [Troubleshoot the TPM: Clear all the keys from the TPM](https://docs.microsoft.com/windows/security/information-protection/tpm/initialize-and-configure-ownership-of-the-tpm#clear-all-the-keys-from-the-tpm).
 
 > [!WARNING]
-> Clearing the TPM can cause data loss.  
+> Clearing the TPM can cause data loss.
 
 ## Access Denied: Failed to backup TPM Owner Authorization information to Active Directory Domain Services. Errorcode: 0x80070005
 
@@ -81,7 +80,7 @@ The TPM did not have sufficient permissions on the TPM Devices container in Acti
 
 This issue appears to be limited to computers that run versions of Windows that are earlier than Windows 10.
 
-### Resolution  
+### Resolution
 
 To verify that you have correctly identified this issue, use one of the following methods:
 
@@ -90,7 +89,7 @@ To verify that you have correctly identified this issue, use one of the followin
 
 1. To review the TPM information for the affected computer, open an elevated Windows PowerShell window and run the following command:
 
-   ```ps
+   ```powershell
    Get-ADComputer -Filter {Name -like "ComputerName"} -Property * | Format-Table name,msTPM-TPMInformationForComputer
    ```
 
@@ -100,7 +99,7 @@ To verify that you have correctly identified this issue, use one of the followin
 
 ## Cannot prepare the TPM, error 0x80072030: "There is no such object on the server"
 
-Your domain controllers were upgraded from Windows Server 2008 R2to Windows Server 2012 R2. A Group Policy Object (GPO) enforces the **Do not enable BitLocker until recovery information is stored in AD DS** policy.  
+Your domain controllers were upgraded from Windows Server 2008 R2to Windows Server 2012 R2. A Group Policy Object (GPO) enforces the **Do not enable BitLocker until recovery information is stored in AD DS** policy.
 
 You cannot turn on BitLocker Drive Encryption on a device. You use the TPM management console (tpm.msc) to prepare the TPM on a device. The operation fails and you see a message that resembles the following:
 
@@ -121,10 +120,10 @@ To resolve this issue, follow these steps:
 1. In the script, modify the value of **strPathToDomain** to your domain name.
 1. Open an elevated PowerShell window, and run the following command:
 
-   ```ps
+   ```powershell
    cscript <Path>Add-TPMSelfWriteACE.vbs
    ```
-   
+
    In this command \<*Path*> is the path to the script file.
 
 For more information, see the following articles:

--- a/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
+++ b/windows/security/information-protection/bitlocker/ts-bitlocker-cannot-encrypt-tpm-issues.md
@@ -116,9 +116,9 @@ The domain and forest functional level of the environment may still be set to Wi
 To resolve this issue, follow these steps:
 
 1. Upgrade the functional level of the domain and forest to Windows Server 2012 R2.
-1. Download [Add-TPMSelfWriteACE.vbs](https://go.microsoft.com/fwlink/p/?LinkId=167133).
-1. In the script, modify the value of **strPathToDomain** to your domain name.
-1. Open an elevated PowerShell window, and run the following command:
+2. Download [Add-TPMSelfWriteACE.vbs](https://go.microsoft.com/fwlink/p/?LinkId=167133).
+3. In the script, modify the value of **strPathToDomain** to your domain name.
+4. Open an elevated PowerShell window, and run the following command:
 
    ```powershell
    cscript <Path>Add-TPMSelfWriteACE.vbs


### PR DESCRIPTION
**Description:**

As I mentioned in PR #8704 (**Format of resolution for "The TPM is locked out."**), "ps" does not identify as a syntax highlighting code keyword for PowerShell. The keywords "powershell" or "PowerShell" should be used in the current implementation of GitHub Flavored MarkDown (GFM). The syntax highlighting added long before PR PR #8704, "ps", translates to PostScript via one of its filename extensions (.ps, .eps, .epsi, .pfa), whereas PowerShell can only be identified via its filename extensions .ps1, .psd1, .psm1 when not using its dedicated keyword PowerShell/powershell. Secondary IDs like filename extensions are discouraged as long as known keywords exist and are valid.

See also the Linguist project here on GitHub (https://github.com/github/linguist) for a complete list of syntax highlighting keywords:
- https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 ("Defines all Languages known to GitHub.")

**Proposed changes:**
- correct the MarkDown code block syntax highlighting keyword "ps" to "powershell"

**Whitespace changes:**
- remove redundant end-of-line blanks
- reduce the spacing between metadata and page title from 2 to 1 blank line

**Ticket closure or reference:**

ref. #8704