### PR TITLE
Correct mistake in event-4670.md

### DIFF
--- a/windows/security/threat-protection/auditing/event-4670.md
+++ b/windows/security/threat-protection/auditing/event-4670.md
@@ -235,14 +235,14 @@ Example: D:(A;;FA;;;WD)
 | "GR"                       | GENERIC READ                    | "SD"                 | Delete                   |
 | "GW"                       | GENERIC WRITE                   | "WD"                 | Modify Permissions       |
 | "GX"                       | GENERIC EXECUTE                 | "WO"                 | Modify Owner             |
-| File access rights         | "RP"                            | Read All Properties  |
+| File access rights         |                                 | "RP"                 | Read All Properties      |
 | "FA"                       | FILE ALL ACCESS                 | "WP"                 | Write All Properties     |
 | "FR"                       | FILE GENERIC READ               | "CC"                 | Create All Child Objects |
 | "FW"                       | FILE GENERIC WRITE              | "DC"                 | Delete All Child Objects |
 | "FX"                       | FILE GENERIC EXECUTE            | "LC"                 | List Contents            |
-| Registry key access rights | "SW"                            | All Validated Writes |
-| "KA"                       | "LO"                            | "LO"                 | List Object              |
-| "K"                        | KEY READ                        | "DT"                 | Delete Subtree           |
+| Registry key access rights |                                 | "SW"                 | Self Write               |
+| "KA"                       | KEY ALL ACCESS                  | "LO"                 | List Object              |
+| "KR"                       | KEY READ                        | "DT"                 | Delete Subtree           |
 | "KW"                       | KEY WRITE                       | "CR"                 | All Extended Rights      |
 | "KX"                       | KEY EXECUTE                     |                      |                          |
 


### PR DESCRIPTION
## Description

Fill missing information of ACE strings according to:
- https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
- https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f4296d69-1c0f-491f-9587-a960b292d070?redirectedfrom=MSDN

And move other information to other column.

## Why

Because the information is missing, or the information is not in the correct column.

## Changes

It just modifies some strings in a table.
