### PR TITLE
Update usmt-scanstate-syntax.md

### DIFF
--- a/windows/deployment/usmt/usmt-scanstate-syntax.md
+++ b/windows/deployment/usmt/usmt-scanstate-syntax.md
@@ -203,6 +203,7 @@ The following table indicates which command-line options aren't compatible with 
 |**/encrypt**|Required*|X|X||
 |**/keyfile**|N/A||X||
 |**/l**|||||
+|**/listfiles**|||X||
 |**/progress**|||X||
 |**/r**|||X||
 |**/w**|||X||


### PR DESCRIPTION
Updated /listfiles: as an incompatible switch to be used with genconfig.

fixes https://github.com/MicrosoftDocs/windows-itpro-docs/issues/10576
