### PR TITLE
Simplify WDAC AppId setup by skipping PolicyName & PolicyId

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/AppIdTagging/design-create-appid-tagging-policies.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/AppIdTagging/design-create-appid-tagging-policies.md
@@ -74,10 +74,10 @@ Using this method, you create an AppId Tagging policy directly using the WDAC Po
 
 	If you're using filepath rules, you may want to set option 18. Otherwise, there's no need. 
 	
-4. Set the name and ID on the policy, which is helpful for future debugging:
+4. Convery to multi-policy format with new PolicyID:
 
 	```powershell
-	Set-CIPolicyIdInfo -ResetPolicyId -PolicyName "MyPolicyName" -PolicyId "MyPolicyId" -AppIdTaggingPolicy -FilePath ".\AppIdPolicy.xml"
+	Set-CIPolicyIdInfo -ResetPolicyId -AppIdTaggingPolicy -FilePath ".\AppIdPolicy.xml"
 	```
 	The policyID GUID is returned by the PowerShell command if successful. 
 


### PR DESCRIPTION
I'm unable to see any added value in configuring additional `PolicyName` & `PolicyId` parameters for WDAC AppId policies.

### Arguments
* The existing `AppIdTaggingKey` & `AppIdTaggingValue` parameters already show up in WinDBG for tagged processes, so debugging is still possible.
* WDAC AppId tagging seem to work just as well also without `PolicyName` & `PolicyId`.
* I'm unable to figure out where the `PolicyName` & `PolicyId` parameters end up, so I'm only seeing added complexity and no value in defining them.
