### PR TITLE
Make verifier run on next boot only

### DIFF
--- a/windows/security/identity-protection/credential-guard/dg-readiness-tool.md
+++ b/windows/security/identity-protection/credential-guard/dg-readiness-tool.md
@@ -678,7 +678,7 @@ function CheckDriverCompat
     if($verifier_state.ToString().Contains("No drivers are currently verified."))
     {
         LogAndConsole "Enabling Driver verifier"
-        verifier.exe /flags 0x02000000 /all /log.code_integrity
+        verifier.exe /flags 0x02000000 /all /bootmode oneboot /log.code_integrity
 
         LogAndConsole "Enabling Driver Verifier and Rebooting system"
         Log $verifier_state


### PR DESCRIPTION
In its current state, the verifier does not specify a /bootmode, which causes it to use the default behavior, "persistent." As a result the system may get stuck in a boot loop on an incompatible hardware configuration.

This change ensures that the verifier should only run on the next boot, preventing a user from getting their computer stuck in a situation that Windows cannot resolve on its own.

I screwed up a previous version of this pull request - sorry about that. Hopefully this one is correct.