### PR TITLE
Update policy-csp-admx-windowsexplorer.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-admx-windowsexplorer.md
+++ b/windows/client-management/mdm/policy-csp-admx-windowsexplorer.md
@@ -8,7 +8,7 @@ ms.prod: w10
 ms.technology: windows
 author: manikadhiman
 ms.date: 10/29/2020
-ms.reviewer: 
+ms.reviewer:  
 manager: dansimp
 ---
 


### PR DESCRIPTION
For the section "If you enable this setting, users can browse the directory structure of the selected drives in My Computer or File Explorer, but they cannot open folders and access the contents. Also, they cannot use the Run dialog box or the Map Network Drive dialog box to view the directories on these drives." what is the difference between "users can browse the directory structure" and "they cannot open folders"? To me, browse a directory structure includes navigating through the folders.