### PR TITLE
ESU callout for Win 7

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
@@ -85,8 +85,8 @@ Access to Defender for Endpoint is done through a browser, supporting the follow
 ## Hardware and software requirements
 
 ### Supported Windows versions
-- Windows 7 SP1 Enterprise
-- Windows 7 SP1 Pro
+- Windows 7 SP1 Enterprise [requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq)
+- Windows 7 SP1 Pro [requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq)
 - Windows 8.1 Enterprise
 - Windows 8.1 Pro
 - Windows 10 Enterprise

--- a/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/minimum-requirements.md
@@ -85,8 +85,8 @@ Access to Defender for Endpoint is done through a browser, supporting the follow
 ## Hardware and software requirements
 
 ### Supported Windows versions
-- Windows 7 SP1 Enterprise [requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq)
-- Windows 7 SP1 Pro [requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq)
+- Windows 7 SP1 Enterprise ([Requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq).)
+- Windows 7 SP1 Pro ([Requires ESU for support](https://docs.microsoft.com/troubleshoot/windows-client/windows-7-eos-faq/windows-7-extended-security-updates-faq).)
 - Windows 8.1 Enterprise
 - Windows 8.1 Pro
 - Windows 10 Enterprise


### PR DESCRIPTION
Windows 7 requires SCEP or relies upon SCEP, in order for SCEP to be in a supported state, it would require a customer to purchase and use ESU to classify a device as supported for Windows 7 device

Called that out, technically Windows 7 is not listed as a supported OS in SCCM/SCEP any longer - https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/configs/supported-operating-systems-for-clients-and-devices