### PR TITLE
Update journey-step-3.md

### DIFF
--- a/windows/security/identity-protection/passwordless-strategy/journey-step-3.md
+++ b/windows/security/identity-protection/passwordless-strategy/journey-step-3.md
@@ -72,20 +72,8 @@ Modify the **userId** variable of the script to match your environment (first li
 ```azurepowershell-interactive
 $userId = "<UPN of the user>"
 
-function Generate-RandomPassword{
-    [CmdletBinding()]
-    param (
-      [int]$Length = 64
-    )
-  $chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+[]{};:,.<>/?\|`~"
-  $random = New-Object System.Random
-  $password = ""
-  for ($i = 0; $i -lt $Length; $i++) {
-    $index = $random.Next(0, $chars.Length)
-    $password += $chars[$index]
-  }
-  return $password
-}
+$Password = (New-Guid).Guid
+$Password
 
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 Install-Module Microsoft.Graph -Scope CurrentUser
@@ -95,7 +83,7 @@ Connect-MgGraph -Scopes "UserAuthenticationMethod.ReadWrite.All" -NoWelcome
 $passwordParams = @{
  UserId = $userId
  AuthenticationMethodId = "28c10230-6103-485e-b985-444c60001490"
- NewPassword = Generate-RandomPassword
+ NewPassword = $Password
 }
 
 Reset-MgUserAuthenticationMethodPassword @passwordParams
@@ -106,22 +94,10 @@ A similar script can be used to reset the password against Active Directory. Mod
 ```PowerShell
 $samAccountName = <sAMAccountName of the user>
 
-function Generate-RandomPassword{
-    [CmdletBinding()]
-    param (
-      [int]$Length = 64
-    )
-  $chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=+[]{};:,.<>/?\|`~"
-  $random = New-Object System.Random
-  $password = ""
-  for ($i = 0; $i -lt $Length; $i++) {
-    $index = $random.Next(0, $chars.Length)
-    $password += $chars[$index]
-  }
-  return $password
-}
+$Password = (New-Guid).Guid
+$Password
 
-$NewPassword = ConvertTo-SecureString -String (Generate-RandomPassword) -AsPlainText -Force
+$NewPassword = ConvertTo-SecureString -String ($Password) -AsPlainText -Force
 
 Set-ADAccountPassword -identity $userId -NewPassword $NewPassword -Reset
 ```


### PR DESCRIPTION
Proposing to use New-Guid instead, it will generate a "complex" password easier than having to rely on a custom PSFunction.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Reading the code, I realized that you are not promoting the use of New-Guid but instead relying on a custom PSFunction, New-Guid will automatically generate a 38 character long password, while, yes the PSFunction can generate a 64 char password. But New-Guid is in PS from at least 5.1, why not rely on native tools instead? :)
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
