### PR TITLE
Update waas-restart.md

### DIFF
--- a/windows/deployment/update/waas-restart.md
+++ b/windows/deployment/update/waas-restart.md
@@ -69,6 +69,8 @@ To configure active hours using Group Policy, go to **Computer Configuration\Adm
 
 ![Use Group Policy to configure active hours.](images/waas-active-hours-policy.png)
 
+Note:  The max active hours length for Windows 10 1607 and Windows Server 2016 is 12.  Later versions support max active hours length of 18
+
 ### Configuring active hours with MDM
 
 MDM uses the [Update/ActiveHoursStart and Update/ActiveHoursEnd](/windows/client-management/mdm/policy-configuration-service-provider#Update_ActiveHoursEnd)  and [Update/ActiveHoursMaxRange](/windows/client-management/mdm/policy-configuration-service-provider#update-activehoursmaxrange) settings in the [Policy CSP](/windows/client-management/mdm/policy-configuration-service-provider) to configure active hours.


### PR DESCRIPTION
Clarifying the max active hours length.  This was based on customer support case where CSS could not figure why this policy wasn't working.  The screenshot shows 12 in the group policy help but that was only for 1607/WS2016.  After that the max is 18 hours.  This is not clearly documented anywhere

