### PR TITLE
Update index.md

### DIFF
--- a/windows/security/operating-system-security/data-protection/personal-data-encryption/index.md
+++ b/windows/security/operating-system-security/data-protection/personal-data-encryption/index.md
@@ -25,7 +25,7 @@ Unlike BitLocker that releases data encryption keys at boot, Personal Data Encry
 To use Personal Data Encryption, the following prerequisites must be met:
 
 - Windows 11, version 22H2 and later
-- The devices must be [Microsoft Entra joined][AAD-1]. Domain-joined and Microsoft Entra hybrid joined devices aren't supported
+- The devices must be [Microsoft Entra joined][AAD-1]. Domain-joined devices aren't supported
 - Users must sign in using [Windows Hello for Business](../../../identity-protection/hello-for-business/index.md)
 
 > [!IMPORTANT]


### PR DESCRIPTION
Based on lab tests and this article from the PM of the product https://techcommunity.microsoft.com/blog/windows-itpro-blog/personal-data-encryption-folder-protection-now-available/4358947

Prerequisites and recommendations for Personal Data Encryption To enable Personal Data Encryption folder protection, ensure these three prerequisites are met:

The device runs Windows 11 Enterprise (version 24H2 or later). The device is Microsoft Entra or **Microsoft Entra hybrid joined**.
