### PR TITLE
Update smart-card-group-policy-and-registry-settings.md to fix CCS

### DIFF
--- a/windows/security/identity-protection/smart-cards/smart-card-group-policy-and-registry-settings.md
+++ b/windows/security/identity-protection/smart-cards/smart-card-group-policy-and-registry-settings.md
@@ -357,8 +357,8 @@ The following table lists the keys and the corresponding values to turn off cert
 
 | Registry Key | Details |
 |--|--|
-| `HKEY_LOCAL_MACHINE\SYSTEM\CCS\Services\Kdc\UseCachedCRLOnlyAndIgnoreRevocationUnknownErrors` | Type = DWORD<br>Value = 1 |
-| `HKEY_LOCAL_MACHINE\SYSTEM\CCS\Control\LSA\Kerberos\Parameters\UseCachedCRLOnlyAndIgnoreRevocationUnknownErrors` | Type = DWORD<br>Value = 1 |
+| `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Kdc\UseCachedCRLOnlyAndIgnoreRevocationUnknownErrors` | Type = DWORD<br>Value = 1 |
+| `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\LSA\Kerberos\Parameters\UseCachedCRLOnlyAndIgnoreRevocationUnknownErrors` | Type = DWORD<br>Value = 1 |
 
 ## Additional smart card Group Policy settings and registry keys
 


### PR DESCRIPTION
Registry key shows CCS instead of CurrentControlSet.  Customers are taking this literally and stuff is breaking.

<!-- 
Fill out the following information to help us review this pull request. 
You can delete these comments once you are done.
-->
<!-- 
## Description

If your changes are extensive:
- Uncomment this heading and provide a brief description here.
- List more detailed changes below under the changes heading.
-->

## Why

<!--
- Briefly describe _why_ you made this pull request.
- If this pull request relates to an issue, provide the issue number or link.
- If this pull request closes an issue, use a keyword (`Closes #123`).
  - Using a keyword will ensure the issue is automatically closed once this pull request is merged.
  - For more information, see [Linking a pull request to an issue using a keyword](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-->

- Closes #[Issue Number]

## Changes

<!--
- Briefly describe or list _what_ this PR changes.
- Share any important highlights regarding your changes, such as screenshots, code snippets, or formatting.
-->

<!--
Thanks for contributing to Microsoft technical content!

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/)
- [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://learn.microsoft.com/style-guide/welcome/)
-->
