### PR TITLE
Add clearer guidance around registering devices

### DIFF
--- a/windows/deployment/windows-autopatch/deploy/windows-autopatch-register-devices.md
+++ b/windows/deployment/windows-autopatch/deploy/windows-autopatch-register-devices.md
@@ -117,8 +117,8 @@ Since existing Windows 365 Cloud PCs already have an existing Azure AD device ID
 **To register devices with Windows Autopatch:**
 
 1. Go to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com/).
-2. Select **Windows Autopatch** from the left navigation menu.
-3. Select **Devices**.
+2. Select **Devices** from the left navigation menu.
+3. Under the **Windows Autopatch** section, select **Devices**.
 4. Select either the **Ready** or the **Not ready** tab, then select the **Windows Autopatch Device Registration** hyperlink. The Azure Active Directory group blade opens.
 5. Add either devices through direct membership, or other Azure AD dynamic or assigned groups as nested groups in the **Windows Autopatch Device Registration** group.
 


### PR DESCRIPTION
The existing steps to add devices is not aligned with the proper steps to take in the portal