### PR TITLE
Update policy-csp-search.md, removing Pro from DoNotUseWebResults

### DIFF
--- a/windows/client-management/mdm/policy-csp-search.md
+++ b/windows/client-management/mdm/policy-csp-search.md
@@ -919,7 +919,7 @@ This policy setting configures whether or not locations on removable drives can 
 <!-- DoNotUseWebResults-Applicability-Begin -->
 | Scope | Editions | Applicable OS |
 |:--|:--|:--|
-| ✅ Device <br> ❌ User | ✅ Pro <br> ✅ Enterprise <br> ✅ Education <br> ✅ Windows SE <br> ✅ IoT Enterprise / IoT Enterprise LTSC | ✅ Windows 10, version 1803 [10.0.17134] and later |
+| ✅ Device <br> ❌ User | ✅ Enterprise <br> ✅ Education <br> ✅ Windows SE <br> ✅ IoT Enterprise / IoT Enterprise LTSC | ✅ Windows 10, version 1803 [10.0.17134] and later |
 <!-- DoNotUseWebResults-Applicability-End -->
 
 <!-- DoNotUseWebResults-OmaUri-Begin -->


### PR DESCRIPTION
## Description

Removing Pro SKU from DoNotUseWebResults. After code review and internal email discussion with the owner of this component it was decided that the documentation should be updated to accurately reflect the SKUs where this policy works.

## Why

This policy has never worked on the Professional version of Windows. When the policy was introduced, it was restricted to specific SKUs and did not include Pro.

## Changes

Removed Pro from DoNotUseWebResults.