### PR TITLE
Remove private preview URL from MCC Enterprise Docs

### DIFF
--- a/windows/deployment/do/mcc-enterprise.md
+++ b/windows/deployment/do/mcc-enterprise.md
@@ -120,11 +120,7 @@ For information about creating or locating your subscription ID, see [Steps to o
 
 ### Create the MCC resource in Azure
 
-The MCC Azure management portal is used to create and manage MCC nodes. An Azure Subscription ID is used to grant access to the preview and to create the MCC resource in Azure and Cache nodes.
-
-#### Use the following link and sign in to Azure
-
-<https://portal.azure.com/?microsoft_azure_marketplace_ItemHideKey=Microsoft_ConnectedCache_EntHidden>
+The MCC Azure management portal is used to create and manage MCC nodes. An Azure Subscription ID is used to grant access to the preview and to create the MCC resource in Azure and Cache nodes. Please email the MCC team ([msconnectedcache@microsoft.com](mailto:msconnectedcache@microsoft.com)) your Azure subscription id to get access to the preview, we will send you a link to the Azure portal which will allow you to create the resource below. 
 
 1.  On the Azure Portal home page, choose **Create a resource**:  
     ![eMCC img02](images/emcc02.png)


### PR DESCRIPTION
Anyone with this link will be able to create an MCC resource in the Azure portal. This should be removed from public docs ASAP.