### PR TITLE
Clarify EFI partition instructions to indicate that they only apply to signed WDAC policies

### DIFF
--- a/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
+++ b/windows/security/threat-protection/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
@@ -80,7 +80,7 @@ This topic describes how to deploy Windows Defender Application Control (WDAC) p
 
 ## Deploying signed policies
 
-In addition to the steps outlined above, the binary policy file must also be copied to the device's EFI partition. Deploying your policy via [Microsoft Endpoint Manager](/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune) or the Application Control CSP will handle this step automatically. 
+If you are using [signed WDAC policies](windows/security/threat-protection/windows-defender-application-control/use-signed-policies-to-protect-windows-defender-application-control-against-tampering), the policies must be deployed into your device's EFI partition in addition to the steps outlined above. Unsigned WDAC policies do not need to be present in the EFI partition. Deploying your policy via [Microsoft Endpoint Manager](/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune) or the Application Control CSP will handle this step automatically. 
 
 1. Mount the EFI volume and make the directory, if it does not exist, in an elevated PowerShell prompt: 
 


### PR DESCRIPTION

<!-- 
The current documentation for "Deploy WDAC policies using script" is sort of misleading with respect to the EFI guidance.  It is ONLY for signed WDAC policies, and it should be clearer about this.
-->
<!-- 