### PR TITLE
Update windows-10-subscription-activation.md

### DIFF
--- a/windows/deployment/windows-10-subscription-activation.md
+++ b/windows/deployment/windows-10-subscription-activation.md
@@ -39,7 +39,7 @@ This article covers the following information:
 For more information on how to deploy Enterprise licenses, see [Deploy Windows Enterprise licenses](deploy-enterprise-licenses.md).
 
 > [!NOTE]
-> Organizations that use the Subscription Activation feature to enable users to upgrade from one version of Windows to another and use Conditional Access policies to control access need to exclude the [Universal Store Service APIs and Web Application, AppID 45a330b1-b1ec-4cc1-9161-9f03992aa49f](/troubleshoot/azure/active-directory/verify-first-party-apps-sign-in#application-ids-of-commonly-used-microsoft-applications), from their Conditional Access policies using **Select Excluded Cloud Apps**. For more information about configuring exclusions in Conditional Access policies, see [Application exclusions](/azure/active-directory/conditional-access/howto-conditional-access-policy-all-users-mfa#application-exclusions).
+> Organizations that use the Subscription Activation feature to enable users to upgrade from one version of Windows to another and use Conditional Access policies to control access need to exclude the [Windows Store for Business, AppID 45a330b1-b1ec-4cc1-9161-9f03992aa49f](/troubleshoot/azure/active-directory/verify-first-party-apps-sign-in#application-ids-of-commonly-used-microsoft-applications), from their Conditional Access policies using **Select Excluded Cloud Apps**. For more information about configuring exclusions in Conditional Access policies, see [Application exclusions](/azure/active-directory/conditional-access/howto-conditional-access-policy-all-users-mfa#application-exclusions).
 
 ## Subscription activation for Enterprise
 


### PR DESCRIPTION
Changed enterprise app name Universal Store Service APIs and Web Application, to Windows Store for Business to reflect name changes.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description
Universal Store Service APIs and Web Application was renamed to Windows Store for Business 
## Why

Searching Conditional Access for Universal Store Service APIs and Web Application yields no results. Instead, you need to use the new name Windows Store for Business

