### PR TITLE
Update windows-autopatch-edge.md

### DIFF
--- a/windows/deployment/windows-autopatch/manage/windows-autopatch-edge.md
+++ b/windows/deployment/windows-autopatch/manage/windows-autopatch-edge.md
@@ -77,8 +77,8 @@ If you [created an Autopatch group](../manage/windows-autopatch-manage-autopatch
 1. The following new policies should be discoverable from the list of profiles:
     1. `"Windows Autopatch Microsoft Edge Update Policy - <group name> - <ring name>"`
 1. The following profiles should be removed from your list of profiles and no longer visible/active. Use the Search with the keywords "Microsoft Edge Update Channel". The result should return *0 profiles filtered*.
-    1. Windows Autopatch - Microsoft Edge Update Channel Beta
-    1. Windows Autopatch - Microsoft Edge Update Channel Stable
+    1. Windows Autopatch - Edge Update Channel Beta
+    1. Windows Autopatch - Edge Update Channel Stable
 
 ### Verify Microsoft Edge updates policies are created
 


### PR DESCRIPTION
The mmd.config definition for the policy label did not contain Microsoft. One of our big customers raised a concern between the name in documentation and the actual policy within the tenant.


## Description
There's a mismatch between the policy label in docs and in the service configuration we used to push.

## Why

Customer confusion

- Closes 2504150050003720 (DFM case number)

## Changes


Thanks for contributing to Microsoft technical content!

