### PR TITLE
Update windows-sandbox-configure-using-wsb-file.md

### DIFF
--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -76,6 +76,7 @@ Enables or disables networking in the sandbox. You can disable network access to
 `<Networking>value</Networking>`
 
 Supported values:
+- *Disable*: Enables networking in the sandbox.
 - *Disable*: Disables networking in the sandbox.
 - *Default*: This value is the default value for networking support. This value enables networking by creating a virtual switch on the host and connects the sandbox to it via a virtual NIC.
 

--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -185,7 +185,7 @@ Enables or disables sharing of the host clipboard with the sandbox.
 `<ClipboardRedirection>value</ClipboardRedirection>`
 
 Supported values:
-- *Enable*: Enables sharing of host clipboard into the sandbox.
+- *Enable*: Enables sharing of the host clipboard with the sandbox.
 - *Disable*: Disables clipboard redirection in the sandbox. If this value is set, copy/paste in and out of the sandbox will be restricted. 
 - *Default*: This value is the default value for clipboard redirection. Currently, copy/paste between the host and sandbox are permitted under *Default*.
 

--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -184,6 +184,7 @@ Enables or disables sharing of the host clipboard with the sandbox.
 `<ClipboardRedirection>value</ClipboardRedirection>`
 
 Supported values:
+- *Enable*: Enables sharing of host clipboard into the sandbox.
 - *Disable*: Disables clipboard redirection in the sandbox. If this value is set, copy/paste in and out of the sandbox will be restricted. 
 - *Default*: This value is the default value for clipboard redirection. Currently, copy/paste between the host and sandbox are permitted under *Default*.
 

--- a/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/threat-protection/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -76,7 +76,7 @@ Enables or disables networking in the sandbox. You can disable network access to
 `<Networking>value</Networking>`
 
 Supported values:
-- *Disable*: Enables networking in the sandbox.
+- *Enable*: Enables networking in the sandbox.
 - *Disable*: Disables networking in the sandbox.
 - *Default*: This value is the default value for networking support. This value enables networking by creating a virtual switch on the host and connects the sandbox to it via a virtual NIC.
 


### PR DESCRIPTION
## Description
`clipboard redirection & networking` missing "Enable" value

## Why
browsing windows sandbox configure docs and notice missing "Enable" under `clipboard redirection & networking`

## Changes

add "Enable" under `clipboard redirection & networking`