### PR TITLE
Add GitHub PR Template to encourage linking issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!-- 
+Fill out the information below to help us review this pull request. 
+You can delete these comments once you are done.
+-->
+
+# Description
+
+<!-- 
+If your changes are extensive, you can provide a brief description here and list more detailed changes below.
+-->
+
+## Changes
+
+<!--
+- Briefly describe or list **what** this PR changes.
+- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
+-->
+
+## Why
+
+<!--
+- Briefly describe **why** you made this PR.
+- If this PR relates to an issue, provide the issue number or link.
+- If this PR closes an issue, use a keyword (`Closes #123`).
+  - Using a keyword will ensure the issue is automatically closed once this PR is merged.
+  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+-->
+
+Closes #[Issue Number]
+
+<!--
+Thanks for contributing to Microsoft docs content!
+
+Here are some resources that might be helpful while contributing:
+- [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/)
+- [Docs Markdown reference](https://docs.microsoft.com/contribute/markdown-reference)
+- [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/)
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,18 +2,12 @@
 Fill out the information below to help us review this pull request. 
 You can delete these comments once you are done.
 -->
-
-# Description
-
 <!-- 
-If your changes are extensive, you can provide a brief description here and list more detailed changes below.
--->
+## Description
 
-## Changes
-
-<!--
-- Briefly describe or list **what** this PR changes.
-- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
+If your changes are extensive:
+- Uncomment this heading and provide a brief description here.
+- List more detailed changes below under the changes heading.
 -->
 
 ## Why
@@ -26,7 +20,14 @@ If your changes are extensive, you can provide a brief description here and list
   - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 -->
 
-Closes #[Issue Number]
+- Closes #[Issue Number]
+
+## Changes
+
+<!--
+- Briefly describe or list **what** this PR changes.
+- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
+-->
 
 <!--
 Thanks for contributing to Microsoft docs content!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- 
-Fill out the information below to help us review this pull request. 
+Fill out the following information to help us review this pull request. 
 You can delete these comments once you are done.
 -->
 <!-- 
@@ -13,10 +13,10 @@ If your changes are extensive:
 ## Why
 
 <!--
-- Briefly describe **why** you made this PR.
-- If this PR relates to an issue, provide the issue number or link.
-- If this PR closes an issue, use a keyword (`Closes #123`).
-  - Using a keyword will ensure the issue is automatically closed once this PR is merged.
+- Briefly describe _why_ you made this pull request.
+- If this pull request relates to an issue, provide the issue number or link.
+- If this pull request closes an issue, use a keyword (`Closes #123`).
+  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
   - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 -->
 
@@ -25,7 +25,7 @@ If your changes are extensive:
 ## Changes
 
 <!--
-- Briefly describe or list **what** this PR changes.
+- Briefly describe or list _what_ this PR changes.
 - Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
 -->
 


### PR DESCRIPTION
<!-- 
Fill out the information below to help us review this pull request. 
You can delete these comments once you are done.
-->
## Why

I thought it would possibly help to provide more structure to PR descriptions. As outlined in #10584, I have noticed that sometimes PRs are opened and merged without the issue they address being closed. My main goal with adding a template like this is to encourage PR authors to use keywords like `closes` so that the issue they are fixing is automatically closed.
 
This is a suggestion that I would be happy to have merged into this repo. Edits from maintainers are allowed, so feel free to modify it right here, but if Microsoft reviewers want to write their own from scratch feel free to close this.

- Closes #10584

## Changes

This PR adds a GitHub Pull Request template.

I took inspiration from a few other templates while creating this:
- https://github.com/MicrosoftDocs/Contribute/blob/main/.github/PULL_REQUEST_TEMPLATE.md
- https://github.com/github/docs/blob/main/.github/PULL_REQUEST_TEMPLATE.md

