### PR TITLE
Update toc.yml - add link to EAP page

### DIFF
--- a/windows/security/operating-system-security/network-security/toc.yml
+++ b/windows/security/operating-system-security/network-security/toc.yml
@@ -1,8 +1,10 @@
 items:
   - name: Transport layer security (TLS) 🔗
     href: /windows-server/security/tls/tls-ssl-schannel-ssp-overview
-  - name: WiFi Security
+  - name: Wi-Fi Security
     href: https://support.microsoft.com/windows/faster-and-more-secure-wi-fi-in-windows-26177a28-38ed-1a8e-7eca-66f24dc63f09
+  - name: Extensible Authentication Protocol (EAP) for network access
+    href: /windows-server/networking/technologies/extensible-authentication-protocol/network-access
   - name: Windows Firewall 🔗
     href: windows-firewall/windows-firewall-with-advanced-security.md
   - name: Virtual Private Network (VPN)


### PR DESCRIPTION
## Description

Add a link to the EAP page - /windows-server/networking/technologies/extensible-authentication-protocol/network-access - in the network-security toc.yml

## Why

I've done work in the last couple weeks to update that page to be more comprehensive for detailing EAP and 802.1X auth in Windows. There should be an explicit pointer from these IT Pros docs to this page, and it makes sense for it to be here. 
