### PR TITLE
Update /remoteGuard requirements

### DIFF
--- a/windows/security/identity-protection/remote-credential-guard.md
+++ b/windows/security/identity-protection/remote-credential-guard.md
@@ -181,7 +181,7 @@ mstsc.exe /remoteGuard
 ```
 
 > [!NOTE]
-> The user must be part of administrators group.
+> The user must be authorized to connect to the remote server using Remote Desktop Protocol. For example, by being a member of the Remote Desktop Users local group on the remote computer.
 
 ## Considerations when using Windows Defender Remote Credential Guard
 

--- a/windows/security/identity-protection/remote-credential-guard.md
+++ b/windows/security/identity-protection/remote-credential-guard.md
@@ -181,7 +181,7 @@ mstsc.exe /remoteGuard
 ```
 
 > [!NOTE]
-> The user must be authorized to connect to the remote server using Remote Desktop Protocol. For example, by being a member of the Remote Desktop Users local group on the remote computer.
+> The user must be authorized to connect to the remote server using Remote Desktop Protocol, for example by being a member of the Remote Desktop Users local group on the remote computer.
 
 ## Considerations when using Windows Defender Remote Credential Guard
 


### PR DESCRIPTION
/remtoteGuard does not require to be a member of the local admintrators group of the source computer nor the target computer. There used to be a bug which was corrected (discussed with Andrew Wiley from Enterprise & Security SWE R&D)
However, it does require the user to have some RDP permissions at the remote computer level. So I updated the note to reflect the real requirements.