### PR TITLE
Edit "Enable HVCI using Intune" section

### DIFF
--- a/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
+++ b/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
@@ -50,7 +50,7 @@ HVCI is labeled **Memory integrity** in the Windows Security app and it can be a
 
 ### Enable HVCI using Intune
 
-Enabling in Intune requires using the Code Integrity node in the [AppLocker CSP](/windows/client-management/mdm/applocker-csp).
+Enabling HVCI via Intune requires configuring the [Policy CSP - VirtualizationBasedTechnology](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology).
 
 ### Enable HVCI using Group Policy
 


### PR DESCRIPTION
## Description
It changes the Intune configuration section of this article from pointing to Applocker CSP to point to Policy CSP - Virtualization Based Technology.

## Why

Whilst reading through documentation and trying to find the location to configure HVCI in Intune I came across this article and also the Policy CSP one. I think the reference to VirtualizationBasedTechnology I am making is more accurate than the Applocker CSP.


## Changes

From this:
"Enabling in Intune requires using the Code Integrity node in the [AppLocker CSP](https://learn.microsoft.com/en-us/windows/client-management/mdm/applocker-csp)."

To this:
"Enabling HVCI via Intune requires configuring the [Policy CSP - VirtualizationBasedTechnology](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology)."

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
