### PR TITLE
Update win32-and-centennial-app-policy-configuration.md

### DIFF
--- a/windows/client-management/mdm/win32-and-centennial-app-policy-configuration.md
+++ b/windows/client-management/mdm/win32-and-centennial-app-policy-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Win32 and Desktop Bridge app ADMX policy Ingestion
-description: Starting in Windows 10, version 1703, you can ingest ADMX files and set those ADMX policies for Win32 and Desktop Bridge apps.
+description: Starting in Windows 10, version 1904, you can ingest ADMX files and set those ADMX policies for Win32 and Desktop Bridge apps.
 ms.author: dansimp
 ms.topic: article
 ms.prod: w10
@@ -25,7 +25,7 @@ manager: dansimp
 
 ## <a href="" id="overview"></a>Overview
 
-Starting in Windows 10, version 1703, you can ingest ADMX files (ADMX ingestion) and set those ADMX policies for Win32 and Desktop Bridge apps by using Windows 10 Mobile Device Management (MDM) on desktop SKUs. The ADMX files that define policy information can be ingested to your device by using the Policy CSP URI, `./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXInstall`. The ingested ADMX file is then processed into MDM policies. 
+Starting in Windows 10, version 1703, you can ingest ADMX files (ADMX ingestion) and set those ADMX policies for Win32 and Desktop Bridge apps by using Windows 10 Mobile Device Management (MDM) on desktop SKUs. The ADMX files that define policy information can be ingested to your device by using the Policy CSP URI, `./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXUnInstall`. The ingested ADMX file is then processed into MDM policies. 
 
 NOTE: Starting from the following Windows 10 version Replace command is supported
 - Windows 10, version 1903 with KB4512941 and KB4517211 installed 


### PR DESCRIPTION
#disabling-an-app-policy
`./Device/Vendor/MSFT/Policy/ConfigOperations/ADMXUnInstall`
<SyncML xmlns="SYNCML:SYNCML1.1">
  <SyncBody>
    <Replace>
      <CmdID>104</CmdID>
      <Item>
        <Meta>
          <Format>chr</Format>
          <Type>text/plain</Type>
        </Meta>
        <Target>
          <LocURI>./Device/Vendor/MSFT/Policy/Config/ContosoCompanyApp~ Policy~ParentCategoryArea~Category1/L_PolicyConfigurationMode</LocURI>
        </Target>
        <Data><![CDATA[<disabled/>]]></Data>
      </Item>
    </Replace>
    <Final/>
  </SyncBody>
</SyncML>