### PR TITLE
Typo fixes, style fixes

### DIFF
--- a/windows/security/threat-protection/security-policy-settings/act-as-part-of-the-operating-system.md
+++ b/windows/security/threat-protection/security-policy-settings/act-as-part-of-the-operating-system.md
@@ -28,6 +28,7 @@ Describes the best practices, location, values, policy management, and security 
 ## Reference
 
 The **Act as part of the operating system** policy setting determines whether a process can assume the identity of any user and thereby gain access to the resources that the user is authorized to access. Typically, only low-level authentication services require this user right. Potential access isn't limited to what is associated with the user by default. The calling process may request that arbitrary extra privileges be added to the access token. The calling process may also build an access token that doesn't provide a primary identity for auditing in the system event logs.
+
 Constant: SeTcbPrivilege
 
 ### Possible values

--- a/windows/security/threat-protection/security-policy-settings/create-symbolic-links.md
+++ b/windows/security/threat-protection/security-policy-settings/create-symbolic-links.md
@@ -31,7 +31,8 @@ This user right determines if users can create a symbolic link from the device t
 
 A symbolic link is a file system object that points to another file system object that is called the target. Symbolic links are transparent to users. The links appear as normal files or directories, and they can be acted upon by the user or application in exactly the same manner. Symbolic links are designed to aid in migration and application compatibility with UNIX operating systems. Microsoft has implemented symbolic links to function just like UNIX links.
 
->**Warning:**   This privilege should only be given to trusted users. Symbolic links can expose security vulnerabilities in applications that aren't designed to handle them.
+> [!WARNING]
+> This privilege should only be given to trusted users. Symbolic links can expose security vulnerabilities in applications that aren't designed to handle them.
 
 Constant: SeCreateSymbolicLinkPrivilege
 

--- a/windows/security/threat-protection/security-policy-settings/create-symbolic-links.md
+++ b/windows/security/threat-protection/security-policy-settings/create-symbolic-links.md
@@ -29,9 +29,10 @@ Describes the best practices, location, values, policy management, and security 
 
 This user right determines if users can create a symbolic link from the device they're logged on to.
 
-A symbolic link is a file-system object that points to another file-system object that is called the target. Symbolic links are transparent to users. The links appear as normal files or directories, and they can be acted upon by the user or application in exactly the same manner. Symbolic links are designed to aid in migration and application compatibility with UNIX operating systems. Microsoft has implemented symbolic links to function just like UNIX links.
+A symbolic link is a file system object that points to another file system object that is called the target. Symbolic links are transparent to users. The links appear as normal files or directories, and they can be acted upon by the user or application in exactly the same manner. Symbolic links are designed to aid in migration and application compatibility with UNIX operating systems. Microsoft has implemented symbolic links to function just like UNIX links.
 
 >**Warning:**   This privilege should only be given to trusted users. Symbolic links can expose security vulnerabilities in applications that aren't designed to handle them.
+
 Constant: SeCreateSymbolicLinkPrivilege
 
 ### Possible values

--- a/windows/security/threat-protection/security-policy-settings/lock-pages-in-memory.md
+++ b/windows/security/threat-protection/security-policy-settings/lock-pages-in-memory.md
@@ -33,7 +33,8 @@ Normally, an application running on Windows can negotiate for more physical memo
 
 Enabling this policy setting for a specific account (a user account or a process account for an application) prevents paging of the data. Thereby, the amount of memory that Windows can reclaim under pressure is limited. This limitation could lead to performance degradation.
 
->**Note:**  By configuring this policy setting, the performance of the Windows operating system will differ depending on if applications are running on 32-bit or 64-bit systems, and if they are virtualized images. Performance will also differ between earlier and later versions of the Windows operating system.
+> [!NOTE]
+> By configuring this policy setting, the performance of the Windows operating system will differ depending on if applications are running on 32-bit or 64-bit systems, and if they are virtualized images. Performance will also differ between earlier and later versions of the Windows operating system.
  
 Constant: SeLockMemoryPrivilege
 


### PR DESCRIPTION
- Fixed a paragraph that had mistakenly been merged into a warning box.
- Fixed a typo. "File system object" (FSO) and "Group Policy Object" (GPO) are both written without a hyphen.