### PR TITLE
fixed invalid MDM Federated enrollment example code

### DIFF
--- a/windows/client-management/mdm/federated-authentication-device-enrollment.md
+++ b/windows/client-management/mdm/federated-authentication-device-enrollment.md
@@ -119,6 +119,7 @@ The following example shows the discovery service request.
           </request>
         </Discover>
       </s:Body>
+    </s:Envelope>
 ```
 
 The discovery response is in the XML format and includes the following fields:


### PR DESCRIPTION
The example is missing a closing s:Envelope tag hence is currently invalid XML. This PR adds the closing tag to make it valid.