### PR TITLE
Removed notice about not using UTF-8 encoding

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
@@ -21,7 +21,6 @@ If you don't currently have a code signing certificate you can use to sign your 
 > - All policies, including base and supplemental, must be signed according to the [PKCS 7 Standard](https://datatracker.ietf.org/doc/html/rfc5652).
 > - Use RSA keys with 2K, 3K, or 4K key size only. ECDSA isn't supported.
 > - You can use SHA-256, SHA-384, or SHA-512 as the digest algorithm on Windows 11, as well as Windows 10 and Windows Server 2019 and above after applying the November 2022 cumulative security update. All other devices only support SHA-256.
-> - Don't use UTF-8 encoding for certificate fields, like 'subject common name' and 'issuer common name'. These strings must be encoded as PRINTABLE_STRING, IA5STRING or BMPSTRING.
 
 Before you attempt to deploy a signed policy, you should first deploy an unsigned version of the policy to uncover any issues with the policy rules. We also recommend you enable rule options **9 - Enabled:Advanced Boot Options Menu** and **10 - Enabled:Boot Audit on Failure** to leave troubleshooting options available to administrators. To ensure that a rule option is enabled, you can run a command such as `Set-RuleOption -FilePath <PathAndFilename> -Option 9`, even if you're not sure whether the option is already enabled. If so, the command has no effect. When validated and ready for enterprise deployment, you can remove these options. For more information about rule options, see [Windows Defender Application Control policy rules](../design/select-types-of-rules-to-create.md).
 


### PR DESCRIPTION
## Description

The UTF-8 encoding can totally be used for certificate subject names when deploying a signed WDAC policy and no problem such as boot failures occurs as a result of that.

I've tested this for long periods of time and continue to use it daily.

## Why

Because the notice is no longer applicable or necessary to be there. I've recorded a complete video to prove this and **you can watch it here:** 👇
https://www.youtube.com/watch?v=ae41WVQuER0

In the video I show that the certificate is using UTF-8 encoding only, for its subject name and I perform multiple restarts after deploying the signed WDAC policy to show that no boot failure occurs.

I remember this was true around a year ago and we shouldn't have used UTF-8 but since few months ago it's no longer the case.

## Changes

It removes this part

<img width="496" alt="image" src="https://github.com/MicrosoftDocs/windows-itpro-docs/assets/118815227/bec1d5a3-06e4-4b41-9e87-cd10cfd55ae2">


