### PR TITLE
Update deploy-wdac-policies-with-script.md

### DIFF
--- a/windows/security/application-security/application-control/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
+++ b/windows/security/application-security/application-control/windows-defender-application-control/deployment/deploy-wdac-policies-with-script.md
@@ -83,7 +83,7 @@ Use WMI to apply policies on all other versions of Windows and Windows Server.
 
 ## Deploying signed policies
 
-If you're using [signed WDAC policies](/windows/security/threat-protection/windows-defender-application-control/use-signed-policies-to-protect-windows-defender-application-control-against-tampering), the policies must be deployed into your device's EFI partition in addition to the locations outlined in the earlier sections. Unsigned WDAC policies don't need to be present in the EFI partition. <!-- Deploying your policy via [Microsoft Intune](/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune) or the Application Control CSP will handle this step automatically. -->
+If you're using [signed WDAC policies](/windows/security/threat-protection/windows-defender-application-control/use-signed-policies-to-protect-windows-defender-application-control-against-tampering), the policies must be deployed into your device's EFI partition. Unsigned WDAC policies don't need to be present in the EFI partition. <!-- Deploying your policy via [Microsoft Intune](/windows/security/threat-protection/windows-defender-application-control/deploy-windows-defender-application-control-policies-using-intune) or the Application Control CSP will handle this step automatically. -->
 
 1. Mount the EFI volume and make the directory, if it doesn't exist, in an elevated PowerShell prompt:
 


### PR DESCRIPTION
Removed a stipulation which implies that signed WDAC policies have to be placed within System32 and EFI locations.  In some cases they should ONLY be placed in the EFI partition. (NOT the System32 location.) This updated wording matches the real behavior of the CiTool (when using `CiTool --update-policies` to deploy a new signed policy).

Additionally, for devices without the CiTool, (e.g. running Windows 10), you can put signed policies in the EFI partition and not the System32 folder with 0 consequence (correct me if I'm wrong on this.)

Additionally, I haven't put this in the pull request, but the wording of the article should be updated in the section "Deploying policies for Windows 11 22H2 and above" to state that a signed WDAC policy should **not** be placed in both locations (as this will cause a blue-screen! We've verified this on at least 4 different models of Dell running Windows 11.)
The reason this should be put in is there is an implied wording of the article that one **can** use either the CiTool on 22H2 devices and above (i.e., "You can use the inbox CiTool to apply policies on Windows 11 22H2") **or** copy it to both locations -- which is not true, so the wording will have to be updated either way. 

## Description

Removed the "in addition to [previous] locations..." so that it wouldn't imply that you always have to place a signed policy in the System32 location. 

## Why

The proposed changes bring this article in-line with the behavior of Microsoft's CiTool.

## Changes

Clarifies wording of where signed WDAC policies should be placed (when copying signed policies.)

