### PR TITLE
Link 404 correction (ad385bc follow-up)

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-atp/advanced-features.md
+++ b/windows/security/threat-protection/microsoft-defender-atp/advanced-features.md
@@ -201,7 +201,7 @@ You'll have access to upcoming features, which you can provide feedback on to he
 
 Forwards endpoint security alerts and their triage status to Microsoft Compliance Center, allowing you to enhance insider risk management policies with alerts and remediate internal risks before they cause harm. Forwarded data is processed and stored in the same location as your Office 365 data.
 
-After configuring the [Security policy violation indicators](https://docs.microsoft.com/microsoft-365/compliance/insider-risk-management-settings.md#indicators) in the insider risk management settings, Defender for Endpoint alerts will be shared with insider risk management for applicable users.
+After configuring the [Security policy violation indicators](https://docs.microsoft.com/microsoft-365/compliance/insider-risk-management-settings#indicators) in the insider risk management settings, Defender for Endpoint alerts will be shared with insider risk management for applicable users.
 
 ## Related topics
 


### PR DESCRIPTION
**Description:**

As noted in issue ticket #9350 (**Link for "Security policy violation indicators" under Share endpoint alerts with Microsoft Compliance Center is not getting redirected properly.**), the link https://docs.microsoft.com/en-us/microsoft-365/compliance/insider-risk-management-settings.md#indicators does not open the correct page. (To experienced users, it is obvious, because there is a misplaced `.md` within the link, as if it was meant to be a github.com page link.)

Thanks to @vikassou for noticing and reporting the link issue.

**Proposed change:**

- Remove the misplaced `.md` file extension from the link

**Ticket closure or reference:**

Closes #9350