### PR TITLE
Doc updates to Firewall CSP

### DIFF
--- a/windows/client-management/mdm/firewall-csp.md
+++ b/windows/client-management/mdm/firewall-csp.md
@@ -52,6 +52,11 @@ Firewall
 ------------DisableStealthMode
 ------------Shielded
 ------------DisableUnicastResponsesToMulticastBroadcast
+------------EnableLogDroppedPackets
+------------EnableLogSuccessConnections
+------------EnableLogIgnoredRules
+------------LogMaxFileSize
+------------LogFilePath
 ------------DisableInboundNotifications
 ------------AuthAppsAllowUserPrefMerge
 ------------GlobalPortsAllowUserPrefMerge
@@ -65,6 +70,11 @@ Firewall
 ------------DisableStealthMode
 ------------Shielded
 ------------DisableUnicastResponsesToMulticastBroadcast
+------------EnableLogDroppedPackets
+------------EnableLogSuccessConnections
+------------EnableLogIgnoredRules
+------------LogMaxFileSize
+------------LogFilePath
 ------------DisableInboundNotifications
 ------------AuthAppsAllowUserPrefMerge
 ------------GlobalPortsAllowUserPrefMerge
@@ -78,6 +88,11 @@ Firewall
 ------------DisableStealthMode
 ------------Shielded
 ------------DisableUnicastResponsesToMulticastBroadcast
+------------EnableLogDroppedPackets
+------------EnableLogSuccessConnections
+------------EnableLogIgnoredRules
+------------LogMaxFileSize
+------------LogFilePath
 ------------DisableInboundNotifications
 ------------AuthAppsAllowUserPrefMerge
 ------------GlobalPortsAllowUserPrefMerge
@@ -223,6 +238,25 @@ Boolean value. If it's true, unicast responses to multicast broadcast traffic ar
 Default value is false.
 Value type is bool. Supported operations are Add, Get and Replace.
 
+<a href="" id="enablelogdroppedpackets"></a>**/EnableLogDroppedPackets**
+Boolean value. If this value is true, firewall will log all dropped packets. The merge law for this option is to let "on" values win.
+Default value is false. Supported operations are Get and Replace.
+
+<a href="" id="enablelogsuccessconnections"></a>**/EnableLogSuccessConnections**
+Boolean value. If this value is true, firewall will log all successful inbound connections. The merge law for this option is to let "on" values win.
+Default value is false. Supported operations are Get and Replace.
+
+<a href="" id="enablelogignoredrules"></a>**/EnableLogIgnoredRules**
+Boolean value. If this value is true, firewall will log ignored firewall rules. The merge law for this option is to let "on" values win.
+Default value is false. Supported operations are Get and Replace.
+
+<a href="" id="logmaxfilesize"></a>**/LogMaxFileSize**
+Integer value that specifies the size, in kilobytes, of the log file where dropped packets, successful connections and ignored rules are logged. The merge law for this option is to let the value of the GroupPolicyRSoPStore win if it is configured, otherwise the MdmStore value wins if it is configured, otherwise the local store value is used.
+Default value is 1024. Supported operations are Get and Replace
+
+<a href="" id="logfilepath"></a>**/LogFilePath**
+String value that represents the file path to the log where firewall logs dropped packets, successful connections and ignored rules. The merge law for this option is to let the value of the GroupPolicyRSoPStore win if it is configured, otherwise the MdmStore value wins if it is configured, otherwise the local store value is used. Default value is "%systemroot%\system32\LogFiles\Firewall\pfirewall.log". Supported operations are Get and Replace
+
 <a href="" id="disableinboundnotifications"></a>**/DisableInboundNotifications**
 Boolean value. If this value is false, the firewall MAY display a notification to the user when an application is blocked from listening on a port.  If this value is on, the firewall MUST NOT display such a notification. The merge law for this option is to let the value of the GroupPolicyRSoPStore win if it's configured; otherwise, the local store value is used.
 Default value is false.
@@ -349,7 +383,7 @@ Value type is string. Supported operations are Add, Get, Replace, and Delete.
 
 
 <a href="" id="icmptypesandcodes"></a>**FirewallRules/_FirewallRuleName_/IcmpTypesAndCodes**
-ICMP types and codes applicable to the firewall rule. To specify all ICMP types and codes, use the “\*” character. For specific ICMP types and codes, use the “:” character to separate the type and code, for example, 3:4, 1:\*. The “\*” character can be used to represent any code. The “\*” character cannot be used to specify any type; examples such as “\*:4” or “\*:\*” are invalid.
+Comma separated list of ICMP types and codes applicable to the firewall rule. To specify all ICMP types and codes, use the “\*” character. For specific ICMP types and codes, use the “:” character to separate the type and code, for example, 3:4, 1:\*. The “\*” character can be used to represent any code. The “\*” character cannot be used to specify any type; examples such as “\*:4” or “\*:\*” are invalid.
 If not specified, the default is All.
 Value type is string. Supported operations are Add, Get, Replace, and Delete.
 
@@ -431,6 +465,7 @@ Comma separated list of interface types. Valid values:
 - RemoteAccess
 - Wireless
 - Lan
+- MBB (i.e. Mobile Broadband)
 
 If not specified, the default is All.
 Value type is string. Supported operations are Get and Replace.


### PR DESCRIPTION
Summary of changes:

Add documentation for firewall logging settings, for each of DomainProfile, PrivateProfile, PublicProfile. The settings are:
- EnableLogDroppedPackets
- EnableLogSuccessConnections
- EnableLogIgnoredRules
- LogMaxFileSize
- LogFilePath

Update documentation for FirewallRules/FirewallRuleName/IcmpTypesAndCodes to mention a comma separated list of values can be specified

Update documentation for FirewallRules/FirewallRuleName/InterfaceTypes to add MBB (Mobile Broadband) to allowed values