### PR TITLE
Title text change to new naming

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/onboard-offline-machines.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/onboard-offline-machines.md
@@ -1,5 +1,5 @@
 ---
-title: Onboard devices without Internet access to Microsoft Defender ATP
+title: Onboard devices without Internet access to Microsoft Defender for Endpoint
 ms.reviewer: 
 description: Onboard devices without Internet access so that they can send sensor data to the Microsoft Defender ATP sensor
 keywords: onboard, servers, vm, on-premise, oms gateway, log analytics, azure log analytics, mma


### PR DESCRIPTION
The web page title was left still referring to Defender ATP, so updated for Defender for Endpoint. Not sure if other pages also are missing this change when the rest of the page was updated.