### PR TITLE
Fix acronym in audit-directory-service-access.md

### DIFF
--- a/windows/security/threat-protection/auditing/audit-directory-service-access.md
+++ b/windows/security/threat-protection/auditing/audit-directory-service-access.md
@@ -1,6 +1,6 @@
 ---
 title: Audit Directory Service Access (Windows 10)
-description: The policy setting Audit Directory Service Access determines if audit events are generated when an Active Directory Domain Services (ADA DS) object is accessed.
+description: The policy setting Audit Directory Service Access determines if audit events are generated when an Active Directory Domain Services (AD DS) object is accessed.
 ms.assetid: ba2562ba-4282-4588-b87c-a3fcb771c7d0
 ms.reviewer: 
 manager: aaroncz


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->

## Why
AD**A** DS is not a commonly-used acronym for Active Directory Domain Services - the correct acronym (used elsewhere in Microsoft documentation) is AD DS.
<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

## Changes
* `audit-directory-service-access.md`: ADA DS ➡️ AD DS
<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
