### PR TITLE
Update TouchKeyboardEmojiButtonAvailability description

### DIFF
--- a/windows/client-management/mdm/policy-csp-textinput.md
+++ b/windows/client-management/mdm/policy-csp-textinput.md
@@ -1084,15 +1084,15 @@ The following list shows the supported values:
 
 <!--/Scope-->
 <!--Description-->
-Specifies whether the emoji button is enabled or disabled for the touch keyboard. When this policy is set to disabled, the emoji button on touch keyboard is disabled.
+Specifies whether the emoji, GIF (only in Windows 11), and kaomoji (only in Windows 11) buttons are available or unavailable for the touch keyboard. When this policy is set to disabled, the buttons are hidden and unavailable.
 
 <!--/Description-->
 <!--SupportedValues-->
 The following list shows the supported values:
 
--   0 (default) - The OS determines when it's most appropriate to be available.
--   1 - Emoji button on keyboard is always available.
--   2 - Emoji button on keyboard is always disabled.
+- 0 (default) - The OS determines when buttons are most appropriate to be available.
+- 1 - Emoji, GIF, and Kaomoji buttons on the touch keyboard are always available.
+- 2 - Emoji, GIF, and Kaomoji buttons on the touch keyboard are always unavailable.
 
 <!--/SupportedValues-->
 <!--/Policy-->

--- a/windows/client-management/mdm/policy-csp-textinput.md
+++ b/windows/client-management/mdm/policy-csp-textinput.md
@@ -7,7 +7,7 @@ ms.prod: w10
 ms.technology: windows
 author: dansimp
 ms.localizationpriority: medium
-ms.date: 09/27/2019
+ms.date: 03/03/2022
 ms.reviewer: 
 manager: dansimp
 ---


### PR DESCRIPTION
This pull request updates the description of TouchKeyboardEmojiButtonAvailability policy for Windows 11.

The policy specifies whether the emoji button on the touhc keyboard is shown or hidden. In Windows 11, the touch keyboard replaced the emoji button with the expressive input button, which opens the expressive input panel. The policy now controls the visibility of emoji, GIF, and kaomoji buttons inside the expressive input panel on the touch keyboard.