### PR TITLE
Add MCC DHCP Option

### DIFF
--- a/windows/deployment/do/mcc-enterprise-appendix.md
+++ b/windows/deployment/do/mcc-enterprise-appendix.md
@@ -111,6 +111,10 @@ You can either set your Connected Cache IP address or FQDN using:
 
    :::image type="content" source="./images/ent-mcc-group-policy-hostname.png" alt-text="Screenshot of the Group Policy editor showing the Cache Server Hostname Group Policy setting." lightbox="./images/ent-mcc-group-policy-hostname.png":::
 
+#### DHCP Option 235
+
+To dynamically assign one or more Connected Cache hosts you can configure a custom DHCP option 235 to specify a comma-delimited list of host FQDNs or IP addresses. You must then configure a policy to apply to PCs that configures the DOCacheHostSource policy. For for information see [Delivery Optimization reference](/windows/deployment/do/waas-delivery-optimization-reference#cache-server-hostname-source).
+
 ## Verify content using the DO client
 
 To verify that the Delivery Optimization client can download content using Connected Cache, you can use the following steps:


### PR DESCRIPTION
## Description
Added a section here, possibly incomplete by your standards, that call out that there's a DHCP option to point endpoints at the MCC server. I think that's important to call out here in the MCC docs.

## Why

It's the docs for MCC but they were incomplete in terms of the options available to point endpoints at MCC.

## Changes
See Description