### PR TITLE
Fix case (VGpu -> vGpu)

### DIFF
--- a/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
+++ b/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-configure-using-wsb-file.md
@@ -208,7 +208,7 @@ The following config file can be used to easily test the downloaded files inside
 
 ```xml
 <Configuration>
-  <VGpu>Disable</VGpu>
+  <vGpu>Disable</vGpu>
   <Networking>Disable</Networking>
   <MappedFolders>
     <MappedFolder>


### PR DESCRIPTION
Fixes minor typo for consistency.

## Why

The `VGpu` tag should be `vGpu` for consistency with the rest of the document.

## Changes

- Modified the `VGpu` tag to `vGpu` in the configuration file example.
