### PR TITLE
PR Updates link as registered in issue #11407

### DIFF
--- a/education/windows/includes/intune-custom-settings-1.md
+++ b/education/windows/includes/intune-custom-settings-1.md
@@ -7,7 +7,7 @@ ms.topic: include
 
 To configure devices with Microsoft Intune, use a custom policy:
 
-1. Go to the <a href="https://intune.micorsoft.com" target="_blank"><b>Microsoft Intune admin center</b></a>
+1. Go to the <a href="https://intune.microsoft.com" target="_blank"><b>Microsoft Intune admin center</b></a>
 2. Select **Devices > Configuration profiles > Create profile**
 3. Select **Platform > Windows 10 and later** and **Profile type > Templates > Custom**
 4. Select **Create**


### PR DESCRIPTION
## Description

In the intune installation section:

 >> To configure devices with Microsoft Intune, use a custom policy:
  Go to the [Microsoft Intune admin center](https://intune.micorsoft.com/)

The URL is wrong.
It should have been https://intune.microsoft.com/ instead of https://intune.micorsoft.com/
Notice the spelling of Microsoft.


## Why

Explained above

- Closes #11407

## Changes

URL as mentioned above.

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
