### PR TITLE
Update deprecated-features-resources.md

### DIFF
--- a/windows/whats-new/deprecated-features-resources.md
+++ b/windows/whats-new/deprecated-features-resources.md
@@ -36,6 +36,8 @@ In many cases, applications should be able to replace NTLM with Negotiate using 
 
 Negotiate's built-in fallback to NTLM is preserved to mitigate compatibility issues during this transition. For updates on NTLM deprecation, see [https://aka.ms/ntlm](https://aka.ms/ntlm). 
 
+NTLM v1 is removed starting in Windows 11, version 24H2 and Windows Server 2025. Some situations still use NTLMv1 primitives for legacy reasons. MSCHAPv2 uses the same response function as NTLMv1 and is vulnerable to the same attacks against the weak crypto.  MSCHAPv2 is only disabled by enabling Credential Guard.
+
 ## WordPad
 
 WordPad is removed from all editions of Windows starting in Windows 11, version 24H2 and Windows Server 2025. As a result, Windows will no longer have a built-in, default RTF reader. We recommend Microsoft Word for rich text documents like .doc and .rtf and Notepad for plain text documents like .txt. The following binaries will be removed as a result of WordPad removal:


### PR DESCRIPTION
Added a note about NTLMv1 removal including limitations around removal related to other capabilities using the same primitives (i.e. MSCHAPv2).

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- There are some usages of NTLMv1 primitives which are still used in the OS. The current documentation is not clear about this, which is why we are adding a clarifying statement. 

## Changes

Updating NTLM deprecation resource notes.

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
