### PR TITLE
Update event-4624.md

### DIFF
--- a/windows/security/threat-protection/auditing/event-4624.md
+++ b/windows/security/threat-protection/auditing/event-4624.md
@@ -250,6 +250,9 @@ This event generates when a logon session is created (on destination machine). I
 - **Source Port** [Type = UnicodeString]: source port which was used for logon attempt from remote machine.
 
     - 0 for interactive logons.
+ 
+  > [!NOTE]
+  The fields for IP address/port and workstation name are populated depending on the authentication context and protocol used. LSASS will audit the information the authenticating service shares with LSASS. For example, network logons with Kerberos likely have no workstation information, and NTLM logons have no TCP/IP details.
 
 **Detailed Authentication Information:**
 


### PR DESCRIPTION
add note that not all fields will be populated always. Hair-splitter customers will complain about empty fields
<!-- 
## Description

Add a note about how the fields for Network information are used.

## Why

We have recurring customer questions about how these fields are used, and why they are sometimes empty. This last customer is hard to convince, hence eventually updating the public docs.

- Closes CSS SR 2401220040003981

## Changes

Add a note about how the fields for Network information are used.