### PR TITLE
Added PowerShell command for verifying signed binaries and removed leftover text about encoding

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
@@ -111,8 +111,9 @@ certutil.exe -asn <path to signed policy file>
 
 ```powershell
 $CIPolicyBin = 'path to signed policy file'
+Add-Type -AssemblyName 'System.Security'
 $SignedCryptoMsgSyntax = New-Object -TypeName System.Security.Cryptography.Pkcs.SignedCms
-$SignedCryptoMsgSyntax.Decode((Get-Content -LiteralPath $CIPolicyBin -AsByteStream -Raw))
+$SignedCryptoMsgSyntax.Decode([System.IO.File]::ReadAllBytes($CIPolicyBin))
 $SignedCryptoMsgSyntax.Certificates | Format-List -Property *
 ```
 

--- a/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/deployment/use-signed-policies-to-protect-wdac-against-tampering.md
@@ -103,10 +103,17 @@ When complete, the commands should output a signed policy file with a `.p7` exte
 
 ## Verify and deploy the signed policy
 
-You can use certutil.exe to verify the signed file. Review the output to confirm the signature algorithm and encoding for certificate fields, like 'subject common name' and 'issuer common name' as described in the Warning at the top of this article.
+You can use certutil.exe or PowerShell to verify the signed file. Review the output to confirm the signature algorithm as described in the Warning at the top of this article.
 
 ```powershell
 certutil.exe -asn <path to signed policy file>
+```
+
+```powershell
+$CIPolicyBin = 'path to signed policy file'
+$SignedCryptoMsgSyntax = New-Object -TypeName System.Security.Cryptography.Pkcs.SignedCms
+$SignedCryptoMsgSyntax.Decode((Get-Content -LiteralPath $CIPolicyBin -AsByteStream -Raw))
+$SignedCryptoMsgSyntax.Certificates | Format-List -Property *
 ```
 
 Thoroughly test the signed policy on a representative set of computers before proceeding with deployment. Be sure to reboot the test computers at least twice after applying the signed WDAC policy to ensure you don't encounter a boot failure.


### PR DESCRIPTION
## Description

Added a new quick PowerShell native way to verify the signed policy binary file.

The file is read as a byte array because the [SignedCms.Decode()](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.pkcs.signedcms.decode) method expects a byte array as input, it then returns an array of `X509Certificate2` objects that represent the certificate(s) used to sign the `.CIP` binary file.

Also, when reading the document, I found some leftover mentions of encoding in the warning section that no longer exists so removed them too.

## Why

* The PowerShell way produces objects instead of strings which is great for the output to be consumed by other commands.
*  It provides a lot more information than cerutil.exe
* Since all other commands in the page are in PowerShell, this offers more consistency.

## Changes

### Added this

```powershell
$CIPolicyBin = 'path to signed policy file'
Add-Type -AssemblyName 'System.Security'
$SignedCryptoMsgSyntax = New-Object -TypeName System.Security.Cryptography.Pkcs.SignedCms
$SignedCryptoMsgSyntax.Decode([System.IO.File]::ReadAllBytes($CIPolicyBin))
$SignedCryptoMsgSyntax.Certificates | Format-List -Property *
```

### Removed this

```markdown
and encoding for certificate fields, like 'subject common name' and 'issuer common name'
```



<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
