### PR TITLE
mdatp config requires `--value`

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-resources.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-resources.md
@@ -13,9 +13,9 @@ author: dansimp
 ms.localizationpriority: medium
 manager: dansimp
 audience: ITPro
-ms.collection: 
-- m365-security-compliance 
-- m365initiative-defender-endpoint 
+ms.collection:
+- m365-security-compliance
+- m365initiative-defender-endpoint
 ms.topic: conceptual
 ---
 
@@ -90,7 +90,7 @@ Important tasks, such as controlling product settings and triggering on-demand s
 
 |Group        |Scenario                                   |Command                                                                           |
 |-------------|-------------------------------------------|----------------------------------------------------------------------------------|
-|Configuration|Turn on/off real-time protection           |`mdatp config real-time-protection [enabled/disabled]`                            |
+|Configuration|Turn on/off real-time protection           |`mdatp config real-time-protection --value [enabled/disabled]`                    |
 |Configuration|Turn on/off cloud protection               |`mdatp config cloud --value [enabled/disabled]`                                   |
 |Configuration|Turn on/off product diagnostics            |`mdatp config cloud-diagnostic --value [enabled/disabled]`                        |
 |Configuration|Turn on/off automatic sample submission    |`mdatp config cloud-automatic-sample-submission --value [enabled/disabled]`       |


### PR DESCRIPTION
When configuring using `mdatp config` the `--value` argument is required.

```sh
$ sw_vers 
ProductName:    macOS
ProductVersion: 11.1
BuildVersion:   20C69
$ mdatp config real-time-protection
Configure real-time protection:
  --value arg           Accepted values: enabled, disabled
```

closes #8822 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>