### PR TITLE
Updating clouddesktop-csp.md with dedicated mode terminology and adding "Turn off copilot" policy

### DIFF
--- a/windows/client-management/mdm/clouddesktop-csp.md
+++ b/windows/client-management/mdm/clouddesktop-csp.md
@@ -47,7 +47,7 @@ The following list shows the CloudDesktop configuration service provider nodes:
 
 <!-- Device-BootToCloudPCEnhanced-Description-Begin -->
 <!-- Description-Source-DDF -->
-This node allows to configure different kinds of Boot to Cloud mode. Boot to cloud mode enables users to seamlessly sign-in to a Cloud PC. For using this feature, Cloud Provider application must be installed on the PC and the user must have a Cloud PC provisioned. This node supports the below options: 0. Not Configured. 1. Enable Boot to Cloud Shared PC Mode: Boot to Cloud Shared PC mode allows multiple users to sign-in on the device and use for shared purpose. 2. Enable Boot to Cloud Personal Mode (Cloud only): Personal mode allows user to sign-in on the device using various authentication mechanism configured by their organization (For ex. PIN, Biometrics etc). This mode preserves user personalization, including their profile picture and username in local machine, and facilitates fast account switching.
+This node allows to configure different kinds of Boot to Cloud mode. Boot to cloud mode enables users to seamlessly sign-in to a Cloud PC. For using this feature, Cloud Provider application must be installed on the PC and the user must have a Cloud PC provisioned. This node supports the below options: 0. Not Configured. 1. Enable Boot to Cloud Shared PC Mode: Boot to Cloud Shared PC mode allows multiple users to sign-in on the device and use for shared purpose. 2. Enable Boot to Cloud Dedicated Mode (Cloud only): Dedicated mode allows user to sign-in on the device using various authentication mechanism configured by their organization (For ex. PIN, Biometrics etc). This mode preserves user personalization, including their profile picture and username in local machine, and facilitates fast account switching.
 <!-- Device-BootToCloudPCEnhanced-Description-End -->
 
 <!-- Device-BootToCloudPCEnhanced-Editable-Begin -->
@@ -73,7 +73,7 @@ This node allows to configure different kinds of Boot to Cloud mode. Boot to clo
 |:--|:--|
 | 0 (Default) | Not Configured. |
 | 1 | Enable Boot to Cloud Shared PC Mode. |
-| 2 | Enable Boot to Cloud Personal Mode (Cloud only). |
+| 2 | Enable Boot to Cloud Dedicated Mode (Cloud only). |
 <!-- Device-BootToCloudPCEnhanced-AllowedValues-End -->
 
 <!-- Device-BootToCloudPCEnhanced-Examples-Begin -->
@@ -140,10 +140,10 @@ Setting this node to "true" configures boot to cloud for Shared PC mode. Boot to
 <!-- Add any additional information about this CSP here. Anything outside this section will get overwritten. -->
 ## BootToCloudPCEnhanced technical reference
 
-BootToCloudPCEnhanced is the setting used to configure **Boot to Cloud** feature either for shared mode or personal mode. When you enable this setting, multiple policies are applied to achieve the intended behavior. If you wish to customize the **Boot to Cloud** experience, you can utilize the [BootToCloudMode](policy-csp-clouddesktop.md#boottocloudmode) policy, which provides the flexibility to tailor the experience according to your requirements.
+BootToCloudPCEnhanced is the setting used to configure **Boot to Cloud** feature either for shared mode or dedicated mode. When you enable this setting, multiple policies are applied to achieve the intended behavior. If you wish to customize the **Boot to Cloud** experience, you can utilize the [BootToCloudMode](policy-csp-clouddesktop.md#boottocloudmode) policy, which provides the flexibility to tailor the experience according to your requirements.
 
 > [!NOTE]
-> It is recommended not to set any of the policies enforced by this setting to different values, as these policies help provide a smooth UX experience for the **Boot to Cloud** feature for shared and personal mode.
+> It is recommended not to set any of the policies enforced by this setting to different values, as these policies help provide a smooth UX experience for the **Boot to Cloud** feature for shared and dedicated mode.
 
 ### Boot to Cloud Shared PC Mode
 
@@ -189,6 +189,7 @@ When the Shared PC mode is enabled by setting BootToCloudPCEnhanced value to 1:
     | Start Menu and Taskbar/Notifications/Turn off toast notifications                                                      | Enabled                               |
     | Start Menu and Taskbar/Notifications/Remove Notifications and Action Center                                            | Enabled                               |
     | System/Logon/Do not process the legacy run list                                                                        | Enabled                               |
+    | Windows Components/Windows Copilot/Turn off Windows Copilot                                                            | Enabled                               |
 
 - Following registry changes are performed:
 
@@ -197,9 +198,9 @@ When the Shared PC mode is enabled by setting BootToCloudPCEnhanced value to 1:
     | Software\Policies\Microsoft\PassportForWork\Remote\Enabled (Phone sign-in/Use phone sign-in) | 0      |
     | Software\Policies\Microsoft\PassportForWork\Enabled (Use Microsoft Passport for Work)        | 0      |
 
-### Boot to Cloud Personal Mode
+### Boot to Cloud Dedicated Mode
 
-When the Personal mode is enabled by setting BootToCloudPCEnhanced value to 2:
+When the Dedicated mode is enabled by setting BootToCloudPCEnhanced value to 2:
 
 - Following MDM policies are applied for the Device scope (all users):
 
@@ -218,6 +219,7 @@ When the Personal mode is enabled by setting BootToCloudPCEnhanced value to 2:
     | Start Menu and Taskbar/Notifications/Turn off toast notifications                                                      | Enabled                               |
     | Start Menu and Taskbar/Notifications/Remove Notifications and Action Center                                            | Enabled                               |
     | System/Logon/Do not process the legacy run list                                                                        | Enabled                               |
+    | Windows Components/Windows Copilot/Turn off Windows Copilot                                                            | Enabled                               |
 <!-- CloudDesktop-CspMoreInfo-End -->
 
 <!-- CloudDesktop-End -->


### PR DESCRIPTION
Updating Cloud Desktop CSP's documentation as per latest updates
- Personal mode keyword is being replaced by Dedicated mode
- Added a new policy that gets configured with Boot to cloud modes, "Turn off copilot" in the list of GPOs applied