### PR TITLE
Update mandatory-user-profile.md

### DIFF
--- a/windows/client-management/mandatory-user-profile.md
+++ b/windows/client-management/mandatory-user-profile.md
@@ -118,6 +118,13 @@ First, you create a default user profile with the customizations that you want, 
 
 1. Rename `Ntuser.dat` to `Ntuser.man`.
 
+### Check and set the correct owner for the mandatory profile folders
+
+1. Open the properties of the "profile.v6" folder.
+2. Go to the "security" tab and click "Advanced".
+3. Check the "owner" of the folder. It has to be the builtin Administrators group. To change it here if it does not match, you need to be in the Administrators group of the file server to take ownership, or have "set owner" privilege on the server.
+4. When you have set the owner, check the box "Replace owner on subcontainers and objects" before you click OK.
+
 ## Apply a mandatory user profile to users
 
 In a domain, you modify properties for the user account to point to the mandatory profile in a shared folder residing on the server.


### PR DESCRIPTION
add steps to set the correct owner for the mandatory profile folders

<!-- 
## Description

the article is missing setting the correct owner. Profile service is later checking the owner and it has to be "administrators" for a mandatory profile.
-->

## Why

<!--
we have customers either setting incorrect owner (we see for example "everyone") or leave in an incorrect owner. the latter happens when the user who prepares the mandatory profile is not administrator on the file server.

there is actually a 3rd party blog article about the topic that describes this correctly...
-->

## Changes

<!--
Added basic steps to check and set owner of the folder.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
