### PR TITLE
Added another cause of boot failure

### DIFF
--- a/windows/client-management/troubleshoot-inaccessible-boot-device.md
+++ b/windows/client-management/troubleshoot-inaccessible-boot-device.md
@@ -35,9 +35,9 @@ Any one of the following factors might cause the stop error:
 
 * In unusual cases, the failure of the TrustedInstaller service to commit newly installed updates is because of component-based store corruptions
 
-* Corrupted files in the **Boot**  partition (for example, corruption in the volume that's labeled **SYSTEM**  when you run the `diskpart`  > `list vol`  command)
+* Corrupted files in the **Boot** partition (for example, corruption in the volume that's labeled **SYSTEM** when you run the `diskpart` > `list vol` command)
 
-* If there is a blank GPT entry before the entry of the **Boot** partition.
+* If there is a blank GPT entry before the entry of the **Boot** partition
 
 ## Troubleshoot this error
 

--- a/windows/client-management/troubleshoot-inaccessible-boot-device.md
+++ b/windows/client-management/troubleshoot-inaccessible-boot-device.md
@@ -37,6 +37,8 @@ Any one of the following factors might cause the stop error:
 
 * Corrupted files in the **Boot**  partition (for example, corruption in the volume that's labeled **SYSTEM**  when you run the `diskpart`  > `list vol`  command)
 
+* If there is a blank GPT entry before the entry of the boot partition.
+
 ## Troubleshoot this error
 
 Start the computer in [Windows Recovery Mode (WinRE)](https://docs.microsoft.com/windows-hardware/manufacture/desktop/windows-recovery-environment--windows-re--technical-reference#span-identrypointsintowinrespanspan-identrypointsintowinrespanspan-identrypointsintowinrespanentry-points-into-winre). To do this, follow these steps.

--- a/windows/client-management/troubleshoot-inaccessible-boot-device.md
+++ b/windows/client-management/troubleshoot-inaccessible-boot-device.md
@@ -37,7 +37,7 @@ Any one of the following factors might cause the stop error:
 
 * Corrupted files in the **Boot**  partition (for example, corruption in the volume that's labeled **SYSTEM**  when you run the `diskpart`  > `list vol`  command)
 
-* If there is a blank GPT entry before the entry of the boot partition.
+* If there is a blank GPT entry before the entry of the **Boot** partition.
 
 ## Troubleshoot this error
 


### PR DESCRIPTION
If there is a blank GPT entry, the boot partition will not work. Added this info.

Problem: https://github.com/MicrosoftDocs/windows-itpro-docs/issues/9145