### PR TITLE
Clarify use of Device Credentials for Azure Virtual Desktop

### DIFF
--- a/windows/client-management/enroll-a-windows-10-device-automatically-using-group-policy.md
+++ b/windows/client-management/enroll-a-windows-10-device-automatically-using-group-policy.md
@@ -125,7 +125,7 @@ Requirements:
 
     > [!NOTE]
     > In Windows 10, version 1903, the MDM.admx file was updated to include an option to select which credential is used to enroll the device. **Device Credential** is a new option that will only have an effect on clients that have installed Windows 10, version 1903 or later. The default behavior for older releases is to revert to **User Credential**.
-    > **Device Credential** is only supported for Microsoft Intune enrollment in scenarios with Co-management or Azure Virtual Desktop because the Intune subscription is user centric.
+    > **Device Credential** is only supported for Microsoft Intune enrollment in scenarios with Co-management or [Azure Virtual Desktop multi-session host pools](/mem/intune/fundamentals/azure-virtual-desktop-multi-session) because the Intune subscription is user centric. User credentials are supported for [Azure Virtual Desktop personal host pools](/mem/intune/fundamentals/azure-virtual-desktop).
 
     When a group policy refresh occurs on the client, a task is created and scheduled to run every 5 minutes for the duration of one day. The task is called "Schedule created by enrollment client for automatically enrolling in MDM from Azure Active Directory."
 


### PR DESCRIPTION
The NOTE section regarding User vs Device credentials and its reference to Azure Virtual Desktop support is misleading.  Updated the note with a link to specify that Device Credential is only supported for MULTI-SESSION host pools, with a link for reference, and User Credential is still supported for personal host pools.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
Description

While reviewing documentation about InTune + AVD integrations, this docs page is a little misleading in that it does not clearly state the supported scenarios of User vs Device credentials when enrolling Azure Virtual Desktop machines into InTune.  Its dependent upon the pool type which is what this PR is meant to provide clarity around with links/reference to the appropriate pages.

## Why

To ensure clarity of when User credentials can be used vs when device credentials must be used when enrolling different Azure Virtual Desktop host pool machines into InTune.

- Closes #[Issue Number]

## Changes

Adds simple changes to the statement around use of Device credentials for Azure Virtual desktop mutli-session pools and use of User credentials for personal host pools.

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
