### PR TITLE
Update mcc-enterprise.md

### DIFF
--- a/windows/deployment/do/mcc-enterprise.md
+++ b/windows/deployment/do/mcc-enterprise.md
@@ -351,7 +351,7 @@ If the test fails, see the common issues section for more information.
 
 ### Intune (or other management software) configuration for MCC
 
-Example of setting the cache host policy to the MCC’s IP address / FQDN:
+For an Intune deployment, create a Configuration Profile and include the Cache Host eFlow IP Address or FQDN:
 
 ![eMCC img23](images/emcc23.png)
 


### PR DESCRIPTION
Clarification for Intune Configuration setting.  Current doc doesn't indicate to the user that they're required to point the profile to the EFLOW machine and NOT the Windows Server.