### PR TITLE
Update windows-autopatch-conflicting-configurations.md

### DIFF
--- a/windows/deployment/windows-autopatch/references/windows-autopatch-conflicting-configurations.md
+++ b/windows/deployment/windows-autopatch/references/windows-autopatch-conflicting-configurations.md
@@ -37,8 +37,6 @@ The most common sources of conflicting configurations include:
 ```cmd
 Location= HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DoNotConnectToWindowsUpdateInternetLocations Value=Any
 Location= HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\DisableWindowsUpdateAccess Value=Any
-Location= HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\WUServer String=Any
-Location= HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\UseWUServer Value=Any
 Location= HKLM:SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate Value=Any
 ```
 
@@ -90,8 +88,6 @@ Copy and paste the following PowerShell script into PowerShell or a PowerShell e
 ```powershell
 Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations"
 Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess"
-Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer"
-Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer"
 Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate"
 ```
 
@@ -104,8 +100,6 @@ Copy and paste the following code into a text editor, and save it with a `.cmd` 
 echo Deleting registry keys...
 reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DoNotConnectToWindowsUpdateInternetLocations" /f
 reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DisableWindowsUpdateAccess" /f
-reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "WUServer" /f
-reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /f
 reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /f
 echo Registry keys deleted.
 Pause
@@ -120,9 +114,7 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate]
 "DoNotConnectToWindowsUpdateInternetLocations"=-
 "DisableWindowsUpdateAccess"=-
-"WUServer"=-
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU]
-"UseWUServer"=-
 "NoAutoUpdate"=-
 ```
 


### PR DESCRIPTION
WUServer and UseWUServer are no longer tracked in this feature.

<!-- 
UseWUServer and WUServer are no longer tracked as part of the Conflicting Configurations
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Remove unnecessary references to registry settings that we no longer check.
-->

## Changes

<!--
- Removes references to UseWUServer and WUServer from the entire document
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
