### PR TITLE
Rename Windows 11 Family to Home

### DIFF
--- a/windows/privacy/windows-11-endpoints-non-enterprise-editions.md
+++ b/windows/privacy/windows-11-endpoints-non-enterprise-editions.md
@@ -32,7 +32,7 @@ The following methodology was used to derive the network endpoints:
 > [!NOTE]
 > Microsoft uses global load balancers that can appear in network trace-routes. For example, an endpoint for *.akadns.net might be used to load balance requests to an Azure datacenter, which can change over time.
 
-## Windows 11 Family
+## Windows 11 Home
 
 | **Area** | **Description** | **Protocol** | **Destination** |
 |-----------|--------------- |------------- |-----------------|


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

I might be misunderstanding the article, but I believe someone has referred to Windows 11 Home as Windows 11 Family here, and if so as far as I know this is incorrect as that's not the name used for the product.

If I am misunderstanding this, please can someone update the article to be more clear about this, as the wording Windows 11 Family isn't used anywhere else.

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

Renames Windows 11 Family to Windows 11 Home

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
