### PR TITLE
Added necessary steps to configure diagnostic data via the Settings C…

### DIFF
--- a/windows/privacy/configure-windows-diagnostic-data-in-your-organization.md
+++ b/windows/privacy/configure-windows-diagnostic-data-in-your-organization.md
@@ -291,7 +291,35 @@ You can also limit the number of diagnostic logs that are sent back to Microsoft
 
 3. In the **Options** box, choose the setting that you want to configure, and then click **OK**.
 
-### Use MDM to manage diagnostic data collection
+### Use Intune to manage diagnostic data collection
+
+#### Settings Catalog (Recommended)
+
+1. Open the [Microsoft Intune admin center](https://go.microsoft.com/fwlink/?linkid=2109431) and go to Devices > Windows > Configuration > Select **Create** > Select **New Policy**
+2. Configure the policy:
+   - **Platform**: Select Windows 10 and later.
+   - **Profile type**: Select Settings catalog and click Create.
+3. Specify a Name for the policy and click on Next.
+  
+![grafik](https://github.com/user-attachments/assets/783e3d24-60d9-49b3-bd86-1363821bfe8b)
+
+4. On the **Configuration settings** page select "+ Add settings". Now search and add all of the following settings:
+- **Allow Telemetry** → Full
+- **Limit Enhanced Diagnostic Data Windows Analytics** → Enabled)
+- **Limit Dump Collection** → Enabled
+- **Limit Diagnostic Log Collection** → Enabled
+
+![grafik](https://github.com/user-attachments/assets/5f4423e6-4aee-4516-a0f2-265b81dbc2ab)
+
+5. Select **Next** and configure the **Scope Tags** as per your own needs.
+6. In the **Assignments** section, select the target devices.
+   - For Autopatch, it's recommended to assign the policy to the default **Windows Autopatch - Devices All** group.
+7. Click **Next**, review your settings and assignments, and complete the policy creation by selecting **Create**.
+
+>[!Note]
+> More details for these settings can be found here: [Device configuration policies](https://learn.microsoft.com/en-us/windows/deployment/windows-autopatch/references/windows-autopatch-changes-made-at-feature-activation#device-configuration-policies)
+
+#### Custom OMA-URI
 
 Use [Policy Configuration Service Provider (CSP)](/windows/client-management/mdm/policy-configuration-service-provider) to apply the following MDM policies:
 


### PR DESCRIPTION
## Description

This update provides guidance on configuring a Windows Diagnostic Data collection policy in Intune. Due to the removal of the Windows Autopatch - Data Collection policy by March 3, 2025 (Message Center ID: MC996580), administrators must manually create and maintain a new policy to ensure proper diagnostic data collection for Autopatch devices.

The documentation now includes clear steps on how to create this policy using the Settings Catalog in Intune.

## Why

- The Windows Autopatch - Data Collection policy will be removed as part of service maintenance.
- Devices that do not have the correct Windows Diagnostic Data settings configured may miss Client State and Client Substate values.
- Administrators need to proactively configure a replacement policy before the March 3, 2025 deadline.

- Closes #[Issue Number]

## Changes

- Added steps to manually create a Windows Diagnostic Data collection policy via the Settings Catalog in Intune.
- Specified recommended minimum settings for Autopatch compliance.
- Provided additional guidance on using the Windows Autopatch - Devices All group for assignments.
- Included relevant links to Microsoft documentation for further reference.

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
