### PR TITLE
Spelling error in the "Policy timeline" section

### DIFF
--- a/windows/client-management/mdm/policy-csp-restrictedgroups.md
+++ b/windows/client-management/mdm/policy-csp-restrictedgroups.md
@@ -150,7 +150,7 @@ Descriptions of the properties:
 
 **Policy timeline**:
 
-The behavior of this policy setting differs in different Windows 10 versions. For Windows 10, version 1809 through version 1909, you can use name in `<accessgroup dec>` and SID in `<member name>`. For Windows 10, version 2004, you can use name or SID for both the elements, as described in the example.
+The behavior of this policy setting differs in different Windows 10 versions. For Windows 10, version 1809 through version 1909, you can use name in `<accessgroup desc>` and SID in `<member name>`. For Windows 10, version 2004, you can use name or SID for both the elements, as described in the example.
 
 The following table describes how this policy setting behaves in different Windows 10 versions:
 


### PR DESCRIPTION
There is a small spelling error. In the "Policy timeline" section there is a sentence written like this: "accessgroup dec" while the correct one would be "accessgroup desc".

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
