### PR TITLE
Add documentation for ScanBeforeInitialLogonAllowed

### DIFF
--- a/windows/deployment/update/waas-wu-settings.md
+++ b/windows/deployment/update/waas-wu-settings.md
@@ -33,7 +33,7 @@ You can use Group Policy settings or mobile device management (MDM) to configure
 | [Do not include drivers with Windows Updates](#do-not-include-drivers-with-windows-updates) | [ExcludeWUDriversInQualityUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-excludewudriversinqualityupdate) | 1607 |
 | [Configure Automatic Updates](#configure-automatic-updates) | [AllowAutoUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-allowautoupdate) | All |
 | |  [Windows Update notifications display organization name](#bkmk_display-name) </br></br> *Organization name is displayed by default. A registry value can disable this behavior. | Windows 11 devices that are Azure Active Directory joined or registered <!--6286260-->|
-| | [Allow Windows updates to install before initial user logon](#allow-windows-update-before-initial-logon) | Windows 11 version 22H2 |
+| | [Allow Windows updates to install before initial user sign-in](#allow-windows-update-before-initial-sign-in) | Windows 11 version 22H2 |
 
 >[!IMPORTANT]
 >Additional information about settings to manage device restarts and restart notifications for updates is available on **[Manage device restarts after updates](waas-restart.md)**.
@@ -280,7 +280,7 @@ if (!(Test-Path $registryPath))
 New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
 ```
 
-## <a name="allow-windows-update-before-initial-logon"> </a> Allow Windows updates to install before initial user logon
+## <a name="allow-windows-update-before-initial-sign-in"> </a> Allow Windows updates to install before initial user sign-in
 *(Starting in Windows 11, version 22H2)*
 
 On new devices, Windows Update doesn't begin installing background updates until a user has completed the Out of Box Experience (OOBE) and signs in for the first time. In many cases, the user signs in immediately after completing the OOBE. However, some VM-based solutions provision a device and automate the first user experience. These VMs may not be immediately assigned to a user so they won't see an initial sign-in until several days later.  

--- a/windows/deployment/update/waas-wu-settings.md
+++ b/windows/deployment/update/waas-wu-settings.md
@@ -38,6 +38,7 @@ You can use Group Policy settings or mobile device management (MDM) to configure
 | [Do not include drivers with Windows Updates](#do-not-include-drivers-with-windows-updates) | [ExcludeWUDriversInQualityUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-excludewudriversinqualityupdate) | 1607 |
 | [Configure Automatic Updates](#configure-automatic-updates) | [AllowAutoUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-allowautoupdate) | All |
 | |  [Windows Update notifications display organization name](#bkmk_display-name) </br></br> *Organization name is displayed by default. A registry value can disable this behavior. | Windows 11 devices that are Azure Active Directory joined or registered <!--6286260-->| 
+| | [Allow Windows Updates to install before initial user logon](#allow-windows-update-before-initial-logon) | Windows 11 22H2 devices |
 
 >[!IMPORTANT]
 >Additional information about settings to manage device restarts and restart notifications for updates is available on **[Manage device restarts after updates](waas-restart.md)**.
@@ -284,7 +285,7 @@ if (!(Test-Path $registryPath))
 New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
 ```
 
-## <a name="bkmk_display-name"> </a> Allow Windows Updates to install before initial user logon
+## <a name="allow-windows-update-before-initial-logon"> </a> Allow Windows Updates to install before initial user logon
 
 This value is supported on devices running Windows 11, version 22H2 or newer.
 
@@ -296,4 +297,5 @@ In those scenarios, setting the following registry value allows those devices to
 - **DWORD value name**: ScanBeforeInitialLogonAllowed
 - **Value data**: 1
 
-> [!NOTE] This value is designed to be used only for scenarios with a deferred initial user logon.  Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.
+> [!CAUTION]
+> This value is designed to be used only for scenarios with a deferred initial user logon.  Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.

--- a/windows/deployment/update/waas-wu-settings.md
+++ b/windows/deployment/update/waas-wu-settings.md
@@ -283,3 +283,17 @@ if (!(Test-Path $registryPath))
 
 New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
 ```
+
+## <a name="bkmk_display-name"> </a> Allow Windows Updates to install before initial user logon
+
+This value is supported on devices running Windows 11, version 22H2 or newer.
+
+On new devices Windows Update does not begin to install background updates until a user has completed the Out of Box Experience and logs on for the first time.  The initial logon typically happens immediately after completing that first user experience.  Some VM-based solutions provision a device and automate the first user experience but are not immediately assigned to a user and don't see an initial logon until several days later.  
+
+In those scenarios, setting the following registry value allows those devices to begin background update work before a first user logon:
+
+- **Registry key**: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator
+- **DWORD value name**: ScanBeforeInitialLogonAllowed
+- **Value data**: 1
+
+> [!NOTE] This value is designed to be used only for scenarios with a deferred initial user logon.  Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.

--- a/windows/deployment/update/waas-wu-settings.md
+++ b/windows/deployment/update/waas-wu-settings.md
@@ -9,17 +9,12 @@ manager: aaroncz
 ms.topic: article
 ms.collection: highpri, tier2
 ms.technology: itpro-updates
-ms.date: 01/06/2023
+ms.date: 03/09/2023
 ---
 
 # Manage additional Windows Update settings
 
-
-**Applies to**
-
-- Windows 10
-- Windows 11
-
+***(Applies to: Windows 11 & Windows 10)***
 
 > **Looking for consumer information?** See [Windows Update: FAQ](https://support.microsoft.com/help/12373/windows-update-faq)
 
@@ -38,7 +33,7 @@ You can use Group Policy settings or mobile device management (MDM) to configure
 | [Do not include drivers with Windows Updates](#do-not-include-drivers-with-windows-updates) | [ExcludeWUDriversInQualityUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-excludewudriversinqualityupdate) | 1607 |
 | [Configure Automatic Updates](#configure-automatic-updates) | [AllowAutoUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-allowautoupdate) | All |
 | |  [Windows Update notifications display organization name](#bkmk_display-name) </br></br> *Organization name is displayed by default. A registry value can disable this behavior. | Windows 11 devices that are Azure Active Directory joined or registered <!--6286260-->| 
-| | [Allow Windows Updates to install before initial user logon](#allow-windows-update-before-initial-logon) | Windows 11 22H2 devices |
+| | [Allow Windows updates to install before initial user logon](#allow-windows-update-before-initial-logon) | Windows 11 version 22H2 |
 
 >[!IMPORTANT]
 >Additional information about settings to manage device restarts and restart notifications for updates is available on **[Manage device restarts after updates](waas-restart.md)**.
@@ -285,11 +280,11 @@ if (!(Test-Path $registryPath))
 New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
 ```
 
-## <a name="allow-windows-update-before-initial-logon"> </a> Allow Windows Updates to install before initial user logon
+## <a name="allow-windows-update-before-initial-logon"> </a> Allow Windows updates to install before initial user logon
 
-This value is supported on devices running Windows 11, version 22H2 or newer.
+*(Starting in Windows 11, version 22H2)*
 
-On new devices Windows Update does not begin to install background updates until a user has completed the Out of Box Experience and logs on for the first time.  The initial logon typically happens immediately after completing that first user experience.  Some VM-based solutions provision a device and automate the first user experience but are not immediately assigned to a user and don't see an initial logon until several days later.  
+On new devices, Windows Update doesn't begin installing background updates until a user has completed the Out of Box Experience (OOBE) and signs in for the first time. In many cases, the user signs in immediately after completing the OOBE. However, some VM-based solutions provision a device and automate the first user experience but aren't immediately assigned to a user and don't see an initial logon until several days later.  
 
 In those scenarios, setting the following registry value allows those devices to begin background update work before a first user logon:
 
@@ -297,5 +292,5 @@ In those scenarios, setting the following registry value allows those devices to
 - **DWORD value name**: ScanBeforeInitialLogonAllowed
 - **Value data**: 1
 
-> [!CAUTION]
-> This value is designed to be used only for scenarios with a deferred initial user logon.  Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.
+> [!Warning]
+> This value is designed to be used only for scenarios with a deferred initial user sign in. Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.

--- a/windows/deployment/update/waas-wu-settings.md
+++ b/windows/deployment/update/waas-wu-settings.md
@@ -32,7 +32,7 @@ You can use Group Policy settings or mobile device management (MDM) to configure
 | [Allow signed updates from an intranet Microsoft update service location](#allow-signed-updates-from-an-intranet-microsoft-update-service-location) | [AllowNonMicrosoftSignedUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-allownonmicrosoftsignedupdate) | All |
 | [Do not include drivers with Windows Updates](#do-not-include-drivers-with-windows-updates) | [ExcludeWUDriversInQualityUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-excludewudriversinqualityupdate) | 1607 |
 | [Configure Automatic Updates](#configure-automatic-updates) | [AllowAutoUpdate](/windows/client-management/mdm/policy-configuration-service-provider#update-allowautoupdate) | All |
-| |  [Windows Update notifications display organization name](#bkmk_display-name) </br></br> *Organization name is displayed by default. A registry value can disable this behavior. | Windows 11 devices that are Azure Active Directory joined or registered <!--6286260-->| 
+| |  [Windows Update notifications display organization name](#bkmk_display-name) </br></br> *Organization name is displayed by default. A registry value can disable this behavior. | Windows 11 devices that are Azure Active Directory joined or registered <!--6286260-->|
 | | [Allow Windows updates to install before initial user logon](#allow-windows-update-before-initial-logon) | Windows 11 version 22H2 |
 
 >[!IMPORTANT]
@@ -281,27 +281,15 @@ New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWO
 ```
 
 ## <a name="allow-windows-update-before-initial-logon"> </a> Allow Windows updates to install before initial user logon
-
-<<<<<<< HEAD
 *(Starting in Windows 11, version 22H2)*
 
-On new devices, Windows Update doesn't begin installing background updates until a user has completed the Out of Box Experience (OOBE) and signs in for the first time. In many cases, the user signs in immediately after completing the OOBE. However, some VM-based solutions provision a device and automate the first user experience but aren't immediately assigned to a user and don't see an initial logon until several days later.  
-=======
-This value is supported on devices running Windows 11, version 22H2, or later.
+On new devices, Windows Update doesn't begin installing background updates until a user has completed the Out of Box Experience (OOBE) and signs in for the first time. In many cases, the user signs in immediately after completing the OOBE. However, some VM-based solutions provision a device and automate the first user experience. These VMs may not be immediately assigned to a user so they won't see an initial sign-in until several days later.  
 
-On new devices, Windows Update does not begin to install background updates until a user has completed the Out of Box Experience and signs in for the first time.  The user typically signs in initially immediately after completing that first user experience. Some VM-based solutions provision a device and automate the first user experience but are not immediately assigned to a user and don't see a user initially signing in until several days later.  
->>>>>>> e9047ec25fd2823845599b3e4f516ef67e2972e4
-
-In those scenarios, setting the following registry values allows those devices to begin background update work before a user first signs in:
+In scenarios where initial sign-in is delayed, setting the following registry values allow devices to begin background update work before a user first signs in:
 
 - **Registry key**: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator
 - **DWORD value name**: ScanBeforeInitialLogonAllowed
 - **Value data**: 1
 
-<<<<<<< HEAD
 > [!Warning]
-> This value is designed to be used only for scenarios with a deferred initial user sign in. Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user is logging in for the first time.
-=======
-> [!CAUTION]
-> This value is designed to be used only for scenarios where the initial signing-in of a user is deferred. Setting this value on normal consumer retail devices could have a detrimental effect on performance as it may allow update work to occur as the user signs in for the first time.
->>>>>>> e9047ec25fd2823845599b3e4f516ef67e2972e4
+> This value is designed to be used only for scenarios with a deferred initial user sign in. Setting this value on devices where initial user sign in isn't delayed could have a detrimental effect on performance since it may allow update work to occur as the user is signing in for the first time.


### PR DESCRIPTION

## Description

Adding documentation for a registry value being introduced in Win11 22H2 to support scanning for and installing updates before a first user logon.  This is meant to be used only for devices (such as CloudPCs based on Azure VM) where there is a significant delay between the completion of the first user experience and the initial logon.  Included a warning that using this value may have a negative effect when used in retail devices.

## Why

This registry value is being set by CloudPC devices to keep them secure and up to date.  Based on Compliance assessment for this feature, we are required to document this implicit contract.

## Changes

Describes the use case for the ScanBeforeInitialLogonAllowed registry value, the appropriate value to enable it, and also includes a warning of potential negative impacts if used in scenarios that don't have an extended delay before first user logon.

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
