### PR TITLE
MarkDown code blocks & whitespace (ref. #9053)

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-antivirus/detect-block-potentially-unwanted-apps-microsoft-defender-antivirus.md
+++ b/windows/security/threat-protection/microsoft-defender-antivirus/detect-block-potentially-unwanted-apps-microsoft-defender-antivirus.md
@@ -134,19 +134,17 @@ For System Center 2012 Configuration Manager, see [How to Deploy Potentially Unw
 ##### To enable PUA protection
 
 ```PowerShell
-
 Set-MpPreference -PUAProtection Enabled
-
 ```
+
 Setting the value for this cmdlet to `Enabled` turns the feature on if it has been disabled.
 
 ##### To set PUA protection to audit mode
 
 ```PowerShell
-
 Set-MpPreference -PUAProtection AuditMode
-
 ```
+
 Setting `AuditMode` detects PUAs without blocking them.
 
 ##### To disable PUA protection
@@ -154,10 +152,9 @@ Setting `AuditMode` detects PUAs without blocking them.
 We recommend keeping PUA protection turned on. However, you can turn it off by using the following cmdlet:
 
 ```PowerShell
-
 Set-MpPreference -PUAProtection Disabled
-
 ```
+
 Setting the value for this cmdlet to `Disabled` turns the feature off if it has been enabled.
 
 See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](use-powershell-cmdlets-microsoft-defender-antivirus.md) and [Defender cmdlets](https://docs.microsoft.com/powershell/module/defender/index) for more information on how to use PowerShell with Microsoft Defender Antivirus.
@@ -167,7 +164,6 @@ See [Use PowerShell cmdlets to configure and run Microsoft Defender Antivirus](u
 PUA events are reported in the Windows Event Viewer, but not in Microsoft Endpoint Manager or in Intune. You can also use the `Get-MpThreat` cmdlet to view threats that Microsoft Defender Antivirus handled. Here's an example:
 
 ```console
-
 CategoryID       : 27
 DidThreatExecute : False
 IsActive         : False
@@ -188,7 +184,7 @@ See [Troubleshoot event IDs](troubleshoot-microsoft-defender-antivirus.md) for d
 
 ### Allow-listing apps
 
-Sometimes a file is erroneously blocked by PUA protection, or a feature of a PUA is required to complete a task. In these cases, a file can be allow-listed. 
+Sometimes a file is erroneously blocked by PUA protection, or a feature of a PUA is required to complete a task. In these cases, a file can be allow-listed.
 
 For more information, see [Recommended antivirus exclusions for Configuration Manager site servers, site systems, and clients](https://docs.microsoft.com/troubleshoot/mem/configmgr/recommended-antivirus-exclusions#exclusions).
 


### PR DESCRIPTION
**Corrections to PR** #9053 **/ commit** https://github.com/MicrosoftDocs/windows-itpro-docs/commit/9856688ff24ecbf4fe47f7446b9ef9182d2de3a4

A misunderstanding in PR #9053 caused the addition of unneeded & unwanted blank lines within the PowerShell PUA code blocks for the 3 variations of `Set-MpPreference -PUAProtection` and the console output, as well as missing the opportunity to add editorial blank lines below the code blocks, for easier future editing.

**Ref. PR** #9053 **/ commit** https://github.com/MicrosoftDocs/windows-itpro-docs/commit/9856688ff24ecbf4fe47f7446b9ef9182d2de3a4