### PR TITLE
Azure AD temporary access pass

### DIFF
--- a/windows/whats-new/whats-new-windows-10-version-1809.md
+++ b/windows/whats-new/whats-new-windows-10-version-1809.md
@@ -247,7 +247,7 @@ Do you have shared devices deployed in your work place? **Fast sign-in** enables
 >[!IMPORTANT]
 >This is a private preview feature and therefore not meant or recommended for production purposes.
 
-Until now, Windows logon only supported the use of identities federated to ADFS or other providers that support the WS-Fed protocol. We are introducing **web sign-in**, a new way of signing into your Windows PC. Web sign-in enables Windows logon support for credentials not available on Windows (for example, Azure AD temporary access pass). Going forward, web sign-in will be restricted to only support Azure AD temporary access pass. 
+Until now, Windows logon only supported the use of identities federated to ADFS or other providers that support the WS-Fed protocol. We are introducing **web sign-in**, a new way of signing into your Windows PC. Web sign-in enables Windows logon support for credentials not available on Windows and it´s restricted to only support Azure AD temporary access pass.
 
 **To try out web sign-in:**
 1. Azure AD Join your Windows 10 PC. (Web sign-in is only supported on Azure AD Joined PCs).

--- a/windows/whats-new/whats-new-windows-10-version-1809.md
+++ b/windows/whats-new/whats-new-windows-10-version-1809.md
@@ -7,7 +7,7 @@ ms.prod: w10
 ms.mktglfcycl: deploy
 ms.sitesec: library
 author: greg-lindsay
-manager: laurawi
+manager: dougeby
 ms.author: greglin
 ms.localizationpriority: high
 ms.topic: article
@@ -247,7 +247,7 @@ Do you have shared devices deployed in your work place? **Fast sign-in** enables
 >[!IMPORTANT]
 >This is a private preview feature and therefore not meant or recommended for production purposes.
 
-Until now, Windows logon only supported the use of identities federated to ADFS or other providers that support the WS-Fed protocol. We are introducing **web sign-in**, a new way of signing into your Windows PC. Web sign-in enables Windows logon support for credentials not available on Windows and it´s restricted to only support Azure AD temporary access pass.
+Until now, Windows logon only supported the use of identities federated to ADFS or other providers that support the WS-Fed protocol. We are introducing **web sign-in**, a new way of signing into your Windows PC. Web sign-in enables Windows logon support for credentials not available on Windows. Web sign-in is restricted to only support Azure AD temporary access pass.
 
 **To try out web sign-in:**
 1. Azure AD Join your Windows 10 PC. (Web sign-in is only supported on Azure AD Joined PCs).


### PR DESCRIPTION
Based on feedback from customer in a case, the web sign-in is already restricted to Azure AD temporary access pass. 
Otherwise you receive an error: AADSTS130506: Access Pass must be used for Web Sign In. Contact your admin to get an Access Pass.