### PR TITLE
Update Event 4627 Page

### DIFF
--- a/windows/security/threat-protection/auditing/event-4627.md
+++ b/windows/security/threat-protection/auditing/event-4627.md
@@ -21,7 +21,7 @@ ms.technology: mde
 -   Windows Server 2016
 
 
-<img src="images/event-4627.png" alt="Event 4627 illustration" width="438" height="709" hspace="10" align="left" />
+<img src="images/event-4627.png" alt="Event 4627 illustration" width="554" height="896" hspace="10" align="left" />
 
 ***Subcategory:***&nbsp;[Audit Group Membership](audit-group-membership.md)
 

--- a/windows/security/threat-protection/auditing/event-4627.md
+++ b/windows/security/threat-protection/auditing/event-4627.md
@@ -21,7 +21,7 @@ ms.technology: mde
 -   Windows Server 2016
 
 
-<img src="images/event-4627.png" alt="Event 4627 illustration" width="876" height="1418" hspace="10" align="left" />
+<img src="images/event-4627.png" alt="Event 4627 illustration" width="438" height="709" hspace="10" align="left" />
 
 ***Subcategory:***&nbsp;[Audit Group Membership](audit-group-membership.md)
 


### PR DESCRIPTION
It's difficult to read text to the right of the event screenshot as the screenshot is so wide, this change shrinks the screenshot while maintaining the aspect ratio making the text to its right much easier to read.  It also makes this page more consistent with other event id pages.