### PR TITLE
Make Domain Admins well-known SID consistent with others

### DIFF
--- a/windows/security/identity-protection/access-control/active-directory-security-groups.md
+++ b/windows/security/identity-protection/access-control/active-directory-security-groups.md
@@ -1489,7 +1489,7 @@ This security group has not changed since Windows Server 2008.
 <tbody>
 <tr class="odd">
 <td><p>Well-Known SID/RID</p></td>
-<td><p>S-1-5-&lt;domain&gt;-512</p></td>
+<td><p>S-1-5-21-&lt;domain&gt;-512</p></td>
 </tr>
 <tr class="even">
 <td><p>Type</p></td>


### PR DESCRIPTION
It was missing the "-21-" part which all other similar well-known have.
For example, see just below: "Domain Computers" -> "S-1-5-21-<domain>-515