### PR TITLE
Update security-identifiers.md

### DIFF
--- a/windows/security/identity-protection/access-control/security-identifiers.md
+++ b/windows/security/identity-protection/access-control/security-identifiers.md
@@ -166,7 +166,7 @@ The following table lists the universal well-known SIDs.
 | S-1-5 | NT Authority | A SID that represents an identifier authority. |
 | S-1-5-80-0 | All Services | A group that includes all service processes configured on the system. Membership is controlled by the operating system.|
 
-The following table lists the predefined identifier authority constants. The first four values are used with universal well-known SIDs, and the rest values are used with well-known SIDs in Windows operating systems designated in the **Applies To** list.
+The following table lists the predefined identifier authority constants. The first four values are used with universal well-known SIDs, and the rest of the values are used with well-known SIDs in Windows operating systems designated in the **Applies To** list.
 
 | Identifier Authority | Value | SID String Prefix |
 | - | - | - |

--- a/windows/security/identity-protection/access-control/security-identifiers.md
+++ b/windows/security/identity-protection/access-control/security-identifiers.md
@@ -166,7 +166,7 @@ The following table lists the universal well-known SIDs.
 | S-1-5 | NT Authority | A SID that represents an identifier authority. |
 | S-1-5-80-0 | All Services | A group that includes all service processes configured on the system. Membership is controlled by the operating system.|
 
-The following table lists the predefined identifier authority constants. The first four values are used with universal well-known SIDs, and the last value is used with well-known SIDs in Windows operating systems designated in the **Applies To** list.
+The following table lists the predefined identifier authority constants. The first four values are used with universal well-known SIDs, and the rest values are used with well-known SIDs in Windows operating systems designated in the **Applies To** list.
 
 | Identifier Authority | Value | SID String Prefix |
 | - | - | - |
@@ -174,6 +174,8 @@ The following table lists the predefined identifier authority constants. The fir
 | SECURITY_WORLD_SID_AUTHORITY | 1 | S-1-1 |
 | SECURITY_LOCAL_SID_AUTHORITY | 2 | S-1-2 |
 | SECURITY_CREATOR_SID_AUTHORITY | 3 | S-1-3 |
+| SECURITY_NT_AUTHORITY | 5 | S-1-5 |
+| SECURITY_AUTHENTICATION_AUTHORITY | 18 | S-1-18 |
 
 The following RID values are used with universal well-known SIDs. The Identifier authority column shows the prefix of the identifier authority with which you can combine the RID to create a universal well-known SID.
 
@@ -256,14 +258,6 @@ The SECURITY\_NT\_AUTHORITY (S-1-5) predefined identifier authority produces SID
 | S-1-5-80 | NT Service | A SID that is used as an NT Service account prefix.|
 | S-1-5-80-0 | All Services| A group that includes all service processes that are configured on the system. Membership is controlled by the operating system. SID S-1-5-80-0 equals NT SERVICES\ALL SERVICES. This SID was introduced in Windows Server 2008 R2.|
 | S-1-5-83-0| NT VIRTUAL MACHINE\Virtual Machines| A built-in group. The group is created when the Hyper-V role is installed. Membership in the group is maintained by the Hyper-V Management Service (VMMS). This group requires the **Create Symbolic Links** right (SeCreateSymbolicLinkPrivilege), and also the **Log on as a Service** right (SeServiceLogonRight). |
-| S-1-16-0| Untrusted Mandatory Level| A SID that represents an untrusted integrity level.|
-| S-1-16-4096 | Low Mandatory Level| A SID that represents a low integrity level.|
-| S-1-16-8192 | Medium Mandatory Level| This SID represents a medium integrity level.|
-| S-1-16-8448 | Medium Plus Mandatory Level| A SID that represents a medium plus integrity level.|
-| S-1-16-12288 | High Mandatory Level| A SID that represents a high integrity level.|
-| S-1-16-16384 | System Mandatory Level| A SID that represents a system integrity level.|
-| S-1-16-20480 | Protected Process Mandatory Level| A SID that represents a protected-process integrity level.|
-| S-1-16-28672 | Secure Process Mandatory Level| A SID that represents a secure process integrity level.|
 
 The following RIDs are relative to each domain.
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/windows-itpro-docs/issues/10111
added two rows to Identifier Authority table, removed S-1-16 entries from the list of well-known SIDs
source:
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/81d92bba-d22b-4a8c-908a-554ab29148ab
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c6ce4275-3d90-4890-ab3a-514745e4637e