### PR TITLE
Update about rebootless removal of unsigned policies and Supplemental policies

### DIFF
--- a/windows/security/application-security/application-control/app-control-for-business/deployment/disable-appcontrol-policies.md
+++ b/windows/security/application-security/application-control/app-control-for-business/deployment/disable-appcontrol-policies.md
@@ -15,15 +15,17 @@ ms.topic: how-to
 There may come a time when you want to remove one or more App Control policies, or remove all App Control policies you've deployed. This article describes the various ways to remove App Control policies.
 
 > [!IMPORTANT]
-> **Signed App Control policy**
+> **Signed Base App Control policy**
 >
-> If the policy you are trying to remove is a signed App Control policy, you must first deploy a signed replacement policy that includes option **6 Enabled:Unsigned System Integrity Policy**.
+> If the base policy you are trying to remove is a signed App Control policy, you must first deploy a signed replacement policy that includes option **6 Enabled:Unsigned System Integrity Policy**.
 >
 > The replacement policy must have the same PolicyId as the one it's replacing and a version that's equal to or greater than the existing policy. The replacement policy must also include \<UpdatePolicySigners\>.
 >
 > To take effect, this policy must be signed with a certificate included in the \<UpdatePolicySigners\> section of the original policy you want to replace.
 >
 > You must then restart the computer so that the UEFI protection of the policy is deactivated. ***Failing to do so will result in a boot start failure.***
+>
+> Signed supplemental App Control policies can be removed in the same manner as unsigned policies, without the need to follow the aforementioned steps
 
 Before removing any policy, you must first disable the method used to deploy it (such as Group Policy or MDM). Otherwise, the policy may redeploy to the computer.
 

--- a/windows/security/application-security/application-control/app-control-for-business/deployment/disable-appcontrol-policies.md
+++ b/windows/security/application-security/application-control/app-control-for-business/deployment/disable-appcontrol-policies.md
@@ -35,9 +35,6 @@ To make a policy effectively inactive before removing it, you can first replace 
 4. Allow all COM objects. See [Allow COM object registration in an App Control policy](../design/allow-com-object-registration-in-appcontrol-policy.md#examples);
 5. If applicable, remove option **0 Enabled:UMCI** to convert the policy to kernel mode only.
 
-> [!IMPORTANT]
-> After you remove a policy, restart the computer for it to take effect. You can't remove App Control policies without restarting the device.
-
 ### Remove App Control policies using CiTool.exe
 
 Beginning with the Windows 11 2022 Update, you can remove App Control policies using CiTool.exe. From an elevated command window, run the following command. Be sure to replace the text *PolicyId GUID* with the actual PolicyId of the App Control policy you want to remove:
@@ -46,7 +43,8 @@ Beginning with the Windows 11 2022 Update, you can remove App Control policies u
 CiTool.exe -rp "{PolicyId GUID}" -json
 ```
 
-Then restart the computer.
+> [!NOTE]
+> Beginning with the Windows 11 2024 update, unsigned policies can be removed using CiTool.exe without requiring a restart. In previous versions of Windows, however, a restart is required to complete the removal process.
 
 ### Remove App Control policies using MDM solutions like Intune
 


### PR DESCRIPTION
## Description

Updated the described process for removal of App Control policies that are not signed. Also made it clear that supplemental policies, signed or not, can be removed just like any other unsigned policy.

## Why

Beginning Windows 11 version 24H2, reboot is [no longer required](https://x.com/CyberCakeX/status/1798068524335956176) to remove unsigned policies.

## Changes

Removed the statement that reboot is always mandatory. Instead added a note stating that reboot is no longer required if using Windows 11 24H2 or 2024 update, however previous versions still require a reboot to finalize the removal process.

There was no mention of supplemental policies in the document related to App Control policy removal so added some info and made the distention between removing signed base and signed supplemental policies and how supplemental policies can be removed like unsigned policies without requiring the re-signing process.
