### PR TITLE
Use proper capitalization for PowerShell cmdlets

### DIFF
--- a/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
+++ b/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
@@ -18,13 +18,13 @@ To configure assigned access (kiosk mode), you need the Application User Model I
 To get the names and AUMIDs for all apps installed for the current user, open a Windows PowerShell command prompt and enter the following command:
 
 ```powershell
-get-StartApps
+Get-StartApps
 ```
 
 To get the names and AUMIDs for Windows Store apps installed for another user, open a Windows PowerShell command prompt and enter the following commands:
 
 ```powershell
-$installedapps = get-AppxPackage
+$installedapps = Get-AppxPackage
 
 $aumidList = @()
 foreach ($app in $installedapps)
@@ -75,12 +75,12 @@ function listAumids( $userAccount ) {
     elseif ($userAccount)
     {
         # Find installed packages for the specified account. Must be run as an administrator in order to use this option.
-        $installedapps = get-AppxPackage -user $userAccount
+        $installedapps = Get-AppxPackage -user $userAccount
     }
     else
     {
         # Find installed packages for the current account.
-        $installedapps = get-AppxPackage
+        $installedapps = Get-AppxPackage
     }
 
     $aumidList = @()


### PR DESCRIPTION
The title says it. PowerShell code style dictates PascalCase for cmdlets, so let's honor that.