### PR TITLE
Updating all ScheduledInstall* policies to be more explicit

### DIFF
--- a/windows/client-management/mdm/policy-csp-update.md
+++ b/windows/client-management/mdm/policy-csp-update.md
@@ -2988,6 +2988,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the day of the update installation.
 
 Supported data type is an integer.
@@ -3049,6 +3052,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the update installation on every week.
 
 Supported Value type is integer.
@@ -3100,6 +3106,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the update installation on the first week of the month.
 
 Supported value type is integer.
@@ -3151,6 +3160,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the update installation on the fourth week of the month.
 
 Supported value type is integer.
@@ -3202,9 +3214,12 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the update installation on the second week of the month.
 
-Supported vlue type is integer.
+Supported value type is integer.
 
 Supported values:
 
@@ -3254,6 +3269,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the update installation on the third week of the month.
 
 Supported value type is integer.
@@ -3305,6 +3323,9 @@ The table below shows the applicability of Windows:
 
 <!--/Scope-->
 <!--Description-->
+> [!NOTE]
+> This policy will only take effect if <a href="#update-allowautoupdate">Update/AllowAutoUpdate</a> has been configured to option 3 or 4 for scheduled installation.
+
 Enables the IT admin to schedule the time of the update installation. Note that there is a window of approximately 30 minutes to allow for higher success rates of installation.
 
 The supported data type is an integer.


### PR DESCRIPTION
There has been some confusion in the past around why the following policies were not being honored on a device. This update explicitly adds a note to each policy that the AllowAutoUpdate policy must first be configured for scheduled installation before they have any effect.
* ScheduledInstallDay
* ScheduledInstallEveryWeek
* ScheduledInstallFirstWeek
* ScheduledInstallFourthWeek
* ScheduledInstallSecondWeek
* ScheduledInstallThirdWeek
* ScheduledInstallTime

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
