### PR TITLE
Update hybrid-cloud-kerberos-trust.md

### DIFF
--- a/windows/security/identity-protection/hello-for-business/deploy/hybrid-cloud-kerberos-trust.md
+++ b/windows/security/identity-protection/hello-for-business/deploy/hybrid-cloud-kerberos-trust.md
@@ -83,7 +83,7 @@ If the Intune tenant-wide policy is enabled and configured to your needs, you on
 
 | Category | Setting name | Value |
 |--|--|--|
-| **Windows Hello for Business** | Use Passport For Work | true |
+| **Windows Hello for Business** | Use Windows Hello For Business | true |
 | **Windows Hello for Business** | Use Cloud Trust For On Prem Auth | Enabled |
 | **Windows Hello for Business** | Require Security Device | true |
 


### PR DESCRIPTION
Updated text for GPO setting "Use Passport for Work" to reflect new name, "Use Windows Hello for Business"


## Why

The setting name changed, and it is confusing for admins. Intune Support has confirmed the change. https://preview.redd.it/update-microsoft-has-renamed-a-setting-in-the-settings-v0-cq5o6d92qrqd1.png?width=590&format=png&auto=webp&s=8b90276eb483ff9fe7fbd32427564c3c5c42268c

- Closes #[Issue Number]

## Changes

Updates the text for the setting to enable WHfB from "Use Passport for Work" to "Use Windows Hello for Business"
