### PR TITLE
changes for Allow Update Compliance Processing policy requirement

### DIFF
--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -18,7 +18,7 @@ ms.topic: article
 # Manually Configuring Devices for Update Compliance
 
 > [!NOTE]
-> As of May 10, 2021, new policy is required to use Update Compliance, referred to as Allow Update Compliance Processing. See more details below. 
+> As of May 10, 2021, a new policy is required to use Update Compliance, referred to as Allow Update Compliance Processing. See more details below. 
 
 There are a number of requirements to consider when manually configuring devices for Update Compliance. These can potentially change with newer versions of Windows 10. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) will be updated when any configuration requirements change so only a redeployment of the script will be required.
 

--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -18,7 +18,7 @@ ms.topic: article
 # Manually Configuring Devices for Update Compliance
 
 > [!NOTE]
-> As of May 10, 2021, a new policy is required to use Update Compliance, referred to as Allow Update Compliance Processing. See more details below. 
+> As of May 10, 2021, a new policy is required to use Update Compliance: "Allow Update Compliance Processing." For more details, see the Mobile Device Management policies and Group policies tables.
 
 There are a number of requirements to consider when manually configuring devices for Update Compliance. These can potentially change with newer versions of Windows 10. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) will be updated when any configuration requirements change so only a redeployment of the script will be required.
 
@@ -55,9 +55,9 @@ Each MDM Policy links to its documentation in the CSP hierarchy, providing its e
 > [!NOTE]
 > If you use Microsoft Intune, set the **ProviderID** to *MS DM Server*. If you use another MDM product, check with its vendor. See also [DMClient CSP](/windows/client-management/mdm/dmclient-csp).
 
-### Group Policies
+### Group policies
 
-All Group Policies that need to be configured for Update Compliance are under **Computer Configuration>Administrative Templates>Windows Components\Data Collection and Preview Builds**. All of these policies must be in the *Enabled* state and set to the defined *Value* below.  
+All Group policies that need to be configured for Update Compliance are under **Computer Configuration>Administrative Templates>Windows Components\Data Collection and Preview Builds**. All of these policies must be in the *Enabled* state and set to the defined *Value* below.  
 
 | Policy | Value | Function |
 |---------------------------|-|-----------------------------------------------------------|

--- a/windows/deployment/update/update-compliance-configuration-manual.md
+++ b/windows/deployment/update/update-compliance-configuration-manual.md
@@ -17,6 +17,9 @@ ms.topic: article
 
 # Manually Configuring Devices for Update Compliance
 
+> [!NOTE]
+> As of May 10, 2021, new policy is required to use Update Compliance, referred to as Allow Update Compliance Processing. See more details below. 
+
 There are a number of requirements to consider when manually configuring devices for Update Compliance. These can potentially change with newer versions of Windows 10. The [Update Compliance Configuration Script](update-compliance-configuration-script.md) will be updated when any configuration requirements change so only a redeployment of the script will be required.
 
 The requirements are separated into different categories:
@@ -47,6 +50,7 @@ Each MDM Policy links to its documentation in the CSP hierarchy, providing its e
 |**System/**[**AllowTelemetry**](/windows/client-management/mdm/policy-csp-system#system-allowtelemetry) | 1- Basic |Configures the maximum allowed diagnostic data to be sent to Microsoft. Individual users can still set this value lower than what the policy defines. For more information, see the following policy. |
 |**System/**[**ConfigureTelemetryOptInSettingsUx**](/windows/client-management/mdm/policy-csp-system#system-configuretelemetryoptinsettingsux) | 1 - Disable Telemetry opt-in Settings | (in Windows 10, version 1803 and later) Determines whether users of the device can adjust diagnostic data to levels lower than the level defined by AllowTelemetry. We recommend that you disable this policy or the effective diagnostic data level on devices might not be sufficient. |
 |**System/**[**AllowDeviceNameInDiagnosticData**](/windows/client-management/mdm/policy-csp-system#system-allowdevicenameindiagnosticdata) | 1 - Allowed | Allows device name to be sent for Windows Diagnostic Data. If this policy is Not Configured or set to 0 (Disabled), Device Name will not be sent and will not be visible in Update Compliance, showing `#` instead. |
+| **System/AllowUpdateComplianceProcessing** | 16 - Allowed | Enables data flow through Update Compliance's data processing system and indicates a device's explicit enrollment to the service. |
 
 > [!NOTE]
 > If you use Microsoft Intune, set the **ProviderID** to *MS DM Server*. If you use another MDM product, check with its vendor. See also [DMClient CSP](/windows/client-management/mdm/dmclient-csp).
@@ -61,6 +65,7 @@ All Group Policies that need to be configured for Update Compliance are under **
 |**Allow Telemetry** | 1 - Basic |Configures the maximum allowed diagnostic data to be sent to Microsoft. Individual users can still set this value lower than what the policy defines. See the following policy for more information. |
 |**Configure telemetry opt-in setting user interface** | 1 - Disable diagnostic data opt-in Settings |(in Windows 10, version 1803 and later) Determines whether users of the device can adjust diagnostic data to levels lower than the level defined by AllowTelemetry. We recommend that you disable this policy, otherwise the effective diagnostic data level on devices might not be sufficient. |
 |**Allow device name to be sent in Windows diagnostic data** | 1 - Enabled | Allows device name to be sent for Windows Diagnostic Data. If this policy is Not Configured or Disabled, Device Name will not be sent and will not be visible in Update Compliance, showing `#` instead. |
+|**Allow Update Compliance processing** | 16 - Enabled | Enables data flow through Update Compliance's data processing system and indicates a device's explicit enrollment to the service. |
 
 ## Required endpoints
 

--- a/windows/deployment/update/update-compliance-configuration-script.md
+++ b/windows/deployment/update/update-compliance-configuration-script.md
@@ -17,91 +17,83 @@ ms.topic: article
 
 # Configuring devices through the Update Compliance Configuration Script
 
-The Update Compliance Configuration Script is the recommended method of configuring devices to send data to Microsoft for use with Update Compliance. The script configures device policies via Group Policy, ensures that required services are running, and more.
-
 > [!NOTE]
-> The Update Compliance configuration script does not offer options to configure Delivery Optimization. You have to do that separately.
+> A new policy is required to use Update Compliance, referred to as AllowUpdateComplianceProcessing. If you are an existing customer and configured your devices prior to May 10, 2021, you must rerun the script so the new policy can be configured. We do not recommend using this script if you configure devices using MDM; instead, configure the policies listed in [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) via your MDM provider. 
 
+The Update Compliance Configuration Script is the recommended method of configuring devices to send data to Microsoft for use with Update Compliance. The script configures device policies via Group Policy, ensures that required services are running, and more.
 
 You can download the script from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=101086). Keep reading to learn how to configure the script and interpret error codes that are output in logs for troubleshooting.
 
-## How the script is organized
+## Script FAQ
 
-The script is organized into two folders **Pilot** and **Deployment**. Both folders have the same key files: `ConfigScript.ps1` and `RunConfig.bat`. You configure `RunConfig.bat` according to the directions in the .bat itself, which will then execute `ConfigScript.ps1` with the parameters entered to RunConfig.bat.
+1. I manage my devices with MDM. Should I use this script?
+    * You should not use this script and instead configure the below policies through your MDM provider. 
+2. Does this script configure devices for Delivery Optimization?
+    * This script does not configure devices for Delivery Optimization. You must do that separately.
 
-- The **Pilot** folder and its contents are intended to be used on an initial set of single devices in specific environments (main office & satellite office, for example) for testing and troubleshooting prior to broader deployment. This script is configured to collect and output detailed logs for every device it runs on.
-- The **Deployment** folder is intended to be deployed across an entire device population in a specific environment once devices in that environment have been validated with the Pilot script.
+## How this script is organized
 
-## How to use the script
+This script's two primary files are `ConfigScript.ps1` and `RunConfig.bat`. You configure `RunConfig.bat` according to the directions in the `.bat` itself, which will then execute `ConfigScript.ps1` with the parameters entered to `RunConfig.bat`. There are two ways of using the script: in **Pilot** mode or **Deployment** mode. 
 
-### Piloting and Troubleshooting
-
-> [!IMPORTANT]
-> If you encounter an issue with Update Compliance, the first step should be to run the script in Pilot mode on a device you are encountering issues with, and save these Logs for reference with Support.
-
-> [!IMPORTANT]
-> The script must be run in the System context. To do this, use the PsExec tool included in the file. For more about PsExec, see [PsExec](/sysinternals/downloads/psexec).
+* In **Pilot** mode (`runMode=Pilot`), the script will enter a verbose mode with enhanced diagnostics, and save the results in the path defined with `logpath` in `RunConfig.bat`. This is intended for a pilot run of the script or for troubleshooting configuration.
+* In **Deployment** mode (`runMode=Deployment`), the script will quietly execute. 
 
 
-When using the script in the context of troubleshooting, use `Pilot`. Enter `RunConfig.bat`, and configure it as follows:
+## How to use this script
 
-1. Configure `logPath` to a path where the script will have write access and a place you can easily access. This specifies the output of the log files generated when the script is in Verbose mode.
-2. Configure `commercialIDValue` to your CommercialID. To get your CommercialID, see [Getting your CommercialID](update-compliance-get-started.md#get-your-commercialid).
-3. Run the script. The script must be run in System context.
-4. Examine the Logs output for any issues. If there were issues:
-   - Compare Logs output with the required settings covered in [Manually Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).
-   - Examine the script errors and refer to the [script error reference](#script-error-reference) on how to interpret the codes.
-   - Make the necessary corrections and run the script again.
-5. When you no longer have issues, proceed to using the script for more broad deployment with the `Deployment` folder.
+Open `RunConfig.bat`, and configure the following (assuming a first-run, with `runMode=Pilot`:
+
+1. Define `logPath` to where you want the logs to be saved. Ensure that `runMode=Pilot`.
+2. Set `commercialIDValue` to your Commercial ID.
+3. Run the script.
+4. Examine the logs for any issues. If there are no issues, then all devices with a similar configuration and network profile are ready for the script to be deployed with `runMode=Deployment`.
+5. If there are issues, gather the logs and provide them to Support.
 
 
-### Broad deployment
+## Script errors
 
-After verifying on a set of devices in a specific environment that everything is configured correctly, you can proceed to broad deployment.
-
-1. Configure `commercialIDValue` in `RunConfig.bat` to [your CommercialID](update-compliance-get-started.md#get-your-commercialid).
-2. Use a management tool like Configuration Manager or Intune to broadly deploy the script to your entire target population.
-
-## Script Error Reference
-
-|Error |Description |
-|-|-------------------|
-| 27 | Not system account. |
-| 37 | Unexpected exception when collecting logs|
-| 1  | General unexpected error|
-| 6  | Invalid CommercialID|
-| 48 | CommercialID is not a GUID|
-| 8  | Couldn't create registry key path to setup CommercialID|
-| 9  | Couldn't write CommercialID at registry key path|
-| 53 | There are conflicting CommercialID values.|
-| 11 | Unexpected result when setting up CommercialID.|
-| 62 | AllowTelemetry registry key is not of the correct type `REG_DWORD`|
-| 63 | AllowTelemetry is not set to the appropriate value and it could not be set by the script.|
-| 64 | AllowTelemetry is not of the correct type `REG_DWORD`.|
-| 99 | Device is not Windows 10.|
-| 40 | Unexpected exception when checking and setting telemetry.|
-| 12 | CheckVortexConnectivity failed, check Log output for more information.|
-| 12 | Unexpected failure when running CheckVortexConnectivity.|
-| 66 | Failed to verify UTC connectivity and recent uploads.| 
-| 67 | Unexpected failure when verifying UTC CSP connectivity of the WMI Bridge.|
-| 41 | Unable to impersonate logged-on user.|
-| 42 | Unexpected exception when attempting to impersonate logged-on user.|
-| 43 | Unexpected exception when attempting to impersonate logged-on user.|
-| 16 | Reboot is pending on device, restart device and restart script.|
-| 17 | Unexpected exception in CheckRebootRequired.|
-| 44 | Error when running CheckDiagTrack service.|
-| 45 | DiagTrack.dll not found.|
-| 50 | DiagTrack service not running.|
-| 54 | Microsoft Account Sign In Assistant (MSA) Service disabled.|
-| 55 | Failed to create new registry path for `SetDeviceNameOptIn` of the PowerShell script.|
-| 56 | Failed to create property for `SetDeviceNameOptIn` of the PowerShell script at registry path.|
-| 57 | Failed to update value for `SetDeviceNameOptIn` of the PowerShell script.|
-| 58 | Unexpected exception in `SetDeviceNameOptIn` of the PowerShell script.|
-| 59 | Failed to delete `LastPersistedEventTimeOrFirstBoot` property at registry path when attempting to clean up OneSettings.|
-| 60 | Failed to delete registry key when attempting to clean up OneSettings.|
-| 61 | Unexpected exception when attempting to clean up OneSettings.|
-| 52 | Could not find Census.exe|
-| 51 | Unexpected exception when attempting to run Census.exe|
-| 34 | Unexpected exception when attempting to check Proxy settings.|
-| 30 | Unable to disable Enterprise Auth Proxy. This registry value must be 0 for UTC to operate in an authenticated proxy environment.|
-| 35 | Unexpected exception when checking User Proxy.|
+|Error  |Description  |
+|---------|---------|
+| 27    | Not system account. |
+| 37    | Unexpected exception when collecting logs| 
+| 1    | General unexpected error| 
+| 6    | Invalid CommercialID| 
+| 48    | CommercialID is not a GUID| 
+| 8    | Couldn't create registry key path to setup CommercialID| 
+| 9    | Couldn't write CommercialID at registry key path| 
+| 53    | There are conflicting CommercialID values.| 
+| 11    | Unexpected result when setting up CommercialID.| 
+| 62    | AllowTelemetry registry key is not of the correct type REG_DWORD| 
+| 63    | AllowTelemetry is not set to the appropraite value and it could not be set by the script.| 
+| 64    | AllowTelemetry is not of the correct type REG_DWORD.| 
+| 99    | Device is not Windows 10.| 
+| 40    | Unexpected exception when checking and setting telemetry.| 
+| 12    | CheckVortexConnectivity failed, check Log output for more information.| 
+| 12    | Unexpected failure when running CheckVortexConnectivity.| 
+| 66    | Failed to verify UTC connectivity and recent uploads.|  
+| 67    | Unexpected failure when verifying UTC CSP.| 
+| 41    | Unable to impersonate logged-on user.| 
+| 42    | Unexpected exception when attempting to impersonate logged-on user.| 
+| 43    | Unexpected exception when attempting to impersonate logged-on user.| 
+| 16    | Reboot is pending on device, restart device and restart script.| 
+| 17    | Unexpected exception in CheckRebootRequired.| 
+| 44    | Error when running CheckDiagTrack service.| 
+| 45    | DiagTrack.dll not found.| 
+| 50    | DiagTrack service not running.| 
+| 54    | Microsoft Account Sign In Assistant (MSA) Service disabled.| 
+| 55    | Failed to create new registry path for SetDeviceNameOptIn| 
+| 56    | Failed to create property for SetDeviceNameOptIn at registry path| 
+| 57    | Failed to update value for SetDeviceNameOptIn| 
+| 58    | Unexpected exception in SetrDeviceNameOptIn| 
+| 59    | Failed to delete LastPersistedEventTimeOrFirstBoot property at registry path when attempting to clean up OneSettings.| 
+| 60    | Failed to delete registry key when attempting to clean up OneSettings.| 
+| 61    | Unexpected exception when attempting to clean up OneSettings.| 
+| 52    | Could not find Census.exe| 
+| 51    | Unexpected exception when attempting to run Census.exe| 
+| 34    | Unexpected exception when attempting to check  Proxy settings.| 
+| 30    | Unable to disable Enterprise Auth Proxy. This registry value must be 0 for UTC to operate in an authenticated proxy environment.| 
+| 35    | Unexpected exception when checking User Proxy.| 
+| 91    | Failed to create new registry path for EnableAllowUCProcessing| 
+| 92    | Failed to create property for EnableAllowUCProcessing at registry path| 
+| 93    | Failed to update value for EnableAllowUCProcessing| 
+| 94    | Unexpected exception in EnableAllowUCProcessing| 

--- a/windows/deployment/update/update-compliance-configuration-script.md
+++ b/windows/deployment/update/update-compliance-configuration-script.md
@@ -18,7 +18,7 @@ ms.topic: article
 # Configuring devices through the Update Compliance Configuration Script
 
 > [!NOTE]
-> A new policy is required to use Update Compliance, referred to as AllowUpdateComplianceProcessing. If you are an existing customer and configured your devices prior to May 10, 2021, you must rerun the script so the new policy can be configured. We do not recommend using this script if you configure devices using MDM; instead, configure the policies listed in [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) via your MDM provider. 
+> A new policy is required to use Update Compliance: "AllowUpdateComplianceProcessing." If you're already using Update Compliance and have configured your devices prior to May 10, 2021, you must rerun the script so the new policy can be configured. We don't recommend using this script if you configure devices using MDM. Instead, configure the policies listed in [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) by using your MDM provider. 
 
 The Update Compliance Configuration Script is the recommended method of configuring devices to send data to Microsoft for use with Update Compliance. The script configures device policies via Group Policy, ensures that required services are running, and more.
 

--- a/windows/deployment/update/update-compliance-configuration-script.md
+++ b/windows/deployment/update/update-compliance-configuration-script.md
@@ -26,22 +26,22 @@ You can download the script from the [Microsoft Download Center](https://www.mic
 
 ## Script FAQ
 
-1. I manage my devices with MDM. Should I use this script?
-    * You should not use this script and instead configure the below policies through your MDM provider. 
-2. Does this script configure devices for Delivery Optimization?
-    * This script does not configure devices for Delivery Optimization. You must do that separately.
+- I manage my devices with MDM. Should I use this script?
+No, you should not use this script. Instead configure the policies through your MDM provider. 
+- Does this script configure devices for Delivery Optimization?
+No. You must do that separately.
 
 ## How this script is organized
 
-This script's two primary files are `ConfigScript.ps1` and `RunConfig.bat`. You configure `RunConfig.bat` according to the directions in the `.bat` itself, which will then execute `ConfigScript.ps1` with the parameters entered to `RunConfig.bat`. There are two ways of using the script: in **Pilot** mode or **Deployment** mode. 
+This script's two primary files are `ConfigScript.ps1` and `RunConfig.bat`. You configure `RunConfig.bat` according to the directions in the `.bat` itself, which will then run `ConfigScript.ps1` with the parameters entered to `RunConfig.bat`. There are two ways of using the script: in **Pilot** mode or **Deployment** mode. 
 
-* In **Pilot** mode (`runMode=Pilot`), the script will enter a verbose mode with enhanced diagnostics, and save the results in the path defined with `logpath` in `RunConfig.bat`. This is intended for a pilot run of the script or for troubleshooting configuration.
-* In **Deployment** mode (`runMode=Deployment`), the script will quietly execute. 
+- In **Pilot** mode (`runMode=Pilot`), the script will enter a verbose mode with enhanced diagnostics, and save the results in the path defined with `logpath` in `RunConfig.bat`. Pilot mode is best for a pilot run of the script or for troubleshooting configuration.
+- In **Deployment** mode (`runMode=Deployment`), the script will run quietly. 
 
 
 ## How to use this script
 
-Open `RunConfig.bat`, and configure the following (assuming a first-run, with `runMode=Pilot`:
+Open `RunConfig.bat` and configure the following (assuming a first-run, with `runMode=Pilot`):
 
 1. Define `logPath` to where you want the logs to be saved. Ensure that `runMode=Pilot`.
 2. Set `commercialIDValue` to your Commercial ID.

--- a/windows/deployment/update/update-compliance-get-started.md
+++ b/windows/deployment/update/update-compliance-get-started.md
@@ -18,7 +18,7 @@ ms.topic: article
 # Get started with Update Compliance
 
 > [!IMPORTANT]
-> **A new policy is required to use Update Compliance, referred to as AllowUpdateComplianceProcessing**. If you are an existing customer and configured your devices prior to May 10, 2021, you must configure devices with this additional policy. You can do this by rerunning the [Update Compliance Configuration Script](update-compliance-configuration-script.md) if you configure your devices through Group Policy, or refer to [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) for details on manually configuring the new policy for both Group Policy and MDM. 
+> **A new policy is required to use Update Compliance: "AllowUpdateComplianceProcessing"**. If you're already using Update Compliance and have configured your devices prior to May 10, 2021, you must configure devices with this additional policy. You can do this by rerunning the [Update Compliance Configuration Script](update-compliance-configuration-script.md) if you configure your devices through Group Policy, or refer to [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) for details on manually configuring the new policy for both Group Policy and MDM. 
 
 This topic introduces the high-level steps required to enroll to the Update Compliance solution and configure devices to send data to it. The following steps cover the enrollment and device configuration workflow.
 
@@ -26,23 +26,23 @@ This topic introduces the high-level steps required to enroll to the Update Comp
 2. [Add Update Compliance](#add-update-compliance-to-your-azure-subscription) to your Azure subscription.
 3. [Configure devices](#enroll-devices-in-update-compliance)  to send data to Update Compliance.
 
-After adding the solution to Azure and configuring devices, there will be a waiting period of up to 72 hours before you can begin to see devices in the solution. Before or as devices appear, you can learn how to [Use Update Compliance](update-compliance-using.md) to monitor Windows Updates and Delivery Optimization.
+After adding the solution to Azure and configuring devices, it could take up to 72 hours before you can begin to see devices in the solution. Before or as devices appear, you can learn how to [Use Update Compliance](update-compliance-using.md) to monitor Windows Updates and Delivery Optimization.
 
 ## Update Compliance prerequisites
 
 Before you begin the process to add Update Compliance to your Azure subscription, first ensure you can meet the prerequisites:
 
-1. **Compatible Operating Systems and Editions**: Update Compliance works only with Windows 10 Professional, Education, and Enterprise editions. Update Compliance supports both the typical Windows 10 Enterprise edition, as well as [Windows 10 Enterprise multi-session](/azure/virtual-desktop/windows-10-multisession-faq). Update Compliance only provides data for the standard Desktop Windows 10 version and is not currently compatible with Windows Server, Surface Hub, IoT, etc.
-2. **Compatible Windows 10 Servicing Channels**: Update Compliance supports Windows 10 devices on the Semi-Annual Channel (SAC) and the Long-term Servicing Channel (LTSC). Update Compliance *counts* Windows Insider Preview (WIP) devices, but does not currently provide detailed deployment insights for them.
-3. **Diagnostic data requirements**: Update Compliance requires devices be configured to send diagnostic data at *Required* level (previously *Basic*). To learn more about what's included in different diagnostic levels, see [Diagnostics, feedback, and privacy in Windows 10](https://support.microsoft.com/help/4468236/diagnostics-feedback-and-privacy-in-windows-10-microsoft-privacy).
-4. **Data transmission requirements**: Devices must be able to contact specific endpoints required to authenticate and send diagnostic data. These are enumerated in detail at [Configuring Devices for Update Compliance manually](update-compliance-configuration-manual.md).
-5. **Showing Device Names in Update Compliance**: For Windows 10 1803+, device names will not appear in Update Compliance unless you individually opt-in devices via policy. The steps to accomplish this is outlined in [Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).
+- **Compatible Operating Systems and Editions**: Update Compliance works only with Windows 10 Professional, Education, and Enterprise editions. Update Compliance supports both the typical Windows 10 Enterprise edition, as well as [Windows 10 Enterprise multi-session](/azure/virtual-desktop/windows-10-multisession-faq). Update Compliance only provides data for the standard Desktop Windows 10 version and is not currently compatible with Windows Server, Surface Hub, IoT, etc.
+- **Compatible Windows 10 Servicing Channels**: Update Compliance supports Windows 10 devices on the Semi-Annual Channel and the Long-term Servicing Channel (LTSC). Update Compliance *counts* Windows Insider Preview (WIP) devices, but does not currently provide detailed deployment insights for them.
+- **Diagnostic data requirements**: Update Compliance requires devices be configured to send diagnostic data at *Required* level (previously *Basic*). To learn more about what's included in different diagnostic levels, see [Diagnostics, feedback, and privacy in Windows 10](https://support.microsoft.com/help/4468236/diagnostics-feedback-and-privacy-in-windows-10-microsoft-privacy).
+- **Data transmission requirements**: Devices must be able to contact specific endpoints required to authenticate and send diagnostic data. These are enumerated in detail at [Configuring Devices for Update Compliance manually](update-compliance-configuration-manual.md).
+- **Showing Device Names in Update Compliance**: For Windows 10, version 1803 or later, device names will not appear in Update Compliance unless you individually opt-in devices by using policy. The steps to accomplish this is outlined in [Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).
 
 ## Add Update Compliance to your Azure subscription
 
 Update Compliance is offered as an Azure Marketplace application which is linked to a new or existing [Azure Log Analytics](/azure/log-analytics/query-language/get-started-analytics-portal) workspace within your Azure subscription. To configure this, follow these steps:
 
-1. Go to the [Update Compliance page in the Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/Microsoft.WaaSUpdateInsights?tab=Overview). You may need to login to your Azure subscription to access this.
+1. Go to the [Update Compliance page in the Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/Microsoft.WaaSUpdateInsights?tab=Overview). You might need to login to your Azure subscription to access this.
 2. Select **Get it now**.
 3. Choose an existing or configure a new Log Analytics Workspace, ensuring it is in a **Compatible Log Analytics region** from the following table. Although an Azure subscription is required, you won't be charged for ingestion of Update Compliance data.
    - [Desktop Analytics](/sccm/desktop-analytics/overview) users should use the same workspace for Update Compliance.
@@ -84,7 +84,7 @@ Update Compliance is offered as an Azure Marketplace application which is linked
 
 ### Get your CommercialID
 
-A CommercialID is a globally-unique identifier assigned to a specific Log Analytics workspace. The CommercialID is copied to an MDM or Group Policy and is used to identify devices in your environment.
+A CommercialID is a globally unique identifier assigned to a specific Log Analytics workspace. The CommercialID is copied to an MDM or Group Policy and is used to identify devices in your environment.
 
 To find your CommercialID within Azure:
 
@@ -99,10 +99,10 @@ To find your CommercialID within Azure:
 
 Once you've added Update Compliance to a workspace in your Azure subscription, you'll need to configure any devices you want to monitor. There are two ways to configure devices to use Update Compliance:
 
-1. Customers who use Group Policy to manage device policies should use the [Update Compliance Configuration Script](update-compliance-configuration-script.md).
-2. Customers who manage devices through MDM providers like Intune should be [Manually Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).
+- If you use Group Policy to manage device policies, use the [Update Compliance Configuration Script](update-compliance-configuration-script.md).
+- If you manage devices through MDM providers like Intune, [manually configure device for Update Compliance](update-compliance-configuration-manual.md).
 
-After you configure devices, diagnostic data they send will begin to be associated with your tenant. However, enrolling to Update Compliance does not influence the rate at which required data is uploaded from clients. Device connectivity to the internet and generally how "active" the device is highly influences how long it will take before the device appears in Update Compliance. Devices that are active and connected to the internet daily can expect to be fully uploaded within one week (usually less than 72 hours). Devices that are less active can take up to two weeks before data is fully available. 
+After you configure devices, diagnostic data they send will begin to be associated with your Azure AD organization ("tenant"). However, enrolling to Update Compliance doesn't influence the rate at which required data is uploaded from devices. Device connectivity to the internet and generally how active the device is highly influences how long it will take before the device appears in Update Compliance. Devices that are active and connected to the internet daily can expect to be fully uploaded within one week (usually less than 72 hours). Devices that are less active can take up to two weeks before data is fully available. 
 
 ### Update Compliance and Desktop Analytics
 

--- a/windows/deployment/update/update-compliance-get-started.md
+++ b/windows/deployment/update/update-compliance-get-started.md
@@ -17,6 +17,9 @@ ms.topic: article
 
 # Get started with Update Compliance
 
+> [!IMPORTANT]
+> **A new policy is required to use Update Compliance, referred to as AllowUpdateComplianceProcessing**. If you are an existing customer and configured your devices prior to May 10, 2021, you must configure devices with this additional policy. You can do this by rerunning the [Update Compliance Configuration Script](update-compliance-configuration-script.md) if you configure your devices through Group Policy, or refer to [Manually configuring devices for Update Compliance](update-compliance-configuration-manual.md) for details on manually configuring the new policy for both Group Policy and MDM. 
+
 This topic introduces the high-level steps required to enroll to the Update Compliance solution and configure devices to send data to it. The following steps cover the enrollment and device configuration workflow.
 
 1. Ensure you can [meet the requirements](#update-compliance-prerequisites) to use Update Compliance.
@@ -94,20 +97,16 @@ To find your CommercialID within Azure:
 
 ## Enroll devices in Update Compliance
 
-Once you've added Update Compliance to a workspace in your Azure subscription, you'll need to configure any devices you want to monitor. There are two ways to configure devices to use Update Compliance. After you configure devices, it can take up to 72 hours before devices are visible in the solution. Until then, Update Compliance will indicate it is still assessing devices.
+Once you've added Update Compliance to a workspace in your Azure subscription, you'll need to configure any devices you want to monitor. There are two ways to configure devices to use Update Compliance:
 
-> [!NOTE]
-> If you use or plan to use [Desktop Analytics](/mem/configmgr/desktop-analytics/overview), follow the steps in [Enroll devices in Desktop Analytics](/mem/configmgr/desktop-analytics/enroll-devices) to also enroll devices in Update Compliance. You should be aware that the Commercial ID and Log Analytics workspace must be the same for both Desktop Analytics and Update Compliance.
+1. Customers who use Group Policy to manage device policies should use the [Update Compliance Configuration Script](update-compliance-configuration-script.md).
+2. Customers who manage devices through MDM providers like Intune should be [Manually Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).
 
-### Configure devices using the Update Compliance Configuration Script
+After you configure devices, diagnostic data they send will begin to be associated with your tenant. However, enrolling to Update Compliance does not influence the rate at which required data is uploaded from clients. Device connectivity to the internet and generally how "active" the device is highly influences how long it will take before the device appears in Update Compliance. Devices that are active and connected to the internet daily can expect to be fully uploaded within one week (usually less than 72 hours). Devices that are less active can take up to two weeks before data is fully available. 
 
-The recommended way to configure devices to send data to Update Compliance is using the [Update Compliance Configuration Script](update-compliance-configuration-script.md). The script configures required policies via Group Policy. The script comes with two versions:
+### Update Compliance and Desktop Analytics
 
-- Pilot is more verbose and is intended to be use on an initial set of devices and for troubleshooting.
-- Deployment is intended to be deployed across the entire device population you want to monitor with Update Compliance.  
+If you use or plan to use [Desktop Analytics](/mem/configmgr/desktop-analytics/overview), you must use the same Log Analytics workspace for both solutions. 
 
-To download the script and learn what you need to configure and how to troubleshoot errors, see [Configuring Devices using the Update Compliance Configuration Script](update-compliance-configuration-script.md).
 
-### Configure devices manually
 
-It is possible to manually configure devices to send data to Update Compliance, but the recommended method of configuration is to use the [Update Compliance Configuration Script](update-compliance-configuration-script.md). To learn more about configuring devices manually, see [Manually Configuring Devices for Update Compliance](update-compliance-configuration-manual.md).


### PR DESCRIPTION
This is a set of changes to the documentation to announce a new policy that must be configured for devices using Update Compliance, the AllowUpdateComplianceProcessing policy. 

Additionally:

- Directed Intune/MDM customers to not use the configuration script. Config script uses GP, Intune customers should be using MDM. 
- Provided more info on how long it takes devices to enroll to Update Compliance, that it varies based on device activity. 