### PR TITLE
Update live-response-command-examples.md

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/live-response-command-examples.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/live-response-command-examples.md
@@ -158,7 +158,7 @@ registry HKEY_CURRENT_USER\Console
 
 ```
 # Show information about a specific registry value
-registry HKEY_CURRENT_USER\Console\ScreenBufferSize
+registry HKEY_CURRENT_USER\Console\\ScreenBufferSize
 ```
 
 


### PR DESCRIPTION
Missing backslash in the command to view a registry value.