### PR TITLE
Added missing information on network-unlock.md

### DIFF
--- a/windows/security/operating-system-security/data-protection/bitlocker/network-unlock.md
+++ b/windows/security/operating-system-security/data-protection/bitlocker/network-unlock.md
@@ -139,7 +139,7 @@ To enroll a certificate from an existing certificate authority:
 1. Select **All Tasks** > **Request New Certificate**
 1. When the Certificate Enrollment wizard opens, select **Next**
 1. Select **Active Directory Enrollment Policy**
-1. Choose the certificate template that was created for Network Unlock on the domain controller. Then select **Enroll**
+1. Choose the certificate template that was created for Network Unlock on the domain controller. In case the message "More information is required to enroll for this certificate. Click here to configure settings." is shown, click on it. On the new window, in **Subject** tab, under **Alternative names**, select **DNS** and set the FQDN of the WDS server. Save the changes by clicking **OK** and then select **Enroll**
 1. When prompted for more information, select **Subject Name** and provide a friendly name value. The friendly name should include information for the domain or organizational unit for the certificate For example: *BitLocker Network Unlock Certificate for Contoso domain*
 1. Create the certificate. Ensure the certificate appears in the **Personal** folder
 1. Export the public key certificate for Network Unlock:


### PR DESCRIPTION
<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->

## Description

Added information when a warning message like the one described in this link https://community.spiceworks.com/t/setting-up-bitlocker-network-unlock/662752 occurs.

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

To improve the document by missing information.

## Changes

Changes applied on a bullet point of **Create the Network Unlock certificate** section.

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
