### PR TITLE
Update enable-exploit-protection.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
@@ -207,10 +207,10 @@ If you need to restore the mitigation back to the system default, you need to in
 Set-Processmitigation -Name test.exe -Remove -Disable DEP
 ```
 
-This table lists the PowerShell cmdlets (and associated audit mode cmdlet) that can be used to configure each mitigation.
+This table lists the individual **Mitigations** (and **Audits**, when available) to be used with the `-Enable` or `-Disable` cmdlet parameters.
 
-| Mitigation | Applies to | PowerShell cmdlets | Audit mode cmdlet |
-| :--------- | :--------- | :----------------- | :---------------- |
+| Mitigation type | Applies to | Mitigation cmdlet parameter keyword | Audit mode cmdlet parameter |
+| :-------------- | :--------- | :---------------------------------- | :-------------------------- |
 | Control flow guard (CFG) | System and app-level |   CFG,   StrictCFG,   SuppressExports  | Audit not available |
 | Data Execution Prevention (DEP) | System and app-level |   DEP,   EmulateAtlThunks  | Audit not available |
 | Force randomization for images (Mandatory ASLR) | System and app-level |   ForceRelocateImages  | Audit not available |

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
@@ -54,8 +54,8 @@ You can also set mitigations to [audit mode](evaluate-exploit-protection.md). Au
 3. Go to **Program settings** and choose the app you want to apply mitigations to. <br/>
     - If the app you want to configure is already listed, click it and then click **Edit**.
     - If the app is not listed, at the top of the list click **Add program to customize** and then choose how you want to add the app. <br/>
-     - Use **Add by program name** to have the mitigation applied to any running process with that name. You must specify a file with an extension. You can enter a full path to limit the mitigation to only the app with that name in that location.
-     - Use **Choose exact file path** to use a standard Windows Explorer file picker window to find and select the file you want.
+    - Use **Add by program name** to have the mitigation applied to any running process with that name. You must specify a file with an extension. You can enter a full path to limit the mitigation to only the app with that name in that location.
+    - Use **Choose exact file path** to use a standard Windows Explorer file picker window to find and select the file you want.
 
 4. After selecting the app, you'll see a list of all the mitigations that can be applied. Choosing **Audit** will apply the mitigation in audit mode only. You are notified if you need to restart the process or app, or if you need to restart Windows.
 
@@ -114,7 +114,7 @@ The result will be that DEP will be enabled for *test.exe*. DEP will not be enab
 3. Name the profile, choose **Windows 10 and later** and **Endpoint protection**.<br/>
    ![Create endpoint protection profile](../images/create-endpoint-protection-profile.png)<br/>
 
-4. Click **Configure** > **Windows Defender Exploit Guard** > **Exploit protection**.  
+4. Click **Configure** > **Windows Defender Exploit Guard** > **Exploit protection**.
 
 5. Upload an [XML file](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-exploitguard) with the exploit protection settings:<br/>![Enable network protection in Intune](../images/enable-ep-intune.png)<br/>
 
@@ -209,29 +209,29 @@ Set-Processmitigation -Name test.exe -Remove -Disable DEP
 
 This table lists the PowerShell cmdlets (and associated audit mode cmdlet) that can be used to configure each mitigation.
 
-|Mitigation | Applies to | PowerShell cmdlets | Audit mode cmdlet |
-|:---|:---|:---|:---|
-|Control flow guard (CFG) | System and app-level |   CFG,   StrictCFG,   SuppressExports  | Audit not available |
-|Data Execution Prevention (DEP) | System and app-level |   DEP,   EmulateAtlThunks  | Audit not available |
-|Force randomization for images (Mandatory ASLR) | System and app-level |   ForceRelocateImages  | Audit not available |
-|Randomize memory allocations (Bottom-Up ASLR) | System and app-level |   BottomUp,   HighEntropy  | Audit not available
-|Validate exception chains (SEHOP) | System and app-level |   SEHOP,   SEHOPTelemetry  | Audit not available
-|Validate heap integrity | System and app-level |   TerminateOnHeapError  | Audit not available
-|Arbitrary code guard (ACG) | App-level only |   DynamicCode  |   AuditDynamicCode
-|Block low integrity images | App-level only |   BlockLowLabel  |   AuditImageLoad
-|Block remote images | App-level only |   BlockRemoteImages  | Audit not available
-|Block untrusted fonts | App-level only |   DisableNonSystemFonts  |   AuditFont,   FontAuditOnly
-|Code integrity guard | App-level only |   BlockNonMicrosoftSigned,   AllowStoreSigned  |   AuditMicrosoftSigned,   AuditStoreSigned
-|Disable extension points | App-level only |   ExtensionPoint  | Audit not available
-|Disable Win32k system calls | App-level only |   DisableWin32kSystemCalls  |   AuditSystemCall
-|Do not allow child processes | App-level only |   DisallowChildProcessCreation  |   AuditChildProcess
-|Export address filtering (EAF) | App-level only |   EnableExportAddressFilterPlus,   EnableExportAddressFilter  <a href="#r1" id="t1">\[1\]</a> | Audit not available<a href="#r2" id="t2">\[2\]</a> |
-|Import address filtering (IAF) | App-level only |   EnableImportAddressFilter  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
-|Simulate execution (SimExec) | App-level only |   EnableRopSimExec  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
-|Validate API invocation (CallerCheck) | App-level only |   EnableRopCallerCheck  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
-|Validate handle usage | App-level only |   StrictHandle  | Audit not available |
-|Validate image dependency integrity | App-level only |   EnforceModuleDepencySigning  | Audit not available |
-|Validate stack integrity (StackPivot) | App-level only |   EnableRopStackPivot  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Mitigation | Applies to | PowerShell cmdlets | Audit mode cmdlet |
+| :--------- | :--------- | :----------------- | :---------------- |
+| Control flow guard (CFG) | System and app-level |   CFG,   StrictCFG,   SuppressExports  | Audit not available |
+| Data Execution Prevention (DEP) | System and app-level |   DEP,   EmulateAtlThunks  | Audit not available |
+| Force randomization for images (Mandatory ASLR) | System and app-level |   ForceRelocateImages  | Audit not available |
+| Randomize memory allocations (Bottom-Up ASLR) | System and app-level |   BottomUp,   HighEntropy  | Audit not available
+| Validate exception chains (SEHOP) | System and app-level |   SEHOP,   SEHOPTelemetry  | Audit not available |
+| Validate heap integrity | System and app-level |   TerminateOnError  | Audit not available |
+| Arbitrary code guard (ACG) | App-level only |   DynamicCode  |   AuditDynamicCode |
+| Block low integrity images | App-level only |   BlockLowLabel  |   AuditImageLoad |
+| Block remote images | App-level only |   BlockRemoteImages  | Audit not available |
+| Block untrusted fonts | App-level only |   DisableNonSystemFonts  |   AuditFont,   FontAuditOnly |
+| Code integrity guard | App-level only |   BlockNonMicrosoftSigned,   AllowStoreSigned  |   AuditMicrosoftSigned,   AuditStoreSigned |
+| Disable extension points | App-level only |   ExtensionPoint  | Audit not available |
+| Disable Win32k system calls | App-level only |   DisableWin32kSystemCalls  |   AuditSystemCall |
+| Do not allow child processes | App-level only |   DisallowChildProcessCreation  |   AuditChildProcess |
+| Export address filtering (EAF) | App-level only |   EnableExportAddressFilterPlus,   EnableExportAddressFilter  <a href="#r1" id="t1">\[1\]</a> | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Import address filtering (IAF) | App-level only |   EnableImportAddressFilter  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Simulate execution (SimExec) | App-level only |   EnableRopSimExec  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Validate API invocation (CallerCheck) | App-level only |   EnableRopCallerCheck  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
+| Validate handle usage | App-level only |   StrictHandle  | Audit not available |
+| Validate image dependency integrity | App-level only |   EnforceModuleDepencySigning  | Audit not available |
+| Validate stack integrity (StackPivot) | App-level only |   EnableRopStackPivot  | Audit not available<a href="#r2" id="t2">\[2\]</a> |
 
 <a href="#t1" id="r1">\[1\]</a>: Use the following format to enable EAF modules for DLLs for a process:
 
@@ -239,6 +239,7 @@ This table lists the PowerShell cmdlets (and associated audit mode cmdlet) that 
 Set-ProcessMitigation -Name processName.exe -Enable EnableExportAddressFilterPlus -EAFModules dllName1.dll,dllName2.dll
 ```
 <a href="#t2" id="r2">\[2\]</a>: Audit for this mitigation is not available via Powershell cmdlets.
+
 ## Customize the notification
 
 See the [Windows Security](../windows-defender-security-center/windows-defender-security-center.md#customize-notifications-from-the-windows-defender-security-center) topic for more information about customizing the notification when a rule is triggered and blocks an app or file.

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
@@ -30,14 +30,13 @@ manager: dansimp
 
 Many features from the Enhanced Mitigation Experience Toolkit (EMET) are included in exploit protection.
 
-You can enable each mitigation separately by using any of these methods:
-
-* [Windows Security app](#windows-security-app)
-* [Microsoft Intune](#intune)
-* [Mobile Device Management (MDM)](#mdm)
-* [Microsoft Endpoint Configuration Manager](#microsoft-endpoint-configuration-manager)
-* [Group Policy](#group-policy)
-* [PowerShell](#powershell)
+You can enable each mitigation separately by using any of these methods:   
+- [Windows Security app](#windows-security-app)
+- [Microsoft Intune](#intune)
+- [Mobile Device Management (MDM)](#mdm)
+- [Microsoft Endpoint Configuration Manager](#microsoft-endpoint-configuration-manager)
+- [Group Policy](#group-policy)
+- [PowerShell](#powershell)
 
 Exploit protection is configured by default in Windows 10. You can set each mitigation to on, off, or to its default value. Some mitigations have additional options.
 
@@ -160,11 +159,8 @@ Get-ProcessMitigation -Name processName.exe
 
 > [!IMPORTANT]
 > System-level mitigations that have not been configured will show a status of `NOTSET`.
->
-> For system-level settings, `NOTSET` indicates the default setting for that mitigation has been applied.
->
-> For app-level settings, `NOTSET` indicates the system-level setting for the mitigation will be applied.
->
+> - For system-level settings, `NOTSET` indicates the default setting for that mitigation has been applied.
+> - For app-level settings, `NOTSET` indicates the system-level setting for the mitigation will be applied.
 > The default setting for each system-level mitigation can be seen in the Windows Security.
 
 Use `Set` to configure each mitigation in the following format:

--- a/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/enable-exploit-protection.md
@@ -47,7 +47,7 @@ You can also set mitigations to [audit mode](evaluate-exploit-protection.md). Au
 
 ## Windows Security app
 
-1. Open the Windows Security app by clicking the shield icon in the task bar or searching the start menu for **Defender**.
+1. Open the Windows Security app by clicking the shield icon in the task bar or searching the start menu for **Security**.
 
 2. Click the **App & browser control** tile (or the app icon on the left menu bar) and then click **Exploit protection settings**.
 


### PR DESCRIPTION
**Description:**

From issue ticket #8927 (**No such property as TerminateOnHeapError**):

> In the list of properties used for different security exploit settings for the cmdlets, the properties to be set for 'Validate heap integrity' is labeled wrong.
> 
> | Validate heap integrity | System and app-level | TerminateOnHeapError | Audit not available |
>
> **The property 'TerminateOnHeapError' doesn't exist for Heap. It should be TerminateOnError.**

Thanks to @dennisl68-castra for noticing and reporting this incorrect term variant.

**Changes proposed:**
- Change "TerminateOnHeapError" to 'TerminateOnError'

**Whitespace changes:**
- Add recommended minimum cell divider spacing to the MarkDown table cells
- Align table header dividing row cell dividers with the column title row cell dividers
- Add editorial line between footnote mark [2] and second last H2 (##) heading
- Remove redundant end-of-line (EOL) blanks remaining in this document
- Align some misaligned whitespace in a 2nd level bullet point list

**Ticket closure or reference:**

Closes #8927

Ref. old PR #4351 from July 5, 2019 (before Windows Defender Exploit Guard was changed or retired)