### PR TITLE
Update hello-hybrid-cert-whfb-settings-dir-sync.md

### DIFF
--- a/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-whfb-settings-dir-sync.md
+++ b/windows/security/identity-protection/hello-for-business/hello-hybrid-cert-whfb-settings-dir-sync.md
@@ -22,6 +22,7 @@ ms.reviewer:
 **Applies to**
 - Windows 10, version 1703 or later
 - Hybrid deployment
+- Key Trust
 - Certificate Trust
 
 


### PR DESCRIPTION
According to the text below, it should apply to Key trust and certificate trust

"In hybrid deployments, users register the public portion of their Windows Hello for Business credential with Azure.  Azure AD Connect synchronizes the Windows Hello for Business public key to Active Directory.

The key-trust model needs Windows Server 2016 domain controllers, which configure the key registration permissions automatically; however, the certificate-trust model does not and requires you to add the permissions manually."