### PR TITLE
Defender for Endpoint: clarify Note blob contents

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
@@ -34,7 +34,7 @@ There are some minimum requirements for onboarding devices to the service. Learn
 > - Defender for Endpoint demonstrated industry-leading optics and detection capabilities in the recent MITRE evaluation. Read: [Insights from the MITRE ATT&CK-based evaluation](https://cloudblogs.microsoft.com/microsoftsecure/2018/12/03/insights-from-the-mitre-attack-based-evaluation-of-windows-defender-atp/).
 
 ## Licensing requirements
-Microsoft Defender for Endpoint requires one of the following Microsoft Volume Licensing offers:
+Microsoft Defender for Endpoint requires one of the following Microsoft volume licensing offers:
 
 - Windows 10 Enterprise E5
 - Windows 10 Education A5
@@ -43,7 +43,7 @@ Microsoft Defender for Endpoint requires one of the following Microsoft Volume L
 - Microsoft 365 A5 (M365 A5)
 
 > [!NOTE]
-> Eligible Licensed Users may use Microsoft Defender for Endpoint on up to five concurrent devices.
+> Eligible licensed users may use Microsoft Defender for Endpoint on up to five concurrent devices.
 > Microsoft Defender for Endpoint is also available for purchase from a Cloud Solution Provider (CSP).
 
 Microsoft Defender for Endpoint, on Windows Server, requires one of the following licensing options:
@@ -52,14 +52,14 @@ Microsoft Defender for Endpoint, on Windows Server, requires one of the followin
 - Defender for Endpoint for Servers (one per covered server)
 
 > [!NOTE]
-> Customers may acquire Server Licenses (SLs) (one per covered server Operating System Environment (OSE)) for Microsoft Defender for Endpoint for Servers if they have a combined minimum of 50 licenses for one or more of the following User Licenses:
+> Customers may acquire server licenses (one per covered server Operating System Environment (OSE)) for Microsoft Defender for Endpoint for Servers if they have a combined minimum of 50 licenses for one or more of the following user licenses:
 >
 > * Microsoft Defender for Endpoint
 > * Windows E5/A5
 > * Microsoft 365 E5/A5
 > * Microsoft 365 E5 Security
 
-For detailed licensing information, see the [Product Terms site](https://www.microsoft.com/licensing/terms/) and work with your account team to learn the detailed terms and conditions for the product.
+For detailed licensing information, see the [Product Terms site](https://www.microsoft.com/licensing/terms/) and work with your account team to learn more about the terms and conditions.
 
 For more information on the array of features in Windows 10 editions, see [Compare Windows 10 editions](https://www.microsoft.com/windowsforbusiness/compare).
 

--- a/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
@@ -44,7 +44,7 @@ Microsoft Defender for Endpoint requires one of the following Microsoft Volume L
 
 > [!NOTE]
 > Eligible Licensed Users may use Microsoft Defender for Endpoint on up to five concurrent devices.
-> Microsoft Defender for Endpoint is also available for purchase from a Cloud Solution Provider (CSP). 
+> Microsoft Defender for Endpoint is also available for purchase from a Cloud Solution Provider (CSP).
 
 Microsoft Defender for Endpoint, on Windows Server, requires one of the following licensing options:
 
@@ -52,7 +52,12 @@ Microsoft Defender for Endpoint, on Windows Server, requires one of the followin
 - Defender for Endpoint for Servers (one per covered server)
 
 > [!NOTE]
-> Customers with a combined minimum of 50 licenses for one or more of the following may acquire Server SLs for Microsoft Defender Defender for Endpoint for Servers (one per covered Server OSE): Microsoft Defender for Endpoint, Windows E5/A5, Microsoft 365 E5/A5 and Microsoft 365 E5 Security User SLs. This license applies to Defender for Endpoint for Linux.
+> Customers may acquire Server Licenses (SLs) (one per covered server Operating System Environment (OSE)) for Microsoft Defender for Endpoint for Servers if they have a combined minimum of 50 licenses for one or more of the following User Licenses:
+>
+> * Microsoft Defender for Endpoint
+> * Windows E5/A5
+> * Microsoft 365 E5/A5
+> * Microsoft 365 E5 Security
 
 For detailed licensing information, see the [Product Terms site](https://www.microsoft.com/licensing/terms/) and work with your account team to learn the detailed terms and conditions for the product.
 
@@ -104,7 +109,7 @@ The hardware requirements for Defender for Endpoint on devices are the same for 
 
 ### Other supported operating systems
 - Android
-- Linux 
+- Linux
 - macOS
 
 > [!NOTE]
@@ -186,7 +191,7 @@ The Defender for Endpoint agent depends on the ability of Microsoft Defender Ant
 
 Configure Security intelligence updates on the Defender for Endpoint devices whether Microsoft Defender Antivirus is the active antimalware or not. For more information, see [Manage Microsoft Defender Antivirus updates and apply baselines](../microsoft-defender-antivirus/manage-updates-baselines-microsoft-defender-antivirus.md).
 
-When Microsoft Defender Antivirus is not the active antimalware in your organization and you use the Defender for Endpoint service, Microsoft Defender Antivirus goes on passive mode. 
+When Microsoft Defender Antivirus is not the active antimalware in your organization and you use the Defender for Endpoint service, Microsoft Defender Antivirus goes on passive mode.
 
 If your organization has turned off Microsoft Defender Antivirus through group policy or other methods, devices that are onboarded must be excluded from this group policy.
 


### PR DESCRIPTION
**Description:**
From issue ticket #8810 (**Confusing text**):
> The Note about server licensing is confusing. some words are repeated and acronyms are not defined. Please review and edit this so that people that are not familiar with server licensing terminology can understand what is needed. The whole topic of Defender for Endpoint in regards to servers is very confusing and needs to be simplified.

Thanks to @DeanGross for reporting the issue and for pointing out the duplication typo.

**Changes proposed:**
- expand and clarify acronyms and initialisms in the details of the Note blob
- convert the list within the sentence to a bullet point list for better overview
- remove a duplicated word (Microsoft Defender Defender for Endpoint)

**Whitespace changes:**
- remove 3 blanks at end-of-line

**Added corrections:**
- capitalized words changed to lowercase (Volume Licensing, Licensed Users)
- modified "learn the detailed terms and conditions for the product." to read "learn more about the terms and conditions."

**Ticket closure or reference:**
Closes #8810