### PR TITLE
Update troubleshoot-tcpip-rpc-errors.md

### DIFF
--- a/windows/client-management/troubleshoot-tcpip-rpc-errors.md
+++ b/windows/client-management/troubleshoot-tcpip-rpc-errors.md
@@ -120,17 +120,17 @@ Portqry.exe -n 169.254.0.2 -e 135
 ```
 Partial output below:
  
-> Querying target system called:
-> 169.254.0.2
-> Attempting to resolve IP address to a name...
-> IP address resolved to RPCServer.contoso.com
-> querying...
-> TCP port 135 (epmap service): LISTENING
-> Using ephemeral source port
-> Querying Endpoint Mapper Database...
-> Server's response:
-> UUID: d95afe70-a6d5-4259-822e-2c84da1ddb0d
-> ncacn_ip_tcp:169.254.0.10<strong>[49664]</strong>
+> Querying target system called:  
+> 169.254.0.2  
+> Attempting to resolve IP address to a name...  
+> IP address resolved to RPCServer.contoso.com  
+> querying...  
+> TCP port 135 (epmap service): LISTENING  
+> Using ephemeral source port  
+> Querying Endpoint Mapper Database...  
+> Server's response:  
+> UUID: d95afe70-a6d5-4259-822e-2c84da1ddb0d  
+> ncacn_ip_tcp:169.254.0.2<strong>[49664]</strong>
 
  
 The one in bold is the ephemeral port number that you made a connection to successfully. 


### PR DESCRIPTION
Update to format of PortQry output; correction to target IP in PortQry output (target system is 169.254.0.2, not 169.254.0.10)

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
