### PR TITLE
Updated the known issue notice in App Control policy deployment page

### DIFF
--- a/windows/security/application-security/application-control/app-control-for-business/deployment/appcontrol-deployment-guide.md
+++ b/windows/security/application-security/application-control/app-control-for-business/deployment/appcontrol-deployment-guide.md
@@ -43,7 +43,7 @@ All App Control for Business policy changes should be deployed in audit mode bef
 ## Choose how to deploy App Control policies
 
 > [!IMPORTANT]
-> Due to a known issue, you should always activate new **signed** App Control Base policies with a reboot on systems with [**memory integrity**](../../../../hardware-security/enable-virtualization-based-protection-of-code-integrity.md) enabled. We recommend [deploying via script](deploy-appcontrol-policies-with-script.md) in this case.
+> Due to a known issue in Windows 11 updates earlier than 2024 (24H2), you should activate new **signed** App Control Base policies with a reboot on systems with [**memory integrity**](../../../../hardware-security/enable-virtualization-based-protection-of-code-integrity.md) enabled. We recommend [deploying via script](deploy-appcontrol-policies-with-script.md) in this case.
 >
 > This issue does not affect updates to signed Base policies that are already active on the system, deployment of unsigned policies, or deployment of supplemental policies (signed or unsigned). It also does not affect deployments to systems that are not running memory integrity.
 


### PR DESCRIPTION
I updated this [once](https://github.com/MicrosoftDocs/windows-itpro-docs/pull/11954) before on a different page but just noticed it exists in here too. It clarifies that the issue has been fixed and users on 24H2 or later can deploy it normally.