### PR TITLE
Fix incorrect EFI mount code

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
+++ b/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
@@ -85,8 +85,8 @@ In addition to the steps outlined above, the binary policy file must also be cop
 1. Mount the EFI volume and make the directory, if it does not exist, in an elevated PowerShell prompt: 
 
     ```powershell
-   $MountPoint = 'C:\EFI'
-   $EFIDestinationFolder = "$MountPoint\Microsoft\Boot\CiPolicies\Active"
+   $MountPoint = 'C:\EFIMount'
+   $EFIDestinationFolder = "$MountPoint\EFI\Microsoft\Boot\CiPolicies\Active"
    $EFIPartition = (Get-Partition | Where-Object IsSystem).AccessPaths[0]
    mountvol $MountPoint $EFIPartition
    mkdir $EFIDestinationFolder


### PR DESCRIPTION
The $EFIDestinationFolder needs a top-level \EFI folder in the path, which was not present in that line.  To avoid potential confusion by having a C:\EFI\EFI\... structure in $MountPoint, I also changed $MountPoint from C:\EFI to C:\EFIMount for clarity.