### PR TITLE
Update minimum-password-length.md

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/minimum-password-length.md
+++ b/windows/security/threat-protection/security-policy-settings/minimum-password-length.md
@@ -36,7 +36,7 @@ The **Minimum password length** policy setting determines the least number of ch
 
 ### Best practices
 
-Set Minimum password length to at least a value of 14. If the number of characters is set to 0, no password is required. In most environments, an eight-character password is recommended because it's long enough to provide adequate security and still short enough for users to easily remember. A minimum password length greater than 14 isn't supported at this time. This value will help provide adequate defense against a brute force attack. Adding complexity requirements will help reduce the possibility of a dictionary attack. For more info, see [Password must meet complexity requirements](password-must-meet-complexity-requirements.md).
+Set minimum password length to at least a value of 8. If the number of characters is set to 0, no password is required. In most environments, an eight-character password is recommended because it's long enough to provide adequate security and still short enough for users to easily remember. A minimum password length greater than 14 isn't supported at this time. This value will help provide adequate defense against a brute force attack. Adding complexity requirements will help reduce the possibility of a dictionary attack. For more info, see [Password must meet complexity requirements](password-must-meet-complexity-requirements.md).
 
 Permitting short passwords reduces security because short passwords can be easily broken with tools that do dictionary or brute force attacks against the passwords. Requiring long passwords can result in mistyped passwords that might cause account lockouts and might increase the volume of Help Desk calls.
 


### PR DESCRIPTION
Issue: #10390 

Two changes:
• In the Best Practice section:
1. Changed the capitalization from "Set Minimum..." => "Set minimum..."
2. In the first line it says "**Set minimum password length to at least a value of 14**", but on the next line it says "**In most environments, an eight-character password is recommended because it's long enough...**"; a little bit contradictory with each other.  So I changed the minimum password length to 8. 
Also, as of Aug 2022, this is suggested in the **guidelines of NIST SP 800-62 Paragraph 5.1.1.2.**

Ref: https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-63b.pdf (Page: 23, Section: 5.1.1.2)