### PR TITLE
Update enable-virtualization-based-protection-of-code-integrity.md

### DIFF
--- a/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
+++ b/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
@@ -52,7 +52,7 @@ HVCI is labeled **Memory integrity** in the Windows Security app and it can be a
 
 ### Enable HVCI using Intune
 
-Enabling in Intune requires using the Code Integrity node in the [VirtualizationBasedTechnology CSP](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology). You can configure the settings on Windows by using [Settings Catalog](https://learn.microsoft.com/en-us/mem/intune/configuration/settings-catalog).
+Enabling in Intune requires using the Code Integrity node in the [VirtualizationBasedTechnology CSP](/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology). You can configure the settings in Windows by using the [settings catalog](/mem/intune/configuration/settings-catalog).
 
 ### Enable HVCI using Group Policy
 

--- a/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
+++ b/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity.md
@@ -52,7 +52,7 @@ HVCI is labeled **Memory integrity** in the Windows Security app and it can be a
 
 ### Enable HVCI using Intune
 
-Enabling in Intune requires using the Code Integrity node in the [AppLocker CSP](https://docs.microsoft.com/windows/client-management/mdm/applocker-csp).
+Enabling in Intune requires using the Code Integrity node in the [VirtualizationBasedTechnology CSP](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology). You can configure the settings on Windows by using [Settings Catalog](https://learn.microsoft.com/en-us/mem/intune/configuration/settings-catalog).
 
 ### Enable HVCI using Group Policy
 


### PR DESCRIPTION
Updated section: Enable HVCI using Intune
Enabling in Intune requires using the Code Integrity node in the AppLocker CSP. This points a reader to AppLocker CSP, while instead it should be Virtualization based technology CSP: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-virtualizationbasedtechnology. Also, settings can be configured via Settings Catalog so added that reference too. Please verify with Feature PM.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
