### PR TITLE
Windows Drivers update setting to block drivers

### DIFF
--- a/windows/deployment/update/includes/wufb-deployment-driver-policy-considerations.md
+++ b/windows/deployment/update/includes/wufb-deployment-driver-policy-considerations.md
@@ -20,7 +20,7 @@ The following policies exclude drivers from Windows Update for a device:
   -  **Group Policy**: `\Windows Components\Windows Update\Do not include drivers with Windows Updates` set to `enabled`
   - **CSP**: [ExcludeWUDriversInQualityUpdate](/windows/client-management/mdm/policy-csp-update#excludewudriversinqualityupdate) set to `1`
   - **Registry**:  `HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\ExcludeWUDriversFromQualityUpdates` set to `1`
-  - **Intune**: [**Windows Drivers** update setting](/mem/intune/protect/windows-update-settings#update-settings) for the update ring set to `Allow` 
+  - **Intune**: [**Windows Drivers** update setting](/mem/intune/protect/windows-update-settings#update-settings) for the update ring set to `Block` 
 
 **Behavior with the deployment service**: Devices with driver exclusion polices that are enrolled for **drivers** and added to an audience though the deployment service:
   - Will display the applicable driver content in the deployment service


### PR DESCRIPTION
In the 'Locations of policies that exclude drivers' list, the Windows Drivers update setting indicates being set to Allow blocks drivers. I believe this should be **Block** and not **Allow**.

