### PR TITLE
Removed a duplicate DeniedSigner from microsoft-recommended-driver-block-rules

### DIFF
--- a/windows/security/application-security/application-control/app-control-for-business/design/microsoft-recommended-driver-block-rules.md
+++ b/windows/security/application-security/application-control/app-control-for-business/design/microsoft-recommended-driver-block-rules.md
@@ -3150,7 +3150,6 @@ The following recommended blocklist xml policy file can also be downloaded from 
           <DeniedSigner SignerId="ID_SIGNER_DIGICERT_EV" />
           <DeniedSigner SignerId="ID_SIGNER_ECSIODRV" />
           <DeniedSigner SignerId="ID_SIGNER_ELBY" />
-          <DeniedSigner SignerId="ID_SIGNER_ECSIODRV" />
           <DeniedSigner SignerId="ID_SIGNER_ENE" />
           <DeniedSigner SignerId="ID_SIGNER_ETDSUPPORT" />
           <DeniedSigner SignerId="ID_SIGNER_FAIRPLAY_1" />


### PR DESCRIPTION
The following DeniedSigner is mentioned twice which isn't supposed to happen.

```xml
<DeniedSigner SignerId="ID_SIGNER_ECSIODRV" />
```

Only one is enough, there is only one signer referencing it

```xml
 <Signer ID="ID_SIGNER_ECSIODRV" Name="GlobalSign Primary Object Publishing CA">
      <CertRoot Type="TBS" Value="879269F3F467A6D59641960A62FE9CB419355FF6" />
      <CertPublisher Value="ELITEGROUP COMPUTER SYSTEMS CO" />
      <FileAttribRef RuleID="ID_FILEATTRIB_ECSIODRV" />
    </Signer>
```

<br>

So I just removed the extra DenierSigner, everything checks out now and is valid according to the CI Schema.
