### PR TITLE
Update vpnv2-csp.md to include DNS suffix length information

### DIFF
--- a/windows/client-management/mdm/vpnv2-csp.md
+++ b/windows/client-management/mdm/vpnv2-csp.md
@@ -591,7 +591,7 @@ Valid values:
 - True = Register the connection's addresses in DNS.
 
 <a href="" id="vpnv2-profilename-dnssuffix"></a>**VPNv2/**<em>ProfileName</em>**/DnsSuffix**  
-Optional. Specifies one or more comma-separated DNS suffixes. The first in the list is also used as the primary connection specific DNS suffix for the VPN Interface. The entire list will also be added into the SuffixSearchList.
+Optional. Specifies one or more comma-separated DNS suffixes. The first in the list is also used as the primary connection specific DNS suffix for the VPN Interface. The entire list will also be added into the SuffixSearchList. Windows has a limit of 50 DNS suffixes that can be set. Windows name resolution will apply each suffix in order. Long DNS suffix lists may impact performance.
 
 Value type is chr. Supported operations include Get, Add, Replace, and Delete.
 

--- a/windows/client-management/mdm/vpnv2-csp.md
+++ b/windows/client-management/mdm/vpnv2-csp.md
@@ -9,7 +9,7 @@ ms.topic: article
 ms.prod: w10
 ms.technology: windows
 author: manikadhiman
-ms.date: 10/30/2020
+ms.date: 09/21/2021
 ---
 
 # VPNv2 CSP


### PR DESCRIPTION
From customer feedback -- IT admins should not use lots of DNS suffixes. Not only is there a limit to how many you can have, but each one makes name resolution slower.