### PR TITLE
schedulequickscantime does not rely on scanparameter

### DIFF
--- a/windows/client-management/mdm/policy-csp-defender.md
+++ b/windows/client-management/mdm/policy-csp-defender.md
@@ -1922,10 +1922,7 @@ The following list shows the supported values:
 > [!NOTE]
 > This policy is only enforced in Windows 10 for desktop.
  
-Selects the time of day that the Windows Defender quick scan should run.
-
-> [!NOTE]
-> The scan type will depends on what scan type is selected in the **Defender/ScanParameter** setting.
+Selects the time of day that the Windows Defender quick scan should run. The Windows Defender quick scan runs daily, if a time is specified.
 
  
 

--- a/windows/client-management/mdm/policy-csp-defender.md
+++ b/windows/client-management/mdm/policy-csp-defender.md
@@ -1922,7 +1922,7 @@ The following list shows the supported values:
 > [!NOTE]
 > This policy is only enforced in Windows 10 for desktop.
  
-Selects the time of day that the Windows Defender quick scan should run. The Windows Defender quick scan runs daily, if a time is specified.
+Selects the time of day that the Windows Defender quick scan should run. The Windows Defender quick scan runs daily if a time is specified.
 
  
 


### PR DESCRIPTION
Edited to reflect that schedulequickscantime does not rely on scanparameter, as it's about setting the time for a daily quick scan. I added a remark to reiterate the fact that this enables a daily quick scan on the specified time.