### PR TITLE
Added Note clarifying the NMICrashDump key usage.

### DIFF
--- a/windows/client-management/generate-kernel-or-complete-crash-dump.md
+++ b/windows/client-management/generate-kernel-or-complete-crash-dump.md
@@ -79,8 +79,8 @@ To do this, follow these steps:
 > [!IMPORTANT]  
 > Follow the steps in this section carefully. Serious problems might occur if you modify the registry incorrectly. Before you modify it, [back up the registry for restoration](https://support.microsoft.com/help/322756) in case problems occur.
  
->[!Note]
-> This registry key is not required for clients Windows 8 and newer or servers Windows Server 2012 and newer.  Setting this registry key on newer versions of Windows has no effect.
+> [!NOTE]
+> This registry key is not required for clients running Windows 8 and later, or servers running Windows Server 2012 and later. Setting this registry key on later versions of Windows has no effect.
 
 1. In Registry Editor, locate the following registry subkey:
 

--- a/windows/client-management/generate-kernel-or-complete-crash-dump.md
+++ b/windows/client-management/generate-kernel-or-complete-crash-dump.md
@@ -78,6 +78,9 @@ To do this, follow these steps:
 
 > [!IMPORTANT]  
 > Follow the steps in this section carefully. Serious problems might occur if you modify the registry incorrectly. Before you modify it, [back up the registry for restoration](https://support.microsoft.com/help/322756) in case problems occur.
+ 
+>[!Note]
+> This registry key is not required for clients Windows 8 and newer or servers Windows Server 2012 and newer.  Setting this registry key on newer versions of Windows has no effect.
 
 1. In Registry Editor, locate the following registry subkey:
 


### PR DESCRIPTION
For Windows 8+ and Windows Server 2012+ the NMICrashdump key is not required and no longer has any effect.