### PR TITLE
#9812

### DIFF
--- a/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
+++ b/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
@@ -98,7 +98,7 @@ sections:
       - question: |
           Is there a size limit to the domain lists that I need to configure?
         answer: |
-          Yes, both the Enterprise Resource domains that are hosted in the cloud and the domains that are categorized as both work and personal have a 1,6383 Bytes limit.
+          Yes, both the Enterprise Resource domains that are hosted in the cloud and the domains that are categorized as both work and personal have a 1,6383 bytes limit.
 
       - question: |
           Why does my encryption driver break Microsoft Defender Application Guard?

--- a/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
+++ b/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
@@ -9,7 +9,6 @@ metadata:
   ms.localizationpriority: medium
   author: denisebmsft
   ms.author: deniseb
-  ms.date: 03/14/2022
   ms.reviewer:
   manager: dansimp
   ms.custom: asr

--- a/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
+++ b/windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard.yml
@@ -98,7 +98,7 @@ sections:
       - question: |
           Is there a size limit to the domain lists that I need to configure?
         answer: |
-          Yes, both the Enterprise Resource domains that are hosted in the cloud and the domains that are categorized as both work and personal have a 16383-B limit.
+          Yes, both the Enterprise Resource domains that are hosted in the cloud and the domains that are categorized as both work and personal have a 1,6383 Bytes limit.
 
       - question: |
           Why does my encryption driver break Microsoft Defender Application Guard?


### PR DESCRIPTION
#9812 Bytes should be the correct abbreviation because it can never be bits.