### PR TITLE
[WDAC] Ensure that destination folders are present (script deployment method)

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
+++ b/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
@@ -88,8 +88,9 @@ In addition to the steps outlined above, the binary policy file must also be cop
    $MountPoint = 'C:\EFIMount'
    $EFIDestinationFolder = "$MountPoint\EFI\Microsoft\Boot\CiPolicies\Active"
    $EFIPartition = (Get-Partition | Where-Object IsSystem).AccessPaths[0]
+   if (-Not (Test-Path $MountPoint)) { New-Item -Path $MountPoint -Type Directory -Force }
    mountvol $MountPoint $EFIPartition
-   mkdir $EFIDestinationFolder
+   if (-Not (Test-Path $EFIDestinationFolder)) { New-Item -Path $EFIDestinationFolder -Type Directory -Force }
     ```
 
 2. Copy the signed policy to the created folder:


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

As reported by @wdormann on Twitter (https://twitter.com/wdormann/status/1575527526998241289), the current snippet of code is not functional if the EFI mount point doesn't already exist.

This PR add a test that will check if the EFI mount point, and the destination folder for the policy, are both valid paths.

---
#### Document Details

⚠ *Do not edit this section. It is required for learn.microsoft.com ➟ GitHub issue linking.*

* ID: abfc58da-2ac1-e8b7-b4e7-8f61e7f103ab
* Version Independent ID: 2dfd2a31-cf0d-8a11-94da-842792f892d1
* Content: [Deploy Windows Defender Application Control (WDAC) policies using script (Windows) - Windows security](https://learn.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script)
* Content Source: [windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md)
* Product: **m365-security**
* Technology: **windows-sec**
* GitHub Login: @jsuther1974
* Microsoft Alias: **jogeurte**
