### PR TITLE
Update customize-exploit-protection.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/customize-exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/customize-exploit-protection.md
@@ -10,7 +10,7 @@ ms.localizationpriority: medium
 audience: ITPro
 author: levinec
 ms.author: ellevin
-ms.reviewer: 
+ms.reviewer:
 manager: dansimp
 ---
 
@@ -46,44 +46,44 @@ The **Use default** configuration for each of the mitigation settings indicates 
 
 For the associated PowerShell cmdlets for each mitigation, see the [PowerShell reference table](#cmdlets-table) at the bottom of this article.
 
-Mitigation | Description | Can be applied to | Audit mode available
--|-|-|-
-Control flow guard (CFG) | Ensures control flow integrity for indirect calls. Can optionally suppress exports and use strict CFG. | System and app-level | [!include[Check mark no](../images/svg/check-no.svg)]
-Data Execution Prevention (DEP) | Prevents code from being run from data-only memory pages such as the heap and stacks. Only configurable for 32-bit (x86) apps, permanently enabled for all other architectures. Can optionally enable ATL thunk emulation. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)]
-Force randomization for images (Mandatory ASLR) | Forcibly relocates images not compiled with /DYNAMICBASE. Can optionally fail loading images that don't have relocation information. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)]
-Randomize memory allocations (Bottom-Up ASLR) | Randomizes locations for virtual memory allocations. It includes system structure heaps, stacks, TEBs, and PEBs. Can optionally use a wider randomization variance for 64-bit processes. | System and app-level | [!include[Check mark no](../images/svg/check-no.svg)]
-Validate exception chains (SEHOP) | Ensures the integrity of an exception chain during exception dispatch. Only configurable for 32-bit (x86) applications. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)]
-Validate heap integrity | Terminates a process when heap corruption is detected. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)]
-Arbitrary code guard (ACG) | Prevents the introduction of non-image-backed executable code and prevents code pages from being modified. Can optionally allow thread opt-out and allow remote downgrade (configurable only with PowerShell). | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Block low integrity images | Prevents the loading of images marked with Low Integrity. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Block remote images | Prevents loading of images from remote devices. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)]
-Block untrusted fonts | Prevents loading any GDI-based fonts not installed in the system fonts directory, notably fonts from the web. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Code integrity guard | Restricts loading of images signed by Microsoft, WHQL, or higher. Can optionally allow Microsoft Store signed images. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Disable extension points | Disables various extensibility mechanisms that allow DLL injection into all processes, such as AppInit DLLs, window hooks, and Winsock service providers. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)]
-Disable Win32k system calls | Prevents an app from using the Win32k system call table. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Don't allow child processes | Prevents an app from creating child processes. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Export address filtering (EAF) | Detects dangerous operations being resolved by malicious code. Can optionally validate access by modules commonly used by exploits. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Import address filtering (IAF) | Detects dangerous operations being resolved by malicious code. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Simulate execution (SimExec) | Ensures that calls to sensitive APIs return to legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Validate API invocation (CallerCheck) | Ensures that sensitive APIs are invoked by legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
-Validate handle usage | Causes an exception to be raised on any invalid handle references. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)]
-Validate image dependency integrity | Enforces code signing for Windows image dependency loading. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)]
-Validate stack integrity (StackPivot) | Ensures that the stack hasn't been redirected for sensitive APIs. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)]
+| Mitigation | Description | Can be applied to | Audit mode available |
+| ---------- | ----------- | ----------------- | -------------------- |
+| Control flow guard (CFG) | Ensures control flow integrity for indirect calls. Can optionally suppress exports and use strict CFG. | System and app-level | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Data Execution Prevention (DEP) | Prevents code from being run from data-only memory pages such as the heap and stacks. Only configurable for 32-bit (x86) apps, permanently enabled for all other architectures. Can optionally enable ATL thunk emulation. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Force randomization for images (Mandatory ASLR) | Forcibly relocates images not compiled with /DYNAMICBASE. Can optionally fail loading images that don't have relocation information. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Randomize memory allocations (Bottom-Up ASLR) | Randomizes locations for virtual memory allocations. It includes system structure heaps, stacks, TEBs, and PEBs. Can optionally use a wider randomization variance for 64-bit processes. | System and app-level | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Validate exception chains (SEHOP) | Ensures the integrity of an exception chain during exception dispatch. Only configurable for 32-bit (x86) applications. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Validate heap integrity | Terminates a process when heap corruption is detected. | System and app-level  | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Arbitrary code guard (ACG) | Prevents the introduction of non-image-backed executable code and prevents code pages from being modified. Can optionally allow thread opt-out and allow remote downgrade (configurable only with PowerShell). | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Block low integrity images | Prevents the loading of images marked with Low Integrity. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Block remote images | Prevents loading of images from remote devices. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Block untrusted fonts | Prevents loading any GDI-based fonts not installed in the system fonts directory, notably fonts from the web. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Code integrity guard | Restricts loading of images signed by Microsoft, WHQL, or higher. Can optionally allow Microsoft Store signed images. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Disable extension points | Disables various extensibility mechanisms that allow DLL injection into all processes, such as AppInit DLLs, window hooks, and Winsock service providers. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Disable Win32k system calls | Prevents an app from using the Win32k system call table. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Don't allow child processes | Prevents an app from creating child processes. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Export address filtering (EAF) | Detects dangerous operations being resolved by malicious code. Can optionally validate access by modules commonly used by exploits. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Import address filtering (IAF) | Detects dangerous operations being resolved by malicious code. | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Simulate execution (SimExec) | Ensures that calls to sensitive APIs return to legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Validate API invocation (CallerCheck) | Ensures that sensitive APIs are invoked by legitimate callers. Only configurable for 32-bit (x86) applications. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
+| Validate handle usage | Causes an exception to be raised on any invalid handle references. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Validate image dependency integrity | Enforces code signing for Windows image dependency loading. | App-level only | [!include[Check mark no](../images/svg/check-no.svg)] |
+| Validate stack integrity (StackPivot) | Ensures that the stack hasn't been redirected for sensitive APIs. Not compatible with ACG | App-level only | [!include[Check mark yes](../images/svg/check-yes.svg)] |
 
 > [!IMPORTANT]
 > If you add an app to the **Program settings** section and configure individual mitigation settings there, they will be honored above the configuration for the same mitigations specified in the **System settings** section. The following matrix and examples help to illustrate how defaults work:
 >
 >
-> Enabled in **Program settings** | Enabled in **System settings** | Behavior
-> -|-|-
-> [!include[Check mark yes](../images/svg/check-yes.svg)] | [!include[Check mark no](../images/svg/check-no.svg)] | As defined in **Program settings**
-> [!include[Check mark yes](../images/svg/check-yes.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | As defined in **Program settings**
-> [!include[Check mark no](../images/svg/check-no.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | As defined in **System settings**
-> [!include[Check mark no](../images/svg/check-no.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | Default as defined in **Use default** option
+> | Enabled in **Program settings** | Enabled in **System settings** | Behavior |
+> | ------------------------------- | ------------------------------ | -------- |
+> | [!include[Check mark yes](../images/svg/check-yes.svg)] | [!include[Check mark no](../images/svg/check-no.svg)] | As defined in **Program settings** |
+> | [!include[Check mark yes](../images/svg/check-yes.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | As defined in **Program settings** |
+> | [!include[Check mark no](../images/svg/check-no.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | As defined in **System settings** |
+> | [!include[Check mark no](../images/svg/check-no.svg)] | [!include[Check mark yes](../images/svg/check-yes.svg)] | Default as defined in **Use default** option |
 >
 >
 >
-> * **Example 1**  
+> * **Example 1**
 >
 >    Mikael configures **Data Execution Prevention (DEP)** in the **System settings** section to be **Off by default**.
 >
@@ -116,10 +116,10 @@ Validate stack integrity (StackPivot) | Ensures that the stack hasn't been redir
    * **Off by default** - The mitigation is *disabled* for apps that don't have this mitigation set in the app-specific **Program settings** section
    * **Use default** - The mitigation is either enabled or disabled, depending on the default configuration that is set up by Windows 10 installation; the default value (**On** or **Off**) is always specified next to the **Use default** label for each mitigation
 
-     >[!NOTE]
-     >You may see a User Account Control window when changing some settings. Enter administrator credentials to apply the setting.
+   > [!NOTE]
+   > You may see a User Account Control window when changing some settings. Enter administrator credentials to apply the setting.
 
-     Changing some settings may require a restart.
+   Changing some settings may require a restart.
 
 4. Repeat this for all the system-level mitigations you want to configure.
 
@@ -127,8 +127,8 @@ Validate stack integrity (StackPivot) | Ensures that the stack hasn't been redir
 
    1. If the app you want to configure is already listed, select it and then select **Edit**
    2. If the app isn't listed, at the top of the list select **Add program to customize** and then choose how you want to add the app:
-        * Use **Add by program name** to have the mitigation applied to any running process with that name. You must specify a file with an extension. You can enter a full path to limit the mitigation to only the app with that name in that location.
-        * Use **Choose exact file path** to use a standard Windows Explorer file picker window to find and select the file you want.
+      * Use **Add by program name** to have the mitigation applied to any running process with that name. You must specify a file with an extension. You can enter a full path to limit the mitigation to only the app with that name in that location.
+      * Use **Choose exact file path** to use a standard Windows Explorer file picker window to find and select the file you want.
 
 6. After selecting the app, you'll see a list of all the mitigations that can be applied. To enable the mitigation, select the check box and then change the slider to **On**. Select any additional options. Choosing **Audit** will apply the mitigation in audit mode only. You will be notified if you need to restart the process or app, or if you need to restart Windows.
 
@@ -140,14 +140,14 @@ Exporting the configuration as an XML file allows you to copy the configuration 
 
 ## PowerShell reference
 
- You can use the Windows Security app to configure Exploit protection, or you can use PowerShell cmdlets.
+You can use the Windows Security app to configure Exploit protection, or you can use PowerShell cmdlets.
 
- The configuration settings that were most recently modified will always be applied - regardless of whether you use PowerShell or Windows Security. This means that if you use the app to configure a mitigation, then use PowerShell to configure the same mitigation, the app will update to show the changes you made with PowerShell. If you were to then use the app to change the mitigation again, that change would apply.
+The configuration settings that were most recently modified will always be applied - regardless of whether you use PowerShell or Windows Security. This means that if you use the app to configure a mitigation, then use PowerShell to configure the same mitigation, the app will update to show the changes you made with PowerShell. If you were to then use the app to change the mitigation again, that change would apply.
 
- >[!IMPORTANT]
- >Any changes that are deployed to a device through Group Policy will override the local configuration. When setting up an initial configuration, use a device that will not have a Group Policy configuration applied to ensure your changes aren't overridden.
+> [!IMPORTANT]
+> Any changes that are deployed to a device through Group Policy will override the local configuration. When setting up an initial configuration, use a device that will not have a Group Policy configuration applied to ensure your changes aren't overridden.
 
- You can use the PowerShell verb `Get` or `Set` with the cmdlet `ProcessMitigation`. Using `Get` will list the current configuration status of any mitigations that have been enabled on the device - add the `-Name` cmdlet and app exe to see mitigations for just that app:
+You can use the PowerShell verb `Get` or `Set` with the cmdlet `ProcessMitigation`. Using `Get` will list the current configuration status of any mitigations that have been enabled on the device - add the `-Name` cmdlet and app exe to see mitigations for just that app:
 
 ```PowerShell
 Get-ProcessMitigation -Name processName.exe
@@ -164,7 +164,7 @@ Get-ProcessMitigation -Name processName.exe
 
 Use `Set` to configure each mitigation in the following format:
 
- ```PowerShell
+```PowerShell
 Set-ProcessMitigation -<scope> <app executable> -<action> <mitigation or options>,<mitigation or options>,<mitigation or options>
 ```
 
@@ -179,34 +179,34 @@ Where:
 * \<Mitigation>:
     * The mitigation's cmdlet as defined in the [mitigation cmdlets table](#cmdlets-table) below, along with any suboptions (surrounded with spaces). Each mitigation is separated with a comma.
 
-  For example, to enable the Data Execution Prevention (DEP) mitigation with ATL thunk emulation and for an executable called *testing.exe* in the folder *C:\Apps\LOB\tests*, and to prevent that executable from creating child processes, you'd use the following command:
+For example, to enable the Data Execution Prevention (DEP) mitigation with ATL thunk emulation and for an executable called *testing.exe* in the folder *C:\Apps\LOB\tests*, and to prevent that executable from creating child processes, you'd use the following command:
 
-  ```PowerShell
-  Set-ProcessMitigation -Name c:\apps\lob\tests\testing.exe -Enable DEP, EmulateAtlThunks, DisallowChildProcessCreation
-  ```
+```PowerShell
+Set-ProcessMitigation -Name c:\apps\lob\tests\testing.exe -Enable DEP, EmulateAtlThunks, DisallowChildProcessCreation
+```
 
-  > [!IMPORTANT]
-  > Separate each mitigation option with commas.
+> [!IMPORTANT]
+> Separate each mitigation option with commas.
 
-  If you wanted to apply DEP at the system level, you'd use the following command:
+If you wanted to apply DEP at the system level, you'd use the following command:
 
-  ```PowerShell
-  Set-Processmitigation -System -Enable DEP
-  ```
+```PowerShell
+Set-Processmitigation -System -Enable DEP
+```
 
-  To disable mitigations, you can replace `-Enable` with `-Disable`. However, for app-level mitigations, this will force the mitigation to be disabled only for that app.
+To disable mitigations, you can replace `-Enable` with `-Disable`. However, for app-level mitigations, this will force the mitigation to be disabled only for that app.
 
-  If you need to restore the mitigation back to the system default, you need to include the `-Remove` cmdlet as well, as in the following example:
+If you need to restore the mitigation back to the system default, you need to include the `-Remove` cmdlet as well, as in the following example:
 
-  ```PowerShell
-  Set-Processmitigation -Name test.exe -Remove -Disable DEP
-  ```
+```PowerShell
+Set-Processmitigation -Name test.exe -Remove -Disable DEP
+```
 
- You can also set some mitigations to audit mode. Instead of using the PowerShell cmdlet for the mitigation, use the **Audit mode** cmdlet as specified in the [mitigation cmdlets table](#cmdlets-table) below.
+You can also set some mitigations to audit mode. Instead of using the PowerShell cmdlet for the mitigation, use the **Audit mode** cmdlet as specified in the [mitigation cmdlets table](#cmdlets-table) below.
 
- For example, to enable Arbitrary Code Guard (ACG) in audit mode for the *testing.exe* used previously, you'd use the following command:
+For example, to enable Arbitrary Code Guard (ACG) in audit mode for the *testing.exe* used previously, you'd use the following command:
 
- ```PowerShell
+```PowerShell
 Set-ProcessMitigation -Name c:\apps\lob\tests\testing.exe -Enable AuditDynamicCode
 ```
 
@@ -218,29 +218,29 @@ This table lists the PowerShell cmdlets (and associated audit mode cmdlet) that 
 
 <a id="cmdlets-table"></a>
 
-Mitigation | Applies to | PowerShell cmdlets | Audit mode cmdlet
-- | - | - | -
-Control flow guard (CFG) | System and app-level |   CFG,   StrictCFG,   SuppressExports  | Audit not available
-Data Execution Prevention (DEP) | System and app-level |   DEP,   EmulateAtlThunks  | Audit not available
-Force randomization for images (Mandatory ASLR) | System and app-level |   ForceRelocateImages  | Audit not available
-Randomize memory allocations (Bottom-Up ASLR) | System and app-level |   BottomUp,   HighEntropy  | Audit not available
-Validate exception chains (SEHOP) | System and app-level |   SEHOP,   SEHOPTelemetry  | Audit not available
-Validate heap integrity | System and app-level |   TerminateOnError  | Audit not available
-Arbitrary code guard (ACG) | App-level only |   DynamicCode  |   AuditDynamicCode
-Block low integrity images | App-level only |   BlockLowLabel  |   AuditImageLoad
-Block remote images | App-level only |   BlockRemoteImages  | Audit not available
-Block untrusted fonts | App-level only |   DisableNonSystemFonts  |   AuditFont,   FontAuditOnly
-Code integrity guard | App-level only |   BlockNonMicrosoftSigned,   AllowStoreSigned  |   AuditMicrosoftSigned,   AuditStoreSigned
-Disable extension points | App-level only |   ExtensionPoint  | Audit not available
-Disable Win32k system calls | App-level only |   DisableWin32kSystemCalls  |   AuditSystemCall
-Do not allow child processes | App-level only |   DisallowChildProcessCreation  |   AuditChildProcess
-Export address filtering (EAF) | App-level only |   EnableExportAddressFilterPlus,   EnableExportAddressFilter  <a href="#r1" id="t1">\[1\]</a> | Audit not available<a href="#r2" id="t2">\[2\]</a>
-Import address filtering (IAF) | App-level only |   EnableImportAddressFilter  | Audit not available<a href="#r2" id="t2">\[2\]</a>
-Simulate execution (SimExec) | App-level only |   EnableRopSimExec  | Audit not available<a href="#r2" id="t2">\[2\]</a>
-Validate API invocation (CallerCheck) | App-level only |   EnableRopCallerCheck  | Audit not available<a href="#r2" id="t2">\[2\]</a>
-Validate handle usage | App-level only |   StrictHandle  | Audit not available
-Validate image dependency integrity | App-level only |   EnforceModuleDepencySigning  | Audit not available
-Validate stack integrity (StackPivot) | App-level only |   EnableRopStackPivot  | Audit not available<a href="#r2" id="t2">\[2\]</a>
+| Mitigation | Applies to | PowerShell cmdlets | Audit mode cmdlet |
+| ---------- | ---------- | ------------------ | ----------------- |
+| Control flow guard (CFG) | System and app-level |   CFG,   StrictCFG,   SuppressExports  | Audit not available |
+| Data Execution Prevention (DEP) | System and app-level |   DEP,   EmulateAtlThunks  | Audit not available |
+| Force randomization for images (Mandatory ASLR) | System and app-level |   ForceRelocateImages  | Audit not available |
+| Randomize memory allocations (Bottom-Up ASLR) | System and app-level |   BottomUp,   HighEntropy  | Audit not available |
+| Validate exception chains (SEHOP) | System and app-level |   SEHOP,   SEHOPTelemetry  | Audit not available |
+| Validate heap integrity | System and app-level |   TerminateOnError  | Audit not available |
+| Arbitrary code guard (ACG) | App-level only |   DynamicCode  |   AuditDynamicCode |
+| Block low integrity images | App-level only |   BlockLowLabel  |   AuditImageLoad |
+| Block remote images | App-level only |   BlockRemoteImages  | Audit not available |
+| Block untrusted fonts | App-level only |   DisableNonSystemFonts  |   AuditFont,   FontAuditOnly |
+| Code integrity guard | App-level only |   BlockNonMicrosoftSigned,   AllowStoreSigned  |   AuditMicrosoftSigned,   AuditStoreSigned |
+| Disable extension points | App-level only |   ExtensionPoint  | Audit not available |
+| Disable Win32k system calls | App-level only |   DisableWin32kSystemCalls  |   AuditSystemCall |
+| Do not allow child processes | App-level only |   DisallowChildProcessCreation  |   AuditChildProcess |
+| Export address filtering (EAF) | App-level only |   EnableExportAddressFilterPlus,   EnableExportAddressFilter  <a href="#r1" id="t1">\[1\]</a> | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Import address filtering (IAF) | App-level only |   EnableImportAddressFilter  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Simulate execution (SimExec) | App-level only |   EnableRopSimExec  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Validate API invocation (CallerCheck) | App-level only |   EnableRopCallerCheck  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Validate handle usage | App-level only |   StrictHandle  | Audit not available |
+| Validate image dependency integrity | App-level only |   EnforceModuleDepencySigning  | Audit not available |
+| Validate stack integrity (StackPivot) | App-level only |   EnableRopStackPivot  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
 
 <a href="#t1" id="r1">\[1\]</a>: Use the following format to enable EAF modules for dlls for a process:
 
@@ -254,7 +254,7 @@ Set-ProcessMitigation -Name processName.exe -Enable EnableExportAddressFilterPlu
 
 For more information about customizing the notification when a rule is triggered and blocks an app or file, see [Windows Security](../windows-defender-security-center/windows-defender-security-center.md#customize-notifications-from-the-windows-defender-security-center).
 
-## See also
+## See also:
 
 * [Protect devices from exploits](exploit-protection.md)
 * [Evaluate exploit protection](evaluate-exploit-protection.md)


### PR DESCRIPTION
**Changes proposed:**

- MarkDown table restoration (one of the tables are broken on GitHub due to non-standard table divider indicators)
- Whitespace formatting corrections (end-of-line blank space removal, redundant leading whitespace removal)

**PR or ticket reference / closure:**

Ref. #8765 (md_cleanup / follow-up)