### PR TITLE
#10456

### DIFF
--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -112,7 +112,7 @@ An array of folders, each representing a location on the host machine that will 
 
 ### Logon command
 
-Specifies a single command that will be invoked automatically after the sandbox logs on. Apps in the sandbox are run under the container user account.
+Specifies a single command that will be invoked automatically after the sandbox logs on. Apps in the sandbox are run under the container user account. The container user account should be an Administrator.
 
 ```xml
 <LogonCommand>

--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -112,7 +112,7 @@ An array of folders, each representing a location on the host machine that will 
 
 ### Logon command
 
-Specifies a single command that will be invoked automatically after the sandbox logs on. Apps in the sandbox are run under the container user account. The container user account should be an Administrator.
+Specifies a single command that will be invoked automatically after the sandbox logs on. Apps in the sandbox are run under the container user account. The container user account should be an administrator account.
 
 ```xml
 <LogonCommand>


### PR DESCRIPTION
fixes #10456 
it wants to clarify the level of the logon command account, and assumed it must be an Administrator, so I added this info.