### PR TITLE
Update usmt-recognized-environment-variables.md

### DIFF
--- a/windows/deployment/usmt/usmt-recognized-environment-variables.md
+++ b/windows/deployment/usmt/usmt-recognized-environment-variables.md
@@ -66,8 +66,8 @@ These variables can be used within sections in the **.xml** files with `context=
 |*CSIDL_DEFAULT_TEMPLATES*|Refers to the Templates folder inside `%DEFAULTUSERPROFILE%`.|
 |*CSIDL_DEFAULT_QUICKLAUNCH*|Refers to the Quick Launch folder inside `%DEFAULTUSERPROFILE%`.|
 |*CSIDL_FONTS*|A virtual folder containing fonts. A typical path is `C:\Windows\Fonts`.|
-|*CSIDL_PROGRAM_FILESX86*|The Program Files folder on 64-bit systems. A typical path is `C:\Program Files(86)`.|
-|*CSIDL_PROGRAM_FILES_COMMONX86*|A folder for components that are shared across applications on 64-bit systems. A typical path is `C:\Program Files(86)\Common`.|
+|*CSIDL_PROGRAM_FILESX86*|The Program Files folder on 64-bit systems. A typical path is `C:\Program Files (x86)`.|
+|*CSIDL_PROGRAM_FILES_COMMONX86*|A folder for components that are shared across applications on 64-bit systems. A typical path is `C:\Program Files (x86)\Common`.|
 |*CSIDL_PROGRAM_FILES*|The Program Files folder. A typical path is `C:\Program Files`.|
 |*CSIDL_PROGRAM_FILES_COMMON*|A folder for components that are shared across applications. A typical path is `C:\Program Files\Common`.|
 |*CSIDL_RESOURCES*|The file-system directory that contains resource data. A typical path is `C:\Windows\Resources`.|


### PR DESCRIPTION

## Description
The following paths:
 
`C:\Program Files(86)`
`C:\Program Files(86)\Common` 

are referenced in explanations for the "CSIDL_PROGRAM_FILESX86" and "CSIDL_PROGRAM_FILES_COMMONX86" environmental variables.

I'm assuming this is an error, since these paths don't exist on a clean install of Windows 11, and placing Program Files(86) between two percent symbols: `cd %Program Files(86)%` returns `The system cannot find the path specified.`.

Additionally, the explanations for the "PROGRAMFILES(X86)" and "COMMONPROGRAMFILES(X86)" environmental variables reference the correct paths: 

`C:\Program Files (x86)`
`C:\Program Files (x86)\Common Files`

If this is intentional, I think the page would benefit from having an explanatory footnote or something similar since a cursory Google search doesn't return anything helpful.

## Why

I believe that there's an error in the documentation.

## Changes

Changed the explanations of "CSIDL_PROGRAM_FILESX86" and "CSIDL_PROGRAM_FILES_COMMONX86" to `C:\Program Files (x86)` and `C:\Program Files (x86)\Common Files`, respectively.

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
