### PR TITLE
Update mac-jamfpro-policies.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/mac-jamfpro-policies.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/mac-jamfpro-policies.md
@@ -188,13 +188,13 @@ You'll need to take the following steps:
                      <key>isDirectory</key>
                      <true/>
                      <key>path</key>
-                     <string>/home</string>
+                     <string>/testpath</string>
                  </dict>
                  <dict>
                      <key>$type</key>
                      <string>excludedFileExtension</string>
                      <key>extension</key>
-                     <string>pdf</string>
+                     <string>.abc</string>
                  </dict>
                  <dict>
                      <key>$type</key>
@@ -204,7 +204,7 @@ You'll need to take the following steps:
                  </dict>
              </array>
              <key>exclusionsMergePolicy</key>
-             <string>merge</string>
+             <string>admin</string>
              <key>allowedThreats</key>
              <array>
                  <string>EICAR-Test-File (not a virus)</string>
@@ -249,6 +249,7 @@ You'll need to take the following steps:
                      <key>key</key>
                      <string>GROUP</string>
                      <key>value</key>
+<!-- Make sure you remove this tag when you use the config file in production -->			 
                      <string>ExampleTag</string>
                  </dict>
              </array>


### PR DESCRIPTION
I have seen few customers using the example xml file as is , which will lead to exposing the device to risks (excluding pdfs , allowing users to create own exclusions , excluding the /home folder).

I modified the xml to include examples that would not expose the device to risk. Also added a comment for a customer to review the tags because if they dont change it all their devices will have the "ExampleTag" :)