### PR TITLE
Add additional troubleshooting link for loopback and UWA

### DIFF
--- a/windows/security/threat-protection/windows-firewall/troubleshooting-uwp-firewall.md
+++ b/windows/security/threat-protection/windows-firewall/troubleshooting-uwp-firewall.md
@@ -74,7 +74,7 @@ localhost
 
 Note: If you are in the middle of developing a UWA application and want to test its loopback, ensure to uninstall and re-install the UWA app if the network capabilties change for whatever reason. 
 
-Also, see [How to enable loopback and troubleshoot network isolation (Windows Runtime apps)](https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh780593(v=win.10)#debug-network-isolation-issues).
+Also, see [How to enable loopback and troubleshoot network isolation (Windows Runtime apps)](https://docs.microsoft.com/previous-versions/windows/apps/hh780593(v=win.10)#debug-network-isolation-issues).
 
 ## Debugging Live Drops
 

--- a/windows/security/threat-protection/windows-firewall/troubleshooting-uwp-firewall.md
+++ b/windows/security/threat-protection/windows-firewall/troubleshooting-uwp-firewall.md
@@ -72,6 +72,10 @@ For more information about loopback scenarios, see [Communicating with
 localhost
 (loopback)](/windows/iot-core/develop-your-app/loopback).
 
+Note: If you are in the middle of developing a UWA application and want to test its loopback, ensure to uninstall and re-install the UWA app if the network capabilties change for whatever reason. 
+
+Also, see [How to enable loopback and troubleshoot network isolation (Windows Runtime apps)](https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh780593(v=win.10)#debug-network-isolation-issues).
+
 ## Debugging Live Drops
 
 If the issue happened recently, but you find you are not able to reproduce the issue, go to Debugging Past Drops for the appropriate trace commands.


### PR DESCRIPTION
Clarified that when developer changes the capability, they should uninstall and re install the app to ensure the rules are correctly added.
Also, added an additional link to "How to enable loopback and troubleshoot network isolation (Windows Runtime apps)." https://docs.microsoft.com/en-us/previous-versions/windows/apps/hh780593(v=win.10)#debug-network-isolation-issues