### PR TITLE
Update configure.md

### DIFF
--- a/windows/security/identity-protection/credential-guard/configure.md
+++ b/windows/security/identity-protection/credential-guard/configure.md
@@ -212,7 +212,7 @@ The following event indicates whether TPM is used for key protection. Path: `App
   :::column-end:::
 :::row-end:::
 
-If you're running with a TPM, the TPM PCR mask value is something other than 0.
+The TPM PCR mask is only relevant when SRTM is used. If the cached Copy status is 1, SRTM was not used - typically indicating DRTM is in use - and the PCR mask should be ignored.
 
 ## Disable Credential Guard
 


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why


Update to the note under Event ID 51 to reflect that the SRTM PCR mask is only relevant if DRTM is not being used - since SRTM code has no way to know what DRTM PCR values will be used.



## Changes



Change clarifies a note about Event ID 51, where even if the TPM is enabled, the TPM CPR mask value is 0. That is because SRTM reports what SRTM PCR mask is being used. If SRTM is not being used (as in this case), it chooses to report nothing, since the data is not sealed to SRTM PCRs. 


<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
