### PR TITLE
Complexity requirements reduce password strength

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements.md
+++ b/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements.md
@@ -62,11 +62,11 @@ Additional settings that can be included in a custom Passfilt.dll are the use of
 > [!TIP]
 > For the latest best practices, see [Password Guidance](https://www.microsoft.com/research/publication/password-guidance).
 
-Set **Passwords must meet complexity requirements** to Enabled. This policy setting, combined with a minimum password length of 8, ensures that there are at least 218,340,105,584,896 different possibilities for a single password. This setting makes a brute force attack difficult, but still not impossible.
+Set **Passwords must meet complexity requirements** to Enabled. This policy setting, combined with a minimum password length of 8, ensures that there are at least 159,238,157,238,528 different possibilities for a single password. This setting makes a brute force attack difficult, but still not impossible.
 
 The use of ALT key character combinations may greatly enhance the complexity of a password. However, requiring all users in an organization to adhere to such stringent password requirements might result in unhappy users and an over-worked Help Desk. Consider implementing a requirement in your organization to use ALT characters in the range from 0128 through 0159 as part of all administrator passwords. (ALT characters outside of that range can represent standard alphanumeric characters that do not add more complexity to the password.)
 
-Passwords that contain only alphanumeric characters are easy to compromise by using publicly available tools. To prevent this, passwords should contain additional characters and meet complexity requirements.
+Short passwords that contain only alphanumeric characters are easy to compromise by using publicly available tools. To prevent this, passwords should contain additional characters and/or meet complexity requirements.
 
 ### Location
 


### PR DESCRIPTION
Long passwords with only alphanumeric characters are not easy to compromise. Short passwords are easy to compromise. Adding length is more important than adding complexity.

The article provides a number 218,340,105,584,896 different possibilities for a single password. That number is clearly based on the calculation (26 + 26 + 10)^8 = 218,340,105,584,896 on the basis the 8 characters may be any of 26 uppercase letters, 26 lowercase and 10 digits.

However, turning on complexity requirements will ensure that there are at least 3 categories of character, and eliminate some of those possibilities. It will eliminate cases where there were no digits, cases where there are no uppercase letters, and cases where there are no lowercase letters.

|specification|possibilities|
|---|---|
|eight characters of any uppercase, lowercase *or* digits|218,340,105,584,896|
| | ... minus ... |
|eight characters of uppercase or lowercase with no digits|53,459,728,531,456|
| | ... minus ... |
|eight characters of lowercase or digits with no uppercase|2,821,109,907,456|
| | ... minus ... |
|eight characters of uppercase or digits with no lowercase|2,821,109,907,456|
| | ... equals ... |
|eight characters of uppercase, lowercase *and* digits|159,238,157,238,528|

Rather than enforcing complexity, administrators are better off increasing the minimum length. A minimum length of 11 instead of 8 would be sufficient to add so many more possibilities that even if users only used lowercase letters, there are more possibilities of 11 lowercase letters than there are of 8 complex characters:

8 complex characters = 62^8 = 218,340,105,584,896 possibilities

11 lowercase letters = 26^11 = 3,670,344,486,987,776 possibilities