### PR TITLE
Fix capitalization for RetryTimeInHours profilexml example

### DIFF
--- a/windows/client-management/mdm/vpnv2-csp.md
+++ b/windows/client-management/mdm/vpnv2-csp.md
@@ -9037,7 +9037,7 @@ Profile example
         <NativeProtocol>
           <Type>Sstp</Type>
         </NativeProtocol>
-        <RetryTimeinHours>168</RetryTimeinHours>
+        <RetryTimeInHours>168</RetryTimeInHours>
       </ProtocolList>
     <Authentication>
       <UserMethod>Eap</UserMethod>


### PR DESCRIPTION
## Why
Xml Node names are case sensitive, so this example does not actually work and fails to configure RetryTimeInHours.

## Changes
Fix capitalization in example
<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->
