### PR TITLE
Update policy-csp-admx-windowsstore.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-admx-windowsstore.md
+++ b/windows/client-management/mdm/policy-csp-admx-windowsstore.md
@@ -206,7 +206,7 @@ ADMX Info:
 |Edition|Windows 10|Windows 11|
 |--- |--- |--- |
 |Home|No|No|
-|Pro|Yes|Yes|
+|Pro|No|No|
 |Windows SE|No|Yes|
 |Business|Yes|Yes|
 |Enterprise|Yes|Yes|
@@ -256,7 +256,7 @@ ADMX Info:
 |Edition|Windows 10|Windows 11|
 |--- |--- |--- |
 |Home|No|No|
-|Pro|Yes|Yes|
+|Pro|No|No|
 |Windows SE|No|Yes|
 |Business|Yes|Yes|
 |Enterprise|Yes|Yes|


### PR DESCRIPTION

## Why

Current document is incorrect.

## Changes

RemoveWindowsStore registry key which is set by this CSP (and by the equivalent GPO) does not work on Win 10 Pro SKU (1809 and later) or Win 11 Pro SKU (any release). Tested multiple times, Pro device allows the user to download and install apps but as soon as you uplift the device to Enterprise SKU and restart, the store becomes blocked.

Old article referring to 1809 and 1903 here: https://docs.microsoft.com/en-us/troubleshoot/windows-client/group-policy/cannot-disable-microsoft-store

<!--
Thanks for contributing to Microsoft docs content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/)
- [Docs Markdown reference](https://docs.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/)
-->