### PR TITLE
"Disable WDAC Policies": Cleanup formatting

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/disable-windows-defender-application-control-policies.md
+++ b/windows/security/threat-protection/windows-defender-application-control/disable-windows-defender-application-control-policies.md
@@ -32,7 +32,6 @@ This topic covers how to disable unsigned or signed WDAC policies.
 There may come a time when an administrator wants to disable a WDAC policy. For unsigned WDAC policies, this process is simple. The method used to deploy the policy (such as Group Policy) must first be disabled, then simply delete the SIPolicy.p7b policy file from the following locations, and the WDAC policy will be disabled on the next computer restart:
 
 -   &lt;EFI System Partition&gt;\\Microsoft\\Boot\\
-
 -   &lt;OS Volume&gt;\\Windows\\System32\\CodeIntegrity\\
 
 Note that as of the Windows 10 May 2019 Update (1903), WDAC allows multiple policies to be deployed to a device. To fully disable WDAC when multiple policies are in effect, you must first disable each method being used to deploy a policy. Then delete the {Policy GUID}.cip policy files found in the \CIPolicies\Active subfolder under each of the paths listed above in addition to any SIPolicy.p7b file found in the root directory.
@@ -43,21 +42,22 @@ Signed policies protect Windows from administrative manipulation as well as malw
 
 > [!NOTE]
 > For reference, signed WDAC policies should be replaced and removed from the following locations:
-
--   &lt;EFI System Partition&gt;\\Microsoft\\Boot\\
-
--   &lt;OS Volume&gt;\\Windows\\System32\\CodeIntegrity\\
+> 
+> * &lt;EFI System Partition&gt;\\Microsoft\\Boot\\
+> * &lt;OS Volume&gt;\\Windows\\System32\\CodeIntegrity\\
 
 
 1.  Replace the existing policy with another signed policy that has the **6 Enabled: Unsigned System Integrity Policy** rule option enabled.
 
-    > **Note**&nbsp;&nbsp;To take effect, this policy must be signed with a certificate previously added to the **UpdatePolicySigners** section of the original signed policy you want to replace.
+    > [!NOTE]
+    > To take effect, this policy must be signed with a certificate previously added to the **UpdatePolicySigners** section of the original signed policy you want to replace.
 
 2.  Restart the client computer.
 
 3.  Verify that the new signed policy exists on the client.
 
-    > **Note**&nbsp;&nbsp;If the signed policy that contains rule option 6 has not been processed on the client, the addition of an unsigned policy may cause boot failures.
+    > [!NOTE]
+    > If the signed policy that contains rule option 6 has not been processed on the client, the addition of an unsigned policy may cause boot failures.
 
 4.  Delete the new policy.
 
@@ -67,13 +67,15 @@ If the signed WDAC policy has been deployed using by using Group Policy, you mus
 
 1.  Replace the existing policy in the GPO with another signed policy that has the **6 Enabled: Unsigned System Integrity Policy** rule option enabled.
 
-    > **Note**&nbsp;&nbsp;To take effect, this policy must be signed with a certificate previously added to the **UpdatePolicySigners** section of the original signed policy you want to replace.
+    > [!NOTE]  
+    > To take effect, this policy must be signed with a certificate previously added to the **UpdatePolicySigners** section of the original signed policy you want to replace.
 
 2.  Restart the client computer.
 
 3.  Verify that the new signed policy exists on the client.
 
-    > **Note**&nbsp;&nbsp;If the signed policy that contains rule option 6 has not been processed on the client, the addition of an unsigned policy may cause boot failures.
+    > [!NOTE]
+    > If the signed policy that contains rule option 6 has not been processed on the client, the addition of an unsigned policy may cause boot failures.
 
 4.  Set the GPO to disabled.
 
@@ -86,5 +88,4 @@ If the signed WDAC policy has been deployed using by using Group Policy, you mus
 There may be a time when signed WDAC policies cause a boot failure. Because WDAC policies enforce kernel mode drivers, it is important that they be thoroughly tested on each software and hardware configuration before being enforced and signed. Signed WDAC policies are validated in the pre-boot sequence by using Secure Boot. When you disable the Secure Boot feature in the BIOS, and then delete the file from the following locations on the operating system disk, it allows the system to boot into Windows:
 
 -   &lt;EFI System Partition&gt;\\Microsoft\\Boot\\
-
 -   &lt;OS Volume&gt;\\Windows\\System32\\CodeIntegrity\\


### PR DESCRIPTION
This PR performs a few list/callout-related changes to the article ["Disable Windows Defender Application Control Policies"](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/disable-windows-defender-application-control-policies):  
* Move list of WDAC policy locations into "Note" callout referencing them
* Replace boldface "Note"  with DFM `[!NOTE]` tags