### PR TITLE
Add helpful PowerShell example Get-AppAUMID

### DIFF
--- a/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
+++ b/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
@@ -109,3 +109,40 @@ listAumids("CustomerAccount")
 # Get a list of AUMIDs for all accounts on the device:
 listAumids("allusers")
 ```
+
+## Example
+The following code sample creates a function in Windows PowerShell that returns the AUMID of any application currently listed in the Start Menu
+
+```powershell
+function Get-AppAUMID {
+param (
+[string]$AppName
+)
+$Apps = (New-Object -Com Shell.Application).NameSpace('shell:::{4234d49b-0245-4df3-b780-3893943456e1}').Items()
+if ($AppName){
+    $Result = $Apps | Where-Object { $_.name -like "*$AppName*" } | Select-Object name,@{n="AUMID";e={$_.path}}
+        if ($Result){
+            Return $Result
+        }
+    else {"Unable to locate {0}" -f $AppName}
+}
+else {
+    $Result = $Apps | Select-Object name,@{n="AUMID";e={$_.path}}
+    Return $Result
+}
+}
+```
+
+The following Windows PowerShell commands demonstrate how you can call the Get-AppAUMID function after you've created it.
+
+```powershell
+# Get the AUMID for OneDrive
+Get-AppAUMID -AppName OneDrive
+
+# Get the AUMID for Microsoft Word
+Get-AppAUMID -AppName Word
+
+# List all apps and their AUMID in the Start Menu
+Get-AppAUMID
+```
+

--- a/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
+++ b/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
@@ -111,7 +111,8 @@ listAumids("allusers")
 ```
 
 ## Example
-The following code sample creates a function in Windows PowerShell that returns the AUMID of any application currently listed in the Start Menu
+
+The following code sample creates a function in Windows PowerShell that returns the AUMID of any application currently listed in the Start menu.
 
 ```powershell
 function Get-AppAUMID {

--- a/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
+++ b/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
@@ -118,7 +118,7 @@ function Get-AppAUMID {
 param (
 [string]$AppName
 )
-$Apps = (New-Object -Com Shell.Application).NameSpace('shell:::{4234d49b-0245-4df3-b780-3893943456e1}').Items()
+$Apps = (New-Object -ComObject Shell.Application).NameSpace('shell:::{4234d49b-0245-4df3-b780-3893943456e1}').Items()
 if ($AppName){
     $Result = $Apps | Where-Object { $_.name -like "*$AppName*" } | Select-Object name,@{n="AUMID";e={$_.path}}
         if ($Result){

--- a/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
+++ b/windows/configuration/find-the-application-user-model-id-of-an-installed-app.md
@@ -143,7 +143,7 @@ Get-AppAUMID -AppName OneDrive
 # Get the AUMID for Microsoft Word
 Get-AppAUMID -AppName Word
 
-# List all apps and their AUMID in the Start Menu
+# List all apps and their AUMID in the Start menu
 Get-AppAUMID
 ```
 


### PR DESCRIPTION
## Description
Added the PowerShell example Get-AppAUMID. This is very helpful when customizing the start menu layout and needing to add non UWP apps. 

## Why
To help other ITPros by enriching the documentation with real world examples that I use in my day to day work. 

## Changes

This PR adds the PowerShell function "Get-AppAUMID" and examples for using it. 
