### PR TITLE
CiTool in Windows Server, improved wording and updated notice

### DIFF
--- a/windows/security/application-security/application-control/app-control-for-business/deployment/deploy-appcontrol-policies-with-script.md
+++ b/windows/security/application-security/application-control/app-control-for-business/deployment/deploy-appcontrol-policies-with-script.md
@@ -16,13 +16,13 @@ This article describes how to deploy App Control for Business policies using scr
 You should now have one or more App Control policies converted into binary form. If not, follow the steps described in [Deploying App Control for Business policies](appcontrol-deployment-guide.md).
 
 > [!IMPORTANT]
-> Due to a known issue, you should always activate new **signed** App Control Base policies with a reboot on systems with [**memory integrity**](../../../../hardware-security/enable-virtualization-based-protection-of-code-integrity.md) enabled. Skip all steps below that use CiTool, RefreshPolicy.exe, or WMI to initiate a policy activation. Instead, copy the policy binary to the correct system32 and EFI locations and then activate the policy with a system restart.
+> Due to a known issue in Windows 11 updates earlier than 2024 (24H2), you should always activate new **signed** App Control Base policies with a reboot on systems with [**memory integrity**](../../../../hardware-security/enable-virtualization-based-protection-of-code-integrity.md) enabled. Skip all steps below that use CiTool, RefreshPolicy.exe, or WMI to initiate a policy activation. Instead, copy the policy binary to the correct system32 and EFI locations and then activate the policy with a system restart.
 >
 > This issue does not affect updates to signed Base policies that are already active on the system, deployment of unsigned policies, or deployment of supplemental policies (signed or unsigned). It also does not affect deployments to systems that are not running memory integrity.
 
-## Deploying policies for Windows 11 22H2 and above
+## Deploying policies for Windows 11 22H2 and above, and Windows Server 2025 and above
 
-You can use the inbox [CiTool](../operations/citool-commands.md) to apply policies on Windows 11 22H2 with the following commands. Be sure to replace **&lt;Path to policy binary file to deploy&gt;** in the following example with the actual path to your App Control policy binary file.
+You can use the inbox [CiTool](../operations/citool-commands.md) to deploy signed and unsigned policies on Windows 11 22H2 and Windows Server 2025 with the following commands. Be sure to replace **&lt;Path to policy binary file to deploy&gt;** in the following example with the actual path to your App Control policy binary file.
 
 ```powershell
 # Policy binary files should be named as {GUID}.cip for multiple policy format files (where {GUID} = <PolicyId> from the Policy XML)
@@ -58,7 +58,7 @@ To use this procedure, download and distribute the [App Control policy refresh t
 
 ## Deploying policies for all other versions of Windows and Windows Server
 
-Use WMI to apply policies on all other versions of Windows and Windows Server.
+Use WMI to deploy policies on all other versions of Windows and Windows Server.
 
 1. Initialize the variables to be used by the script.
 


### PR DESCRIPTION
## Description

Windows Server 2025 has the inbox CiTool.exe.

Updated wording to be consistent, changed apply to deploy. Apply was only used in 2 places while everywhere else the word "Deploy" was used.

Added a note to the known issue notice.

## Why

Windows Server 2025, which is nearly GA, has the inbox CiTool.exe which has the same features as the CiTool.exe in Windows 11 24H2. It can be used to deploy signed and unsigned policies.

Before when this repository allowed opening issues, i had opened an issue where I asked about the known issue between memory integrity and deploying signed policies. One of the persons responsible for the feature commented that the problem is resolving in the next update, that was almost a year ago and in Windows 11 24H2, the problem is no longer reproducible as far as I can tell. So I added a note to make it conditional but if that update is backported or you plan to do so then I suggest removing it entirely.

