### PR TITLE
Typo fix update in configure-recovery-password-rotation.md

### DIFF
--- a/windows/security/operating-system-security/data-protection/bitlocker/includes/configure-recovery-password-rotation.md
+++ b/windows/security/operating-system-security/data-protection/bitlocker/includes/configure-recovery-password-rotation.md
@@ -16,7 +16,7 @@ Possible values are:
 - `2`: numeric recovery password rotation upon use is *on* for both Microsoft Entra joined devices and Microsoft Entra hybrid joined devices
 
 > [!NOTE]
-> The Policy is effective only when Micropsoft Entra ID or Active Directory backup for recovery password is configured to *required*
+> The policy is effective only when Microsoft Entra ID or Active Directory backup for recovery password is configured to *required*
 >
 > - For OS drive: enable *Do not enable BitLocker until recovery information is stored to AD DS for operating system drives*
 > - For fixed drives: enable "*Do not enable BitLocker until recovery information is stored to AD DS for fixed data drives*


### PR DESCRIPTION
Fix typo in 'Microsoft' and lowercase 'policy'

## Description

In the document [configure-recovery-password-rotation.md](https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/operating-system-security/data-protection/bitlocker/includes/configure-recovery-password-rotation.md) there is a typo in Microsoft name.

## Why

To make it easier and look more professional

## Changes

Changed:
The Policy is effective only when Micropsoft Entra ID 

to:
The policy is effective only when Microsoft Entra ID 
