### PR TITLE
Update distribute-offline-apps.md

### DIFF
--- a/store-for-business/distribute-offline-apps.md
+++ b/store-for-business/distribute-offline-apps.md
@@ -29,7 +29,7 @@ Offline licensing is a new licensing option for Windows 10 with Microsoft Store 
 
 Offline-licensed apps offer an alternative to online apps, and provide additional deployment options. Some reasons to use offline-licensed apps:
 
-- **You don't have access to Microsoft Store services** - If your employees don't have access to the internet and Microsoft Store services, downloading offline-licensed apps and deploying them with imaging is an alternative to online-licensed apps.
+- **You don't have access to Microsoft Store services** - If your employees don't have access to the Internet and Microsoft Store services, downloading offline-licensed apps and deploying them with imaging is an alternative to online-licensed apps.
 
 - **You use imaging to manage devices in your organization** - Offline-licensed apps can be added to images and deployed with Deployment Image Servicing and Management (DISM), or Windows Imaging and Configuration Designer (ICD).
 

--- a/store-for-business/distribute-offline-apps.md
+++ b/store-for-business/distribute-offline-apps.md
@@ -18,10 +18,10 @@ ms.date: 10/17/2017
 # Distribute offline apps
 
 
-**Applies to**
+**Applies to:**
 
--   Windows 10
--   Windows 10 Mobile
+- Windows 10
+- Windows 10 Mobile
 
 Offline licensing is a new licensing option for Windows 10 with Microsoft Store for Business and Microsoft Store for Education. With offline licenses, organizations can download apps and their licenses to deploy within their network, or on devices that are not connected to the Internet. ISVs or devs can opt-in their apps for offline licensing when they submit them to the Windows Dev Center. Only apps that are opted in to offline licensing will show that they are available for offline licensing in Microsoft Store for Business and Microsoft Store for Education. This model allows organizations to deploy apps when users or devices do not have connectivity to the Store.
 
@@ -29,23 +29,23 @@ Offline licensing is a new licensing option for Windows 10 with Microsoft Store 
 
 Offline-licensed apps offer an alternative to online apps, and provide additional deployment options. Some reasons to use offline-licensed apps:
 
--   **You don't have access to Microsoft Store services** - If your employees don't have access to the internet and Microsoft Store services, downloading offline-licensed apps and deploying them with imaging is an alternative to online-licensed apps.
+- **You don't have access to Microsoft Store services** - If your employees don't have access to the internet and Microsoft Store services, downloading offline-licensed apps and deploying them with imaging is an alternative to online-licensed apps.
 
--   **You use imaging to manage devices in your organization** - Offline-licensed apps can be added to images and deployed with Deployment Image Servicing and Management (DISM), or Windows Imaging and Configuration Designer (ICD).
+- **You use imaging to manage devices in your organization** - Offline-licensed apps can be added to images and deployed with Deployment Image Servicing and Management (DISM), or Windows Imaging and Configuration Designer (ICD).
 
--   **Your employees do not have Azure Active Directory (AD) accounts** - Azure AD accounts are required for employees that install apps assigned to them from Microsoft Store or that claim apps from a private store.
+- **Your employees do not have Azure Active Directory (AD) accounts** - Azure AD accounts are required for employees that install apps assigned to them from Microsoft Store or that claim apps from a private store.
 
 ## Distribution options for offline-licensed apps
 
 You can't distribute offline-licensed apps directly from Microsoft Store. Once you download the items for the offline-licensed app, you have options for distributing the apps:
 
--   **Deployment Image Servicing and Management**. DISM is a command-line tool that is used to mount and service Microsoft Windows images before deployment. You can also use DISM to install, uninstall, configure, and update Windows features, packages, drivers, and international settings in a .wim file or VHD using the DISM servicing commands. DISM commands are used on offline images. For more information, see [Deployment Image Servicing and Management](https://msdn.microsoft.com/windows/hardware/commercialize/manufacture/desktop/dism---deployment-image-servicing-and-management-technical-reference-for-windows).
+- **Deployment Image Servicing and Management**. DISM is a command-line tool that is used to mount and service Microsoft Windows images before deployment. You can also use DISM to install, uninstall, configure, and update Windows features, packages, drivers, and international settings in a .wim file or VHD using the DISM servicing commands. DISM commands are used on offline images. For more information, see [Deployment Image Servicing and Management](https://msdn.microsoft.com/windows/hardware/commercialize/manufacture/desktop/dism---deployment-image-servicing-and-management-technical-reference-for-windows).
 
--   **Create provisioning package**. You can use Windows Imaging and Configuration Designer (ICD) to create a provisioning package for your offline app. Once you have the package, there are options to [apply the provisioning package](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-apply-package). For more information, see [Provisioning Packages for Windows 10](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).
+- **Create provisioning package**. You can use Windows Imaging and Configuration Designer (ICD) to create a provisioning package for your offline app. Once you have the package, there are options to [apply the provisioning package](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-apply-package). For more information, see [Provisioning Packages for Windows 10](https://docs.microsoft.com/windows/configuration/provisioning-packages/provisioning-packages).
 
--   **Mobile device management provider or management server.** You can use a mobile device management (MDM) provider or management server to distribute offline apps. For more information, see these topics:
+- **Mobile device management provider or management server.** You can use a mobile device management (MDM) provider or management server to distribute offline apps. For more information, see these topics:
     - [Manage apps from Microsoft Store for Business with Microsoft Endpoint Configuration Manager](https://docs.microsoft.com/configmgr/apps/deploy-use/manage-apps-from-the-windows-store-for-business)
-    - [Manage apps from Microsoft Store for Business with Microsoft Intune](https://docs.microsoft.com/intune/deploy-use/manage-apps-you-purchased-from-the-windows-store-for-business-with-microsoft-intune)<br>
+    - [Manage apps from Microsoft Store for Business with Microsoft Intune](https://docs.microsoft.com/mem/intune/apps/windows-store-for-business)<br>
 
 For third-party MDM providers or management servers, check your product documentation.
 
@@ -53,23 +53,22 @@ For third-party MDM providers or management servers, check your product document
 
 There are several items to download or create for offline-licensed apps. The app package and app license are required; app metadata and app frameworks are optional. This section includes more info on each item, and tells you how to download an offline-licensed app.
 
--   **App metadata** - App metadata is optional. The metadata includes app details, links to icons, product id, localized product ids, and other items. Devs who plan to use an app as part of another app or tool, might want the app metadata.
+- **App metadata** - App metadata is optional. The metadata includes app details, links to icons, product id, localized product ids, and other items. Devs who plan to use an app as part of another app or tool, might want the app metadata.
 
--   **App package** - App packages are required for distributing offline apps. There are app packages for different combinations of app platform and device architecture. You'll need to know what device architectures you have in your organization to know if there are app packages to support your devices.
+- **App package** - App packages are required for distributing offline apps. There are app packages for different combinations of app platform and device architecture. You'll need to know what device architectures you have in your organization to know if there are app packages to support your devices.
 
--   **App license** - App licenses are required for distributing offline apps. Use encoded licenses when you distribute offline-licensed apps using a management tool or ICD. Use unencoded licenses when you distribute offline-licensed apps using DISM.
+- **App license** - App licenses are required for distributing offline apps. Use encoded licenses when you distribute offline-licensed apps using a management tool or ICD. Use unencoded licenses when you distribute offline-licensed apps using DISM.
 
--   **App frameworks** - App frameworks are optional. If you already have the required framework, you don't need to download another copy. The Store for Business will select the app framework needed for the app platform and architecture that you selected.
+- **App frameworks** - App frameworks are optional. If you already have the required framework, you don't need to download another copy. The Store for Business will select the app framework needed for the app platform and architecture that you selected.
 
-<a href="" id="download-offline-licensed-app"></a>
-**To download an offline-licensed app**
+### <a href="" id="download-offline-licensed-app"></a> To download an offline-licensed app
 
-1.  Sign in to the [Microsoft Store for Business](https://businessstore.microsoft.com/) or [Microsoft Store for Education](https://educationstore.microsoft.com).
-2.  Click **Manage**.
-3.  Click **Settings**.
-4.  Click **Shop**. Search for the **Shopping experience** section, change the License type to **Offline**, and click  **Get the app**, which will add the app to your inventory.
-5.  Click **Manage**. You now have access to download the appx bundle package metadata and license file.
-6.  Go to **Products & services**, and select **Apps & software**. (The list may be empty, but it will auto-populate after some time.)
+1. Sign in to the [Microsoft Store for Business](https://businessstore.microsoft.com/) or [Microsoft Store for Education](https://educationstore.microsoft.com).
+2. Click **Manage**.
+3. Click **Settings**.
+4. Click **Shop**. Search for the **Shopping experience** section, change the License type to **Offline**, and click  **Get the app**, which will add the app to your inventory.
+5. Click **Manage**. You now have access to download the appx bundle package metadata and license file.
+6. Go to **Products & services**, and select **Apps & software**. (The list may be empty, but it will auto-populate after some time.)
 
     - **To download app metadata**: Choose the language for the app metadata, and then click **Download**. Save the downloaded app metadata. This is optional.
     - **To download app package**: Click to expand the package details information, choose the Platform and Architecture combination that you need for your organization, and then click **Download**. Save the downloaded app package. This is required.
@@ -78,16 +77,3 @@ There are several items to download or create for offline-licensed apps. The app
 
 > [!NOTE]
 > You need the framework to support your app package, but if you already have a copy, you don't need to download it again. Frameworks are backward compatible.
-
-
-
-     
-
- 
-
- 
-
-
-
-
-

--- a/store-for-business/distribute-offline-apps.md
+++ b/store-for-business/distribute-offline-apps.md
@@ -61,7 +61,7 @@ There are several items to download or create for offline-licensed apps. The app
 
 - **App frameworks** - App frameworks are optional. If you already have the required framework, you don't need to download another copy. The Store for Business will select the app framework needed for the app platform and architecture that you selected.
 
-### <a href="" id="download-offline-licensed-app"></a> To download an offline-licensed app
+<a href="" id="download-offline-licensed-app"></a>**To download an offline-licensed app**
 
 1. Sign in to the [Microsoft Store for Business](https://businessstore.microsoft.com/) or [Microsoft Store for Education](https://educationstore.microsoft.com).
 2. Click **Manage**.


### PR DESCRIPTION
**Description:**

From issue ticket #8942 (**Broken link - Distribute offline apps**):

> Hi all.
> 
> In Distribute offline apps (https://docs.microsoft.com/en-us/microsoft-store/distribute-offline-apps) the link Manage apps from Microsoft Store for Business with Microsoft Intune that points to [docs.microsoft.com/en-us/intune/deploy-use/manage-apps-you-purchased-from-the-windows-store-for-business-with-microsoft-intune](https://docs.microsoft.com/en-us/intune/deploy-use/manage-apps-you-purchased-from-the-windows-store-for-business-with-microsoft-intune) rports error 404. Probably the destination has changed URL. I believe that it should point to the doc How to manage volume purchased apps from the Microsoft Store for Business with Microsoft Intune - [docs.microsoft.com/en-us/mem/intune/apps/windows-store-for-business](https://docs.microsoft.com/en-us/mem/intune/apps/windows-store-for-business).
> 
> Can you double check this and fix it please?

Thanks to @joaonltome for noticing and reporting this broken link and also suggesting a likely solution.

**Changes proposed:**

- Replace the broken link /microsoft-store/distribute-offline-apps with the working page link /mem/intune/apps/windows-store-for-business .
- ~~Change the paragraph title "To download an offline-licensed app" from **bold** formatting to a H3 heading, as well as including the HTML anchor in that heading.
  (This heading level might possibly need to be a H4 heading size to remain the same size as its current **bold**-only format.)~~

**Whitespace changes:**

- Remove 13 redundant blank lines at the end of the document page.
- By removing these 13 blank lines, we also remove that redundant empty command copy box (created by indents).
- Remove the Line break (NewLine) between the anchor link and the paragraph title, to see if the common format works.
- Reduce 12 occurrences of 3 blank spaces after bullet point list indicators to 1 space.
- Reduce 6 occurrences of double blank space after numbered list indicators to 1 space.
- Add missing colon in **Applies to:**
 
**Ticket closure or reference:**

Closes #8942