### PR TITLE
Update firewall-csp.md

### DIFF
--- a/windows/client-management/mdm/firewall-csp.md
+++ b/windows/client-management/mdm/firewall-csp.md
@@ -1895,9 +1895,7 @@ New rules have the EdgeTraversal property disabled by default.
 
 <!-- Device-MdmStore-FirewallRules-{FirewallRuleName}-Enabled-Description-Begin -->
 <!-- Description-Source-DDF -->
-Indicates whether the rule is enabled or disabled. If the rule must be enabled, this value must be set to true.
-
-If not specified - a new rule is disabled by default.
+Indicates whether the rule is enabled or disabled. If not specified - a new rule is enabled by default.
 <!-- Device-MdmStore-FirewallRules-{FirewallRuleName}-Enabled-Description-End -->
 
 <!-- Device-MdmStore-FirewallRules-{FirewallRuleName}-Enabled-Editable-Begin -->
@@ -3253,9 +3251,7 @@ If not specified the default is OUT.
 
 <!-- Device-MdmStore-HyperVFirewallRules-{FirewallRuleName}-Enabled-Description-Begin -->
 <!-- Description-Source-DDF -->
-Indicates whether the rule is enabled or disabled. If the rule must be enabled, this value must be set to true.
-
-If not specified - a new rule is disabled by default.
+Indicates whether the rule is enabled or disabled. If not specified - a new rule is enabled by default.
 <!-- Device-MdmStore-HyperVFirewallRules-{FirewallRuleName}-Enabled-Description-End -->
 
 <!-- Device-MdmStore-HyperVFirewallRules-{FirewallRuleName}-Enabled-Editable-Begin -->


### PR DESCRIPTION
This PR fixes the description of the "enabled" field for firewall and Hyper-V rules.
The rules are enabled by default if no value is specified for the "Enabled" field. However, the descriptions state that the rules are disabled if no value is specified. This PR fixes the description to match the behavior.