### PR TITLE
Update broken links in windows-autopatch-faq.yml

### DIFF
--- a/windows/deployment/windows-autopatch/overview/windows-autopatch-faq.yml
+++ b/windows/deployment/windows-autopatch/overview/windows-autopatch-faq.yml
@@ -95,11 +95,11 @@ sections:
       - question: What happens if there's an issue with an update?
         answer: |
           Autopatch relies on the following capabilities to help resolve update issues:
-          - Pausing and resuming: For more information about pausing and resuming updates, see [pausing and resuming Windows quality updates](../operate/windows-autopatch-windows-quality-update-overview.md#pausing-and-resuming-a-release).
+          - Pausing and resuming: For more information about pausing and resuming updates, see [pausing and resuming Windows quality updates](../operate/windows-autopatch-windows-quality-update-overview.md#pause-and-resume-a-release).
           - Rollback: For more information about Microsoft 365 Apps for enterprise, see [Update controls for Microsoft 365 Apps for enterprise](../operate/windows-autopatch-microsoft-365-apps-enterprise.md#microsoft-365-apps-for-enterprise-update-controls).
       - question: Can I permanently pause a Windows feature update deployment?
         answer: |
-          Yes. Windows Autopatch provides a [permanent pause of a feature update deployment](../operate/windows-autopatch-windows-feature-update-overview.md#pausing-and-resuming-a-release).
+          Yes. Windows Autopatch provides a [permanent pause of a feature update deployment](../operate/windows-autopatch-groups-manage-windows-feature-update-release.md#pause-and-resume-a-release).
       - question: Will Windows quality updates be released more quickly after vulnerabilities are identified, or what is the regular cadence of updates?
         answer: |
           For zero-day threats, Autopatch will have an [expedited release cadence](../operate/windows-autopatch-windows-quality-update-overview.md#expedited-releases). For normal updates Autopatch, uses a [regular release cadence](../operate/windows-autopatch-wqu-overview.md#windows-quality-update-releases) starting with devices in the Test ring and completing with general rollout to the Broad ring.


### PR DESCRIPTION
## Description
Fix broken links/anchors in the Autopatch FAQ that lead to pausing and resuming releases for quality updates and feature updates.

## Why
- Noticed broken anchors while browsing public docs, simple break/fix.

## Changes
- The anchor for pausing quality updates is #pause-and-resume-a-release (https://learn.microsoft.com/en-us/windows/deployment/windows-autopatch/operate/windows-autopatch-groups-windows-quality-update-overview#pause-and-resume-a-release), not #pausing-and-resuming-a-release.
- The content for pause/resume feature updates has moved to a different page (https://learn.microsoft.com/en-us/windows/deployment/windows-autopatch/operate/windows-autopatch-groups-manage-windows-feature-update-release#pause-and-resume-a-release) with same changes to the anchor as above.
