### PR TITLE
Fixed typo and policy name

### DIFF
--- a/windows/security/application-security/application-control/app-control-for-business/operations/event-tag-explanations.md
+++ b/windows/security/application-security/application-control/app-control-for-business/operations/event-tag-explanations.md
@@ -76,7 +76,7 @@ Represents why verification failed, or if it succeeded.
 | 23 | Invalid image hash. This error can indicate file corruption or a problem with the file's signature. Signatures using elliptic curve cryptography (ECC), such as ECDSA, return this VerificationError. |
 | 24 | Flight root not allowed; indicates trying to run flight-signed code on production OS. |
 | 25 | Anti-cheat policy violation. |
-| 26 | Explicitly denied by WADC policy. |
+| 26 | Explicitly denied by App Control for Business policy. |
 | 27 | The signing chain appears to be tampered/invalid. |
 | 28 | Resource page hash mismatch. |
 

--- a/windows/security/application-security/application-control/app-control-for-business/operations/event-tag-explanations.md
+++ b/windows/security/application-security/application-control/app-control-for-business/operations/event-tag-explanations.md
@@ -76,7 +76,7 @@ Represents why verification failed, or if it succeeded.
 | 23 | Invalid image hash. This error can indicate file corruption or a problem with the file's signature. Signatures using elliptic curve cryptography (ECC), such as ECDSA, return this VerificationError. |
 | 24 | Flight root not allowed; indicates trying to run flight-signed code on production OS. |
 | 25 | Anti-cheat policy violation. |
-| 26 | Explicitly denied by App Control for Business policy. |
+| 26 | Explicitly denied by App Control policy. |
 | 27 | The signing chain appears to be tampered/invalid. |
 | 28 | Resource page hash mismatch. |
 


### PR DESCRIPTION
## Description

Fixing a typo and policy name

## Why

There was a typo "WADC". 

## Changes

It was previously correctly set to "WDAC", but at some point it was changed to "WADC" which is a typo.
Instead of setting it to "WDAC", i set it to "App Control for Business" to follow the new naming convention.
