### PR TITLE
Update prepare-for-zero-touch-installation-of-windows-10-with-configu…

### DIFF
--- a/windows/deployment/deploy-windows-cm/prepare-for-zero-touch-installation-of-windows-10-with-configuration-manager.md
+++ b/windows/deployment/deploy-windows-cm/prepare-for-zero-touch-installation-of-windows-10-with-configuration-manager.md
@@ -77,7 +77,7 @@ ForEach($entry in $oulist){
 }
 ```
 
-Next, copy the following list of OU names and paths into a text file and save it as <b>C:\Setup\Scripts\oulist.txt</b>
+Next, copy the following list of OU names and paths into a text file and save it as **C:\Setup\Scripts\oulist.txt**
 
 ```text
 OUName,OUPath


### PR DESCRIPTION
…ration-manager.md

<b> tags are not valid in markdown and are probably leftover from migrating this content.   This is causing a problem with the localized files.
According to the markdown guidelines 
To format text as bold, enclose it in two asterisks
This text is **bold**.
https://review.docs.microsoft.com/en-us/help/contribute/markdown-reference?branch=master