### PR TITLE
Clarification on GPO effect on restrictedAdmin

### DIFF
--- a/windows/security/identity-protection/remote-credential-guard.md
+++ b/windows/security/identity-protection/remote-credential-guard.md
@@ -156,6 +156,7 @@ Beginning with Windows 10 version 1703, you can enable Windows Defender Remote C
 
      > [!NOTE]
      > Neither Windows Defender Remote Credential Guard nor Restricted Admin mode will send credentials in clear text to the Remote Desktop server.
+     > When **Restrict Credential Delegation** is enabled the /restrictedAdmin switch has no effect; consequently, Windows Defender Remote Credential Guard will be preferred.
 
    - If you want to require Windows Defender Remote Credential Guard, choose **Require Remote Credential Guard**. With this setting, a Remote Desktop connection will succeed only if the remote computer meets the [requirements](#reqs) listed earlier in this topic.
 

--- a/windows/security/identity-protection/remote-credential-guard.md
+++ b/windows/security/identity-protection/remote-credential-guard.md
@@ -156,7 +156,7 @@ Beginning with Windows 10 version 1703, you can enable Windows Defender Remote C
 
      > [!NOTE]
      > Neither Windows Defender Remote Credential Guard nor Restricted Admin mode will send credentials in clear text to the Remote Desktop server.
-     > When **Restrict Credential Delegation** is enabled the /restrictedAdmin switch has no effect; consequently, Windows Defender Remote Credential Guard will be preferred.
+     > When **Restrict Credential Delegation** is enabled, the /restrictedAdmin switch will be ignored. Windows will enforce the policy configuration instead and will use Windows Defender Remote Credential Guard. 
 
    - If you want to require Windows Defender Remote Credential Guard, choose **Require Remote Credential Guard**. With this setting, a Remote Desktop connection will succeed only if the remote computer meets the [requirements](#reqs) listed earlier in this topic.
 


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

My testing shows that Restricted Admin mode cannot be enforced with "mstsc.exe /remoteAdmin" when "Restrict Credential Delegation" is enabled. I had previously assumed this but it seems not to be the case. A clarification would be useful for others.

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->
Clarifying the effect of "Restrict Credential Delegation" on "mstsc.exe /remoteAdmin".

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
