### PR TITLE
Fix typo in configure-wdac-managed-installer

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer.md
@@ -1,6 +1,6 @@
 ---
 title: Managed installer and ISG technical reference and troubleshooting guide
-description: Explains how to configure a custom Manged Installer.
+description: Explains how to configure a custom Managed Installer.
 ms.localizationpriority: medium
 ms.date: 11/11/2022
 ms.topic: article

--- a/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer.md
@@ -1,9 +1,9 @@
 ---
 title: Managed installer and ISG technical reference and troubleshooting guide
-description: Explains how to configure a custom Managed Installer.
+description: A technical reference and troubleshooting guide for managed installer and Intelligent Security Graph (ISG).
 ms.localizationpriority: medium
 ms.date: 11/11/2022
-ms.topic: article
+ms.topic: troubleshooting
 ---
 
 # Managed installer and ISG technical reference and troubleshooting guide


### PR DESCRIPTION
## Changes

Manged -> Managed

Fix typo in metadata of [Managed installer and ISG technical reference and troubleshooting guide](https://learn.microsoft.com/en-us/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer).

```
view-source:https://learn.microsoft.com/en-us/windows/security/application-security/application-control/windows-defender-application-control/operations/configure-wdac-managed-installer
```

<details>

<summary>Screenshot</summary>

![image](https://github.com/MicrosoftDocs/windows-itpro-docs/assets/26336/494b83a1-f0fe-46ac-b415-77d7df2c85c6)

</details>

### Related

#11852 