### PR TITLE
Update deploy-enterprise-licenses.md

### DIFF
--- a/windows/deployment/deploy-enterprise-licenses.md
+++ b/windows/deployment/deploy-enterprise-licenses.md
@@ -28,7 +28,8 @@ These activation features require a supported and licensed version of Windows Pr
 - Enterprise E3 in CSP.
 - Automatic, non-KMS activation also requires a device with a firmware-embedded activation key.
 - Subscription activation requires Enterprise _per user_ licensing. It doesn't work with _per device_ licensing.
-
+- Device-based licensing doesn't work with Enterprise license, for example: E3 &E5, on the Windows Operating System.
+- For example: upgrade From Windows 10 Pro to Windows 10/11 Enterprise using device-based licensing will not work, Enterprise _per user_ licensing is required for the Windows Operating System.
 ## Enable subscription activation with an existing EA
 
 EA customers with an existing Microsoft 365 tenant can use the following steps to enable Windows subscription licenses on the existing tenant:


### PR DESCRIPTION
Device-based licensing doesn't work with Enterprise license, for example: E3 &E5, on the Windows Operating System.
- For example: upgrade From Windows 10 Pro to Windows 10/11 Enterprise using device-based licensing will not work, Enterprise _per user_ licensing is required for the Windows Operating System.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
