### PR TITLE
Add missing info about RequirePrivateStoreOnly

### DIFF
--- a/windows/client-management/mdm/policies-in-policy-csp-supported-by-hololens2.md
+++ b/windows/client-management/mdm/policies-in-policy-csp-supported-by-hololens2.md
@@ -18,6 +18,7 @@ ms.date: 08/01/2022
 - [ApplicationManagement/AllowAllTrustedApps](policy-csp-applicationmanagement.md#applicationmanagement-allowalltrustedapps)
 - [ApplicationManagement/AllowAppStoreAutoUpdate](policy-csp-applicationmanagement.md#applicationmanagement-allowappstoreautoupdate)
 - [ApplicationManagement/AllowDeveloperUnlock](policy-csp-applicationmanagement.md#applicationmanagement-allowdeveloperunlock)
+- [ApplicationManagement/RequirePrivateStoreOnly](policy-csp-applicationmanagement.md#applicationmanagement-requireprivatestoreonly) <sup>11</sup>
 - [Authentication/AllowFastReconnect](policy-csp-authentication.md#authentication-allowfastreconnect)
 - [Authentication/PreferredAadTenantDomainName](policy-csp-authentication.md#authentication-preferredaadtenantdomainname)
 - [Bluetooth/AllowDiscoverableMode](policy-csp-bluetooth.md#bluetooth-allowdiscoverablemode)


### PR DESCRIPTION
## Description
ApplicationManagement/RequirePrivateStoreOnly is missing from the list. HoloLens release notes (https://learn.microsoft.com/en-us/hololens/hololens-release-notes#windows-holographic-version-21h2 and https://learn.microsoft.com/en-us/hololens/hololens-release-notes#use-only-private-store-apps-for-microsoft-store) clearly states it's available since 21H2

## Why
I noticed the HoloLens2 Policy CSP is missing an item that is mentioned elsewhere as available for this platform.

## Changes
added a new line with a link to the missing setting
