### PR TITLE
Update windows-autopatch-windows-quality-update-end-user-exp.md

### DIFF
--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -71,4 +71,4 @@ In the following example:
 
 Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
 Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
-If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/en-us/windows/deployment/update/waas-wufb-csp-mdm#user-settings-for-notifications)
+If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm#user-settings-for-notifications)

--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -70,5 +70,5 @@ In the following example:
 ## Minimize user disruption due to updates
 
 Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
-Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
-If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](/windows/deployment/update/waas-wufb-csp-mdm)
+
+Windows Autopatch doesn't modify the existing Windows Update notifications. If you wish to modify the end-user update notification experience, see [Use CSPs and MDMs to configure Windows Update for Business](/windows/deployment/update/waas-wufb-csp-mdm).

--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -69,4 +69,6 @@ In the following example:
 
 ## Minimize user disruption due to updates
 
-Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached.
+Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
+Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
+If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/en-us/windows/deployment/update/waas-wufb-csp-mdm#user-settings-for-notifications)

--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -71,4 +71,4 @@ In the following example:
 
 Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
 Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
-If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm#user-settings-for-notifications)
+If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm)

--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -71,4 +71,4 @@ In the following example:
 
 Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
 Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
-If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](//learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm)
+If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](/windows/deployment/update/waas-wufb-csp-mdm)

--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-windows-quality-update-end-user-exp.md
@@ -71,4 +71,4 @@ In the following example:
 
 Windows Autopatch understands the importance of not disrupting end users but also updating the devices quickly. To achieve this goal, updates are automatically downloaded and installed at an optimal time determined by the device. By default, [Active hours](/windows/client-management/mdm/policy-csp-update#activehoursstart) are configured dynamically based on device usage patterns. Device restarts occur outside of active hours until the deadline is reached. 
 Windows Autopatch does not modify the existing Windows Update notifications for the end-user. 
-If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](https://learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm)
+If you wish to modify the end-user update notification experience, access the following link to learn more [Use CSPs and MDMs to configure Windows Update for Business](//learn.microsoft.com/windows/deployment/update/waas-wufb-csp-mdm)


### PR DESCRIPTION
Added additional information on end-user's Windows Update Notifications Experience.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

Added reference regarding end-user experience Update Notifications
-->

## Why

Windows Autopatch customers believe that Windows Autopatch forces machine restart and does not allow the end-user to postpone or propose a time to install updates

## Changes
Statement that Windows Autopatch does not modify notification update level and uses the default Windows Update notifications.
Added Microsoft Learn article on how the Windows Updates deliver the notifications and how to change them if desired.