### PR TITLE
Removing groups option from Windows 10 version 2004

### DIFF
--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -9,7 +9,7 @@ ms.pagetype: devices
 author: dansimp
 ms.localizationpriority: medium
 ms.author: dansimp
-ms.date: 01/14/2022
+ms.date: 01/18/2022
 ms.reviewer: 
 manager: dansimp
 ms.topic: article

--- a/windows/client-management/connect-to-remote-aadj-pc.md
+++ b/windows/client-management/connect-to-remote-aadj-pc.md
@@ -66,7 +66,7 @@ Ensure [Remote Credential Guard](/windows/access-protection/remote-credential-gu
 
       - Adding users using policy
      
-         Starting in Windows 10, version 2004, you can add users or Azure AD groups to the Remote Desktop Users using MDM policies as described in [How to manage the local administrators group on Azure AD joined devices](/azure/active-directory/devices/assign-local-admin#manage-administrator-privileges-using-azure-ad-groups-preview).
+         Starting in Windows 10, version 2004, you can add users to the Remote Desktop Users using MDM policies as described in [How to manage the local administrators group on Azure AD joined devices](/azure/active-directory/devices/assign-local-admin#manage-administrator-privileges-using-azure-ad-groups-preview).
 
          > [!TIP]
          > When you connect to the remote PC, enter your account name in this format: AzureAD\yourloginid@domain.com.


### PR DESCRIPTION
After working the case and talking to PG, Ravi Vennapusa, confirmed we cant add groups to Remote Desktop Users. Only users can be added as mentioned in the linked in this section article. Also submitting change request to this branch, since not able to access Review one, getting 404 error.