### PR TITLE
Update policy-csp-experience.md

### DIFF
--- a/windows/client-management/mdm/policy-csp-experience.md
+++ b/windows/client-management/mdm/policy-csp-experience.md
@@ -1807,7 +1807,7 @@ This policy setting allows an organization to prevent its devices from showing f
 <!-- DoNotSyncBrowserSettings-Applicability-Begin -->
 | Scope | Editions | Applicable OS |
 |:--|:--|:--|
-| ✅ Device <br> ❌ User | ✅ Pro <br> ✅ Enterprise <br> ✅ Education <br> ✅ Windows SE | ✅ Windows 10, version 1809 [10.0.17763] and later |
+| ✅ Device <br> ❌ User | ❌ Pro <br> ✅ Enterprise <br> ✅ Education <br> ✅ Windows SE | ✅ Windows 10, version 1809 [10.0.17763] and later |
 <!-- DoNotSyncBrowserSettings-Applicability-End -->
 
 <!-- DoNotSyncBrowserSettings-OmaUri-Begin -->


### PR DESCRIPTION
## Description
On issuing **DoNotSyncBrowserSettings** command to "Windows Pro" edition (Build 19044.1288), throws 405 in response. However received 200 response for **Enterprise Edition**. Considering this is not compatible for Pro edition, request you to check and update the documentation if need be.

## Why
Here is the syncML reference when issued on **Pro Edition**
```
<Replace>
      <CmdID>1</CmdID>
      <Item>
        <Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/DoNotSyncBrowserSettings</LocURI>
        </Target>
        <Meta>
          <Format xmlns="syncml:metinf">int</Format>
          <Type>text/plain</Type>
        </Meta>
        <Data>2</Data>
      </Item>
    </Replace>
    <Status>
      <CmdID>2</CmdID>
      <MsgRef>1</MsgRef>
      <CmdRef>69</CmdRef>
      <Cmd>Replace</Cmd>
      <Data>405</Data>
    </Status>
```

- Closes #[Issue Number]

## Changes

**Pro** edition should be marked - Not supported for DoNotSyncBrowserSettings

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
