### PR TITLE
Removed the last remaining UTF-8 warning for WDAC certificate requirements in all of the documents

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/deployment/create-code-signing-cert-for-wdac.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/deployment/create-code-signing-cert-for-wdac.md
@@ -21,7 +21,6 @@ If you have an internal CA, complete these steps to create a code signing certif
 > - All policies, including base and supplemental, must be signed according to the [PKCS 7 Standard](https://datatracker.ietf.org/doc/html/rfc5652).
 > - Use RSA keys with 2K, 3K, or 4K key size only. ECDSA isn't supported.
 > - You can use SHA-256, SHA-384, or SHA-512 as the digest algorithm on Windows 11, as well as Windows 10 and Windows Server 2019 and above after applying the November 2022 cumulative security update. All other devices only support SHA256.
-> - Don't use UTF-8 encoding for certificate fields, like 'subject common name' and 'issuer common name'. These strings must be encoded as PRINTABLE_STRING, IA5STRING or BMPSTRING.
 
 1. Open the Certification Authority Microsoft Management Console (MMC) snap-in, and then select your issuing CA.
 


### PR DESCRIPTION
## Description

This is the last remaining document that still has the UTF-8 warning/notice for certificate fields, no other page mentions this anymore.

## Why

[Confirmed](https://github.com/MicrosoftDocs/windows-itpro-docs/pull/11889#issuecomment-2105289949) to be no longer required.

## Changes

Removes this part of the document from the warnings section

```markdown
- Don't use UTF-8 encoding for certificate fields, like 'subject common name' and 'issuer common name'. These strings must be encoded as PRINTABLE_STRING, IA5STRING or BMPSTRING.
```
