### PR TITLE
Update vda-subscription-activation.md

### DIFF
--- a/windows/deployment/vda-subscription-activation.md
+++ b/windows/deployment/vda-subscription-activation.md
@@ -48,7 +48,8 @@ Deployment instructions are provided for the following scenarios:
 
     [Inherited Activation](./windows-10-subscription-activation.md#inherited-activation) is enabled. All VMs created by a user with a Windows E3 or E5 license are automatically activated independent of whether a user signs in with a local account or using an Azure AD account.
 
-For examples of activation issues, see [Troubleshoot the user experience](./deploy-enterprise-licenses.md#troubleshoot-the-user-experience) and see [Troubleshoot Azure Windows virtual machine activation problems](/troubleshoot/azure/virtual-machines/troubleshoot-activation-problems).
+For examples of activation issues, see [Troubleshoot the user experience](./deploy-enterprise-licenses.md#troubleshoot-the-user-experience) and [Troubleshoot Azure Windows virtual machine activation problems](/troubleshoot/azure/virtual-machines/troubleshoot-activation-problems).
+
 
 ## Active Directory-joined VMs
 

--- a/windows/deployment/vda-subscription-activation.md
+++ b/windows/deployment/vda-subscription-activation.md
@@ -31,30 +31,24 @@ Deployment instructions are provided for the following scenarios:
 
 - VMs must be running a supported version of Windows Pro edition.
 - VMs must be joined to Active Directory or Azure Active Directory (Azure AD).
-- VMs must be hosted by a Qualified Multitenant Hoster (QMTH). For more information, download the PDF that describes the [Qualified Multitenant Hoster Program](https://download.microsoft.com/download/3/D/4/3D445779-2870-4E3D-AFCB-D35D2E1BC095/QMTH%20Authorized%20Partner%20List.pdf).
 
 ## Activation
 
 ### Scenario 1
 
 - The VM is running a supported version of Windows.
-- The VM is hosted in Azure, an authorized outsourcer, or another Qualified Multitenant Hoster (QMTH).
+- The VM is hosted in Azure, an Authorized Outsourcer, or your own server.
 
     When a user with VDA rights signs in to the VM using their Azure AD credentials, the VM is automatically stepped-up to Enterprise and activated. There's no need to do Windows Pro activation. This functionality eliminates the need to maintain KMS or MAK in the qualifying cloud infrastructure.
 
 ### Scenario 2
 
-- The Hyper-V host and the VM are both running a supported version of Windows.
+- The Hyper-V host is activated and running a supported version of Windows.
+- The VM is running a supported version of Windows.
 
     [Inherited Activation](./windows-10-subscription-activation.md#inherited-activation) is enabled. All VMs created by a user with a Windows E3 or E5 license are automatically activated independent of whether a user signs in with a local account or using an Azure AD account.
 
-### Scenario 3
-
-- The hoster isn't an authorized QMTH partner.
-
-    In this scenario, the underlying Windows Pro license must be activated prior to using subscription activation Windows Enterprise. Activation is accomplished using a generic volume license key (GVLK) and a volume license KMS activation server provided by the hoster. Alternatively, a KMS activation server can be used. KMS activation is provided for Azure VMs. For more information, see [Troubleshoot Azure Windows virtual machine activation problems](/troubleshoot/azure/virtual-machines/troubleshoot-activation-problems).
-
-For examples of activation issues, see [Troubleshoot the user experience](./deploy-enterprise-licenses.md#troubleshoot-the-user-experience).
+For examples of activation issues, see [Troubleshoot the user experience](./deploy-enterprise-licenses.md#troubleshoot-the-user-experience) and see [Troubleshoot Azure Windows virtual machine activation problems](/troubleshoot/azure/virtual-machines/troubleshoot-activation-problems).
 
 ## Active Directory-joined VMs
 


### PR DESCRIPTION
First - eliminated QMTH references since that is no longer a valid program. All customers with E3 licenses are contractually allowed to run their WIndows Client VMs in public/shared clouds now. There is no longer a requirement that it happen on a "QMTH". 

Second, I found the scenarios confusing and I think there are only two: 1)  sign-in activation, and 2) inherited activation. So I updated the scenarios accordingly. Will you verify or have Michael Pashniak verify? Thanks!

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
